### PR TITLE
Fix spectrum analyzer not displaying after DMG install

### DIFF
--- a/Sources/AdAmp/Resources/Info.plist
+++ b/Sources/AdAmp/Resources/Info.plist
@@ -15,7 +15,7 @@
     <key>CFBundleIconFile</key>
     <string>AppIcon</string>
     <key>CFBundleShortVersionString</key>
-    <string>0.9.14</string>
+    <string>0.9.15</string>
     <key>CFBundleVersion</key>
     <string>1</string>
     <key>LSMinimumSystemVersion</key>

--- a/scripts/build_dmg.sh
+++ b/scripts/build_dmg.sh
@@ -125,6 +125,12 @@ else
     log_warning "No resources found at $BUNDLE_RESOURCES"
 fi
 
+# Copy Metal shader files from bundle root (SPM places .copy() files there)
+if [[ -f "$BUILD_DIR/AdAmp_AdAmp.bundle/SpectrumShaders.metal" ]]; then
+    cp "$BUILD_DIR/AdAmp_AdAmp.bundle/SpectrumShaders.metal" "$RESOURCES_DIR/"
+    log_success "Metal shaders copied"
+fi
+
 # Also copy Info.plist from source
 cp "$REPO_ROOT/Sources/AdAmp/Resources/Info.plist" "$CONTENTS_DIR/"
 


### PR DESCRIPTION
## Summary

- Fix Metal shader file not being copied to app bundle during DMG build
- SPM places `.copy()` resources at the bundle root, but `build_dmg.sh` only copied from `Resources/` subdirectory
- Bump version to 0.9.15

## Test plan

- [x] Build DMG with `./scripts/build_dmg.sh`
- [x] Verify shader file exists: `ls dist/AdAmp.app/Contents/Resources/*.metal`
- [ ] Install DMG on a different machine and verify spectrum analyzer window displays correctly

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated build process to include shader resources in the application.

* **Release**
  * Version bumped to 0.9.15.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->