### PR TITLE
Bump version to 0.9.12

### DIFF
--- a/Sources/AdAmp/Resources/Info.plist
+++ b/Sources/AdAmp/Resources/Info.plist
@@ -15,7 +15,7 @@
     <key>CFBundleIconFile</key>
     <string>AppIcon</string>
     <key>CFBundleShortVersionString</key>
-    <string>0.9.11</string>
+    <string>0.9.12</string>
     <key>CFBundleVersion</key>
     <string>1</string>
     <key>LSMinimumSystemVersion</key>


### PR DESCRIPTION
## Summary
- Bump version from 0.9.11 to 0.9.12

## Changes
- CPU optimizations: reduced idle usage from ~50% to ~10%
- Milkdrop quality toggle (30fps/60fps) in context menu
- Timer visibility checks to pause when windows hidden/minimized