### PR TITLE
Handle M4A streaming errors gracefully with auto-advance

### DIFF
--- a/AGENT_DOCS/AUDIO_SYSTEM.md
+++ b/AGENT_DOCS/AUDIO_SYSTEM.md
@@ -516,6 +516,10 @@ Formats supported by AVAudioFile:
 - MP3, AAC, Ogg Vorbis streams
 - Shoutcast/Icecast with metadata
 
+**M4A Limitation:** Only "fast-start" optimized M4A files are supported for HTTP streaming. Non-optimized M4A files (where the `moov` atom is at the end of the file) will fail with a `streamParseBytesFailure` error. This is a limitation of Apple's AudioFileStream Services. When this error occurs, AdAmp automatically advances to the next track.
+
+To fix problematic M4A files, re-encode with `ffmpeg -i input.m4a -movflags +faststart output.m4a`.
+
 ## Dependencies
 
 | Library | Purpose | Version |

--- a/Sources/AdAmp/Audio/StreamingAudioPlayer.swift
+++ b/Sources/AdAmp/Audio/StreamingAudioPlayer.swift
@@ -10,6 +10,7 @@ protocol StreamingAudioPlayerDelegate: AnyObject {
     func streamingPlayerDidUpdateSpectrum(_ levels: [Float])
     func streamingPlayerDidUpdatePCM(_ samples: [Float])
     func streamingPlayerDidDetectFormat(sampleRate: Int, channels: Int)
+    func streamingPlayerDidEncounterError(_ error: AudioPlayerError)
 }
 
 /// Wrapper around AudioStreaming's AudioPlayer that provides EQ and spectrum analysis
@@ -465,6 +466,7 @@ extension StreamingAudioPlayer: AudioPlayerDelegate {
     
     func audioPlayerUnexpectedError(player: AudioPlayer, error: AudioPlayerError) {
         NSLog("StreamingAudioPlayer: Unexpected error: %@", String(describing: error))
+        delegate?.streamingPlayerDidEncounterError(error)
     }
     
     func audioPlayerDidCancel(player: AudioPlayer, queuedItems: [AudioEntryId]) {


### PR DESCRIPTION
## Summary

- Add error handling for M4A streaming failures caused by non-optimized files (moov atom at end of file)
- Show error message in marquee when a track fails to play
- Auto-advance to the next track instead of stopping playback completely
- Document the M4A fast-start limitation in AUDIO_SYSTEM.md

This addresses a known limitation of Apple's AudioFileStream Services where only "fast-start" optimized M4A files work with HTTP streaming.

## Test plan

- [ ] Play a problematic M4A track from Plex that previously caused the `streamParseBytesFailure` error
- [ ] Verify error message appears briefly in marquee
- [ ] Verify playback auto-advances to next track
- [ ] Verify working tracks still play normally

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added automatic track advancement when audio playback encounters streaming errors.
  * Added error notifications when tracks fail to load.

* **Documentation**
  * Added guidance on M4A file streaming compatibility and remediation steps for problematic files.

* **Bug Fixes**
  * Improved error detection and handling for M4A streaming issues.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->