### PR TITLE
Fix crash when running from standalone app bundle

### DIFF
--- a/Sources/AdAmp/App/AppDelegate.swift
+++ b/Sources/AdAmp/App/AppDelegate.swift
@@ -130,7 +130,8 @@ class AppDelegate: NSObject, NSApplicationDelegate, AVAudioPlayerDelegate {
     
     private func setupDockIcon() {
         // Load the app icon from the Resources bundle
-        if let iconURL = Bundle.module.url(forResource: "AppIcon", withExtension: "png", subdirectory: "Resources"),
+        // Use BundleHelper to work in both SPM development and standalone app bundle
+        if let iconURL = BundleHelper.url(forResource: "AppIcon", withExtension: "png"),
            let iconImage = NSImage(contentsOf: iconURL) {
             NSApplication.shared.applicationIconImage = iconImage
         }
@@ -139,7 +140,8 @@ class AppDelegate: NSObject, NSApplicationDelegate, AVAudioPlayerDelegate {
     // MARK: - Intro Sound
     
     private func playIntro() {
-        guard let introURL = Bundle.module.url(forResource: "DJ Mike Llama - Llama Whippin Intro", withExtension: "mp3", subdirectory: "Resources") else {
+        // Use BundleHelper to work in both SPM development and standalone app bundle
+        guard let introURL = BundleHelper.url(forResource: "DJ Mike Llama - Llama Whippin Intro", withExtension: "mp3") else {
             return
         }
         

--- a/Sources/AdAmp/App/BundleHelper.swift
+++ b/Sources/AdAmp/App/BundleHelper.swift
@@ -1,0 +1,108 @@
+import Foundation
+
+/// Helper to access bundled resources in both SPM development and standalone app bundle
+enum BundleHelper {
+    
+    /// Returns the bundle containing app resources
+    /// - In SPM development: Uses Bundle.module
+    /// - In standalone app: Uses Bundle.main's Resources folder
+    static var resourceBundle: Bundle {
+        // First try Bundle.module (SPM development)
+        #if DEBUG
+        return Bundle.module
+        #else
+        // In release builds, check if we're in an app bundle
+        if let resourceURL = Bundle.main.resourceURL,
+           FileManager.default.fileExists(atPath: resourceURL.appendingPathComponent("Presets").path) {
+            return Bundle.main
+        }
+        // Fallback to module bundle
+        return Bundle.module
+        #endif
+    }
+    
+    /// Find a resource URL, checking both SPM module bundle and main app bundle
+    static func url(forResource name: String, withExtension ext: String?, subdirectory: String? = nil) -> URL? {
+        // Try Bundle.module first (works in SPM development)
+        if let url = Bundle.module.url(forResource: name, withExtension: ext, subdirectory: subdirectory) {
+            return url
+        }
+        
+        // Try main bundle (works in standalone app)
+        if let url = Bundle.main.url(forResource: name, withExtension: ext, subdirectory: subdirectory) {
+            return url
+        }
+        
+        // Try main bundle Resources subdirectory (common app bundle structure)
+        if let subdirectory = subdirectory {
+            if let url = Bundle.main.url(forResource: name, withExtension: ext, subdirectory: "Resources/\(subdirectory)") {
+                return url
+            }
+        }
+        
+        // Try without subdirectory in main bundle
+        if let url = Bundle.main.url(forResource: name, withExtension: ext) {
+            return url
+        }
+        
+        return nil
+    }
+    
+    /// Find a resource URL in a specific subdirectory
+    static func url(forResource name: String, withExtension ext: String?, inDirectory directory: String) -> URL? {
+        return url(forResource: name, withExtension: ext, subdirectory: directory)
+    }
+    
+    /// Get the path to the Presets directory
+    static var presetsDirectory: URL? {
+        // Try module bundle first
+        if let url = Bundle.module.url(forResource: "Presets", withExtension: nil, subdirectory: "Resources") {
+            return url
+        }
+        if let url = Bundle.module.url(forResource: "Presets", withExtension: nil) {
+            return url
+        }
+        
+        // Try main bundle
+        if let url = Bundle.main.url(forResource: "Presets", withExtension: nil) {
+            return url
+        }
+        if let resourceURL = Bundle.main.resourceURL {
+            let presetsURL = resourceURL.appendingPathComponent("Presets")
+            if FileManager.default.fileExists(atPath: presetsURL.path) {
+                return presetsURL
+            }
+        }
+        
+        return nil
+    }
+    
+    /// Get the path to the Textures directory
+    static var texturesDirectory: URL? {
+        // Try module bundle first
+        if let url = Bundle.module.url(forResource: "Textures", withExtension: nil, subdirectory: "Resources") {
+            return url
+        }
+        if let url = Bundle.module.url(forResource: "Textures", withExtension: nil) {
+            return url
+        }
+        
+        // Try main bundle
+        if let url = Bundle.main.url(forResource: "Textures", withExtension: nil) {
+            return url
+        }
+        if let resourceURL = Bundle.main.resourceURL {
+            let texturesURL = resourceURL.appendingPathComponent("Textures")
+            if FileManager.default.fileExists(atPath: texturesURL.path) {
+                return texturesURL
+            }
+        }
+        
+        return nil
+    }
+    
+    /// Get the path to a skin file (wsz)
+    static func skinURL(named name: String) -> URL? {
+        return url(forResource: name, withExtension: "wsz")
+    }
+}

--- a/Sources/AdAmp/Skin/Skin.swift
+++ b/Sources/AdAmp/Skin/Skin.swift
@@ -99,14 +99,14 @@ struct Skin {
     
     /// Library window image loaded from bundle (not from .wsz skins)
     static var libraryWindowImage: NSImage? {
-        guard let url = Bundle.module.url(forResource: "library-window", withExtension: "png") else { return nil }
+        guard let url = BundleHelper.url(forResource: "library-window", withExtension: "png") else { return nil }
         return NSImage(contentsOf: url)
     }
     
     /// Milkdrop title bar image loaded from bundle (custom sprite sheet)
     /// Layout: 1518x48 - 2 rows (24px each): active (y=0-23), inactive (y=24-47)
     static var milkdropTitlebarImage: NSImage? {
-        guard let url = Bundle.module.url(forResource: "milkdrop_titlebar", withExtension: "png") else { return nil }
+        guard let url = BundleHelper.url(forResource: "milkdrop_titlebar", withExtension: "png") else { return nil }
         return NSImage(contentsOf: url)
     }
     
@@ -114,7 +114,7 @@ struct Skin {
     /// Layout: 194x109 - title bars, borders, corners, and pixel alphabet
     /// Provides authentic Winamp-style window chrome for visualization windows
     static var genWindowImage: NSImage? {
-        guard let url = Bundle.module.url(forResource: "gen", withExtension: "png") else { return nil }
+        guard let url = BundleHelper.url(forResource: "gen", withExtension: "png") else { return nil }
         return NSImage(contentsOf: url)
     }
 }

--- a/Sources/AdAmp/Skin/SkinLoader.swift
+++ b/Sources/AdAmp/Skin/SkinLoader.swift
@@ -35,17 +35,15 @@ class SkinLoader {
     /// Load the default/built-in skin from the app bundle (Base Skin 1)
     func loadDefault() -> Skin {
         // Try to load the bundled base-2.91.wsz skin
-        // Swift Package Manager puts resources in a bundle named after the target
-        let bundle = Bundle.module
-        
-        if let bundledSkinURL = bundle.url(forResource: "base-2.91", withExtension: "wsz") {
+        // Use BundleHelper to work in both SPM development and standalone app bundle
+        if let bundledSkinURL = BundleHelper.url(forResource: "base-2.91", withExtension: "wsz") {
             do {
                 return try load(from: bundledSkinURL)
             } catch {
                 print("Failed to load bundled skin: \(error)")
             }
         } else {
-            print("Could not find bundled skin in bundle: \(bundle.bundlePath)")
+            print("Could not find bundled skin base-2.91.wsz")
         }
         
         // Fallback: Return a skin with nil images - will use fallback rendering
@@ -75,16 +73,14 @@ class SkinLoader {
     
     /// Load the second built-in skin from the app bundle (Base Skin 2)
     func loadBaseSkin2() -> Skin {
-        let bundle = Bundle.module
-        
-        if let bundledSkinURL = bundle.url(forResource: "base-skin-2", withExtension: "wsz") {
+        if let bundledSkinURL = BundleHelper.url(forResource: "base-skin-2", withExtension: "wsz") {
             do {
                 return try load(from: bundledSkinURL)
             } catch {
                 print("Failed to load Base Skin 2: \(error)")
             }
         } else {
-            print("Could not find Base Skin 2 in bundle: \(bundle.bundlePath)")
+            print("Could not find Base Skin 2")
         }
         
         // Fallback to default skin
@@ -93,16 +89,14 @@ class SkinLoader {
     
     /// Load the third built-in skin from the app bundle (Base Skin 3)
     func loadBaseSkin3() -> Skin {
-        let bundle = Bundle.module
-        
-        if let bundledSkinURL = bundle.url(forResource: "base-skin-3", withExtension: "wsz") {
+        if let bundledSkinURL = BundleHelper.url(forResource: "base-skin-3", withExtension: "wsz") {
             do {
                 return try load(from: bundledSkinURL)
             } catch {
                 print("Failed to load Base Skin 3: \(error)")
             }
         } else {
-            print("Could not find Base Skin 3 in bundle: \(bundle.bundlePath)")
+            print("Could not find Base Skin 3")
         }
         
         // Fallback to default skin

--- a/Sources/AdAmp/Windows/PlexBrowser/PlexBrowserView.swift
+++ b/Sources/AdAmp/Windows/PlexBrowser/PlexBrowserView.swift
@@ -549,7 +549,8 @@ class PlexBrowserView: NSView {
     /// Radio button icon template (cached)
     private static var radioIconTemplate: NSImage? = {
         // Load radio icon from bundle as template
-        if let url = Bundle.module.url(forResource: "radio-icon", withExtension: "png"),
+        // Use BundleHelper to work in both SPM development and standalone app bundle
+        if let url = BundleHelper.url(forResource: "radio-icon", withExtension: "png"),
            let image = NSImage(contentsOf: url) {
             image.isTemplate = true
             return image


### PR DESCRIPTION
## Summary

- Fix crash on launch when running from DMG distribution
- Add `BundleHelper` to abstract resource loading between SPM and app bundle
- Replace all `Bundle.module` usages with `BundleHelper.url()`

## Problem

The app was crashing with SIGTRAP on launch for users who downloaded the DMG from releases. This was because `Bundle.module` is an SPM construct that doesn't exist in standalone app bundles.

## Solution

Created `BundleHelper` that:
1. Tries `Bundle.module` first (works in development)
2. Falls back to `Bundle.main` (works in standalone app)

## Test plan

- [ ] Build DMG with `./scripts/build_dmg.sh`
- [ ] Copy app to /Applications
- [ ] Run `xattr -cr /Applications/AdAmp.app`
- [ ] Launch app - should not crash
- [ ] Verify skin loads correctly
- [ ] Verify MilkDrop visualizations work

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Improved internal resource loading mechanism to ensure consistent access to app assets across different build configurations, enhancing reliability and maintainability.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->