### PR TITLE
Fix visualization crashes and improve preset switching stability

### DIFF
--- a/AGENT_DOCS/AUDIO_SYSTEM.md
+++ b/AGENT_DOCS/AUDIO_SYSTEM.md
@@ -531,7 +531,7 @@ To fix problematic M4A files, re-encode with `ffmpeg -i input.m4a -movflags +fas
 
 ## Platform Requirements
 
-- **macOS 13.0+** (required by AudioStreaming library)
+- **macOS 14.0+** (required by Swift 6.0 toolchain)
 
 ## Plex Play Statistics
 

--- a/AGENT_DOCS/USER_GUIDE.md
+++ b/AGENT_DOCS/USER_GUIDE.md
@@ -28,7 +28,7 @@ A faithful recreation of Winamp 2.x for macOS with Plex Media Server integration
 
 ## System Requirements
 
-- **macOS 13.0 (Ventura)** or later
+- **macOS 14.0 (Sonoma)** or later
 - Internet connection (for Plex streaming and skin downloads)
 
 ---

--- a/Package.swift
+++ b/Package.swift
@@ -7,7 +7,7 @@ let package = Package(
     name: "AdAmp",
     defaultLocalization: "en",
     platforms: [
-        .macOS(.v13)
+        .macOS(.v14)
     ],
     products: [
         .executable(name: "AdAmp", targets: ["AdAmp"])

--- a/README.md
+++ b/README.md
@@ -57,7 +57,7 @@ After either option, AdAmp will open normally.
 
 ## Requirements
 
-- macOS 13.0 (Ventura) or later
+- macOS 14.0 (Sonoma) or later
 
 ## Building from Source
 

--- a/Sources/AdAmp/Resources/Info.plist
+++ b/Sources/AdAmp/Resources/Info.plist
@@ -15,11 +15,11 @@
     <key>CFBundleIconFile</key>
     <string>AppIcon</string>
     <key>CFBundleShortVersionString</key>
-    <string>0.9.3</string>
+    <string>0.9.7</string>
     <key>CFBundleVersion</key>
-    <string>4</string>
+    <string>8</string>
     <key>LSMinimumSystemVersion</key>
-    <string>12.0</string>
+    <string>14.0</string>
     <key>NSHighResolutionCapable</key>
     <true/>
     

--- a/Sources/AdAmp/Windows/Milkdrop/MilkdropView.swift
+++ b/Sources/AdAmp/Windows/Milkdrop/MilkdropView.swift
@@ -390,8 +390,13 @@ class MilkdropView: NSView {
             return
         }
         
-        // Click in visualization content area - advance to next preset
-        visualizationGLView?.nextPreset(hardCut: false)
+        // Content area - allow window dragging (removed click-to-advance preset to prevent crashes from rapid clicking)
+        // Use arrow keys, context menu, or auto-cycle to change presets instead
+        isDraggingWindow = true
+        windowDragStartPoint = event.locationInWindow
+        if let window = window {
+            WindowManager.shared.windowWillStartDragging(window, fromTitleBar: false)
+        }
     }
     
     /// Handle mouse down in shade mode

--- a/Sources/AdAmp/Windows/Milkdrop/MilkdropWindowController.swift
+++ b/Sources/AdAmp/Windows/Milkdrop/MilkdropWindowController.swift
@@ -64,6 +64,8 @@ class MilkdropWindowController: NSWindowController {
         super.showWindow(sender)
         // Position after window is shown to ensure correct frame dimensions
         positionWindow()
+        // Restart rendering (may have been stopped by windowWillClose)
+        milkdropView.startRendering()
     }
     
     /// Position the window to the LEFT of the main window


### PR DESCRIPTION
## Summary
- Fix visualization not rendering after window close/reopen
- Fix crash from rapid preset switching (EXC_BAD_ACCESS in projectM textures)
- Remove click-to-advance preset behavior to prevent accidental rapid switching

## Changes
- **MilkdropWindowController**: Call `startRendering()` when window reopens
- **ProjectMWrapper**: Add rate limiting (500ms), frame delay (10), time delay (250ms), and proper state tracking with `_presetLoadInProgress`
- **MilkdropView**: Click now drags window; use arrow keys or context menu for presets

## Test plan
- [ ] Open/close visualization window multiple times - should keep rendering
- [ ] Use arrow keys to change presets rapidly
- [ ] Verify clicking visualization now drags window
- [ ] Test auto-cycle and auto-random modes

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Window dragging now available by clicking and dragging in the visualization area
  * Enhanced preset stability with improved initialization timing

* **Chores**
  * Updated minimum macOS requirement to 14.0 (Sonoma)
  * Version bumped to 0.9.7

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->