### PR TITLE
Fix jumpy spectrum analyzer with smoother decay

### DIFF
--- a/Sources/AdAmp/Audio/AudioEngine.swift
+++ b/Sources/AdAmp/Audio/AudioEngine.swift
@@ -711,11 +711,11 @@ class AudioEngine {
         DispatchQueue.main.async { [weak self] in
             guard let self = self else { return }
             for i in 0..<bandCount {
-                // Fast attack, snappy decay for tight beat following
+                // Fast attack, smooth decay for visual appeal
                 if newSpectrum[i] > self.spectrumData[i] {
                     self.spectrumData[i] = newSpectrum[i]
                 } else {
-                    self.spectrumData[i] = self.spectrumData[i] * 0.55 + newSpectrum[i] * 0.45
+                    self.spectrumData[i] = self.spectrumData[i] * 0.90 + newSpectrum[i] * 0.10
                 }
             }
             self.delegate?.audioEngineDidUpdateSpectrum(self.spectrumData)

--- a/Sources/AdAmp/Audio/StreamingAudioPlayer.swift
+++ b/Sources/AdAmp/Audio/StreamingAudioPlayer.swift
@@ -420,11 +420,11 @@ class StreamingAudioPlayer {
         DispatchQueue.main.async { [weak self] in
             guard let self = self else { return }
             for i in 0..<bandCount {
-                // Fast attack, snappy decay for tight beat following
+                // Fast attack, smooth decay for visual appeal
                 if newSpectrum[i] > self.spectrumData[i] {
                     self.spectrumData[i] = newSpectrum[i]
                 } else {
-                    self.spectrumData[i] = self.spectrumData[i] * 0.55 + newSpectrum[i] * 0.45
+                    self.spectrumData[i] = self.spectrumData[i] * 0.90 + newSpectrum[i] * 0.10
                 }
             }
             self.delegate?.streamingPlayerDidUpdateSpectrum(self.spectrumData)

--- a/Sources/AdAmp/Resources/Info.plist
+++ b/Sources/AdAmp/Resources/Info.plist
@@ -15,7 +15,7 @@
     <key>CFBundleIconFile</key>
     <string>AppIcon</string>
     <key>CFBundleShortVersionString</key>
-    <string>0.9.15</string>
+    <string>0.9.16</string>
     <key>CFBundleVersion</key>
     <string>1</string>
     <key>LSMinimumSystemVersion</key>


### PR DESCRIPTION
## Summary

- Increase spectrum decay factor from 0.55 to 0.90 for smoother bar movement
- The previous value was too low (close to 50/50 blend), causing the bars to jump rapidly between values
- Both main window and standalone spectrum analyzer windows now display smooth bar movement
- Bumps version to 0.9.16

## Test plan

- [ ] Play audio and observe main window spectrum analyzer - bars should decay smoothly
- [ ] Open Spectrum Analyzer window and observe - bars should decay smoothly
- [ ] Test with both local files and Plex/Subsonic streaming

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved audio spectrum visualization with smoother decay animation during playback

* **Chores**
  * Version updated to 0.9.16

<!-- end of auto-generated comment: release notes by coderabbit.ai -->