### PR TITLE
Bump version to 0.9.11

### DIFF
--- a/Sources/AdAmp/Resources/Info.plist
+++ b/Sources/AdAmp/Resources/Info.plist
@@ -15,7 +15,7 @@
     <key>CFBundleIconFile</key>
     <string>AppIcon</string>
     <key>CFBundleShortVersionString</key>
-    <string>0.9.10</string>
+    <string>0.9.11</string>
     <key>CFBundleVersion</key>
     <string>1</string>
     <key>LSMinimumSystemVersion</key>


### PR DESCRIPTION
## Summary

- Bump version from 0.9.10 to 0.9.11

## Changes in this release

- Fix artwork crash in PlexBrowserView during rapid track changes (#53)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated application version to 0.9.11

<!-- end of auto-generated comment: release notes by coderabbit.ai -->