### PR TITLE
Bump version to 0.13.0

### DIFF
--- a/Sources/NullPlayer/Resources/Info.plist
+++ b/Sources/NullPlayer/Resources/Info.plist
@@ -15,7 +15,7 @@
     <key>CFBundleIconFile</key>
     <string>AppIcon</string>
     <key>CFBundleShortVersionString</key>
-    <string>0.12.0</string>
+    <string>0.13.0</string>
     <key>CFBundleVersion</key>
     <string>1</string>
     <key>LSMinimumSystemVersion</key>


### PR DESCRIPTION
## Summary

Bump version to 0.13.0 for the modern skin engine release.

## Changes

- `CFBundleShortVersionString`: 0.12.0 → 0.13.0

## Test Plan

- [ ] Build DMG and verify version displays correctly

Made with [Cursor](https://cursor.com)