### PR TITLE
Fix spectrum analyzer pumping with stable adaptive normalization

### DIFF
--- a/Sources/AdAmp/Audio/AudioEngine.swift
+++ b/Sources/AdAmp/Audio/AudioEngine.swift
@@ -689,11 +689,11 @@ class AudioEngine {
             guard regionPeak > 0 else { continue }
             
             // Update adaptive peak for this region
-            // Fast rise, moderate decay for responsiveness
+            // Slow rise and slow decay for stable reference level (avoids pumping)
             if regionPeak > spectrumRegionPeaks[regionIndex] {
-                spectrumRegionPeaks[regionIndex] = spectrumRegionPeaks[regionIndex] * 0.4 + regionPeak * 0.6
+                spectrumRegionPeaks[regionIndex] = spectrumRegionPeaks[regionIndex] * 0.92 + regionPeak * 0.08
             } else {
-                spectrumRegionPeaks[regionIndex] = spectrumRegionPeaks[regionIndex] * 0.97 + regionPeak * 0.03
+                spectrumRegionPeaks[regionIndex] = spectrumRegionPeaks[regionIndex] * 0.995 + regionPeak * 0.005
             }
             
             // Reference level for this region

--- a/Sources/AdAmp/Audio/StreamingAudioPlayer.swift
+++ b/Sources/AdAmp/Audio/StreamingAudioPlayer.swift
@@ -398,11 +398,11 @@ class StreamingAudioPlayer {
             guard regionPeak > 0 else { continue }
             
             // Update adaptive peak for this region
-            // Fast rise, moderate decay for responsiveness
+            // Slow rise and slow decay for stable reference level (avoids pumping)
             if regionPeak > spectrumRegionPeaks[regionIndex] {
-                spectrumRegionPeaks[regionIndex] = spectrumRegionPeaks[regionIndex] * 0.4 + regionPeak * 0.6
+                spectrumRegionPeaks[regionIndex] = spectrumRegionPeaks[regionIndex] * 0.92 + regionPeak * 0.08
             } else {
-                spectrumRegionPeaks[regionIndex] = spectrumRegionPeaks[regionIndex] * 0.97 + regionPeak * 0.03
+                spectrumRegionPeaks[regionIndex] = spectrumRegionPeaks[regionIndex] * 0.995 + regionPeak * 0.005
             }
             
             // Reference level for this region

--- a/Sources/AdAmp/Resources/Info.plist
+++ b/Sources/AdAmp/Resources/Info.plist
@@ -15,7 +15,7 @@
     <key>CFBundleIconFile</key>
     <string>AppIcon</string>
     <key>CFBundleShortVersionString</key>
-    <string>0.9.16</string>
+    <string>0.9.17</string>
     <key>CFBundleVersion</key>
     <string>1</string>
     <key>LSMinimumSystemVersion</key>


### PR DESCRIPTION
## Summary

- Fix spectrum analyzer "pumping" caused by fast-reacting adaptive normalization
- Slow down reference level rise from 0.6 to 0.08 blend factor
- Slow down reference level decay from 0.03 to 0.005 blend factor  
- Keep decay smoothing at 0.90 for smooth bar movement
- Bumps version to 0.9.17

The adaptive per-region normalization was causing bars to suddenly drop when loud beats spiked the reference level. This fix makes the reference level very stable over time while maintaining the benefit of per-region normalization (bass doesn't drown out mids/treble).

## Test plan

- [ ] Play audio and observe spectrum analyzer - bars should move smoothly without pumping/hesitation
- [ ] Test with bass-heavy music - reference level should remain stable
- [ ] Both main window and standalone Spectrum Analyzer window should be smooth

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved audio normalization stability for more consistent output and reduced fluctuations during dynamic playback.

* **Chores**
  * Version bumped to 0.9.17

<!-- end of auto-generated comment: release notes by coderabbit.ai -->