### PR TITLE
Remove Get More Skins and Lock Browser/ProjectM options from classic menu

### DIFF
--- a/Sources/NullPlayer/App/ContextMenuBuilder.swift
+++ b/Sources/NullPlayer/App/ContextMenuBuilder.swift
@@ -192,11 +192,6 @@ class ContextMenuBuilder {
         loadSkin.target = MenuActions.shared
         classicMenu.addItem(loadSkin)
         
-        // Get More Skins...
-        let getMoreSkins = NSMenuItem(title: "Get More Skins...", action: #selector(MenuActions.getMoreSkins), keyEquivalent: "")
-        getMoreSkins.target = MenuActions.shared
-        classicMenu.addItem(getMoreSkins)
-        
         classicMenu.addItem(NSMenuItem.separator())
         
         // Default Skin (Silver)
@@ -207,14 +202,6 @@ class ContextMenuBuilder {
             defaultSkinItem.state = .on
         }
         classicMenu.addItem(defaultSkinItem)
-        
-        classicMenu.addItem(NSMenuItem.separator())
-        
-        // Lock Browser/ProjectM toggle
-        let lockToggle = NSMenuItem(title: "Lock Browser/ProjectM to Default", action: #selector(MenuActions.toggleLockBrowserProjectM(_:)), keyEquivalent: "")
-        lockToggle.target = MenuActions.shared
-        lockToggle.state = WindowManager.shared.lockBrowserProjectMSkin ? .on : .off
-        classicMenu.addItem(lockToggle)
         
         classicMenu.addItem(NSMenuItem.separator())
         
@@ -1919,16 +1906,6 @@ class MenuActions: NSObject {
         } else {
             // Already in modern mode — load the skin immediately
             ModernSkinEngine.shared.loadSkin(named: name)
-        }
-    }
-    
-    @objc func toggleLockBrowserProjectM(_ sender: NSMenuItem) {
-        WindowManager.shared.lockBrowserProjectMSkin.toggle()
-    }
-    
-    @objc func getMoreSkins() {
-        if let url = URL(string: "https://skins.webamp.org/") {
-            NSWorkspace.shared.open(url)
         }
     }
     

--- a/Sources/NullPlayer/App/WindowManager.swift
+++ b/Sources/NullPlayer/App/WindowManager.swift
@@ -1131,23 +1131,6 @@ class WindowManager {
     
     // MARK: - Skin Management
     
-    /// When true, Browser and ProjectM windows always use default skin (default: false - follow skin changes)
-    var lockBrowserProjectMSkin: Bool {
-        get {
-            // Default to false (unlocked) - windows follow skin changes by default
-            if UserDefaults.standard.object(forKey: "lockBrowserProjectMSkin") == nil {
-                return false
-            }
-            return UserDefaults.standard.bool(forKey: "lockBrowserProjectMSkin")
-        }
-        set {
-            UserDefaults.standard.set(newValue, forKey: "lockBrowserProjectMSkin")
-            // Refresh these windows when setting changes
-            plexBrowserWindowController?.skinDidChange()
-            projectMWindowController?.skinDidChange()
-        }
-    }
-    
     /// When true, shows album art as transparent background in browser window (default: true)
     var showBrowserArtworkBackground: Bool {
         get {

--- a/Sources/NullPlayer/Windows/ModernLibraryBrowser/ModernLibraryBrowserView.swift
+++ b/Sources/NullPlayer/Windows/ModernLibraryBrowser/ModernLibraryBrowserView.swift
@@ -354,13 +354,8 @@ class ModernLibraryBrowserView: NSView {
         layer?.isOpaque = false
         layerContentsRedrawPolicy = .onSetNeedsDisplay
         
-        // Load skin (respecting lock)
-        let skin: ModernSkin
-        if WindowManager.shared.lockBrowserProjectMSkin {
-            skin = ModernSkinLoader.shared.loadDefault()
-        } else {
-            skin = ModernSkinEngine.shared.currentSkin ?? ModernSkinLoader.shared.loadDefault()
-        }
+        // Load skin
+        let skin = ModernSkinEngine.shared.currentSkin ?? ModernSkinLoader.shared.loadDefault()
         renderer = ModernSkinRenderer(skin: skin)
         
         // Load saved column widths, visibility, and sort
@@ -485,9 +480,6 @@ class ModernLibraryBrowserView: NSView {
     // MARK: - Current Skin Helper
     
     private func currentSkin() -> ModernSkin {
-        if WindowManager.shared.lockBrowserProjectMSkin {
-            return ModernSkinLoader.shared.loadDefault()
-        }
         return ModernSkinEngine.shared.currentSkin ?? ModernSkinLoader.shared.loadDefault()
     }
     

--- a/Sources/NullPlayer/Windows/ModernProjectM/ModernProjectMView.swift
+++ b/Sources/NullPlayer/Windows/ModernProjectM/ModernProjectMView.swift
@@ -157,11 +157,8 @@ class ModernProjectMView: NSView {
         setAccessibilityLabel("Visualization")
     }
     
-    /// Resolve which skin to use based on lock setting
+    /// Resolve which skin to use
     private func resolveCurrentSkin() -> ModernSkin {
-        if WindowManager.shared.lockBrowserProjectMSkin {
-            return ModernSkinLoader.shared.loadDefault()
-        }
         return ModernSkinEngine.shared.currentSkin ?? ModernSkinLoader.shared.loadDefault()
     }
     

--- a/Sources/NullPlayer/Windows/PlexBrowser/PlexBrowserView.swift
+++ b/Sources/NullPlayer/Windows/PlexBrowser/PlexBrowserView.swift
@@ -1335,13 +1335,8 @@ class PlexBrowserView: NSView {
         let originalSize = originalWindowSize
         let scale = scaleFactor
         
-        // Use default skin if locked, otherwise use current skin
-        let skin: Skin
-        if WindowManager.shared.lockBrowserProjectMSkin {
-            skin = SkinLoader.shared.loadDefault()
-        } else {
-            skin = WindowManager.shared.currentSkin ?? SkinLoader.shared.loadDefault()
-        }
+        // Use current skin
+        let skin = WindowManager.shared.currentSkin ?? SkinLoader.shared.loadDefault()
         let renderer = SkinRenderer(skin: skin)
         let isActive = window?.isKeyWindow ?? true
         

--- a/Sources/NullPlayer/Windows/ProjectM/ProjectMView.swift
+++ b/Sources/NullPlayer/Windows/ProjectM/ProjectMView.swift
@@ -200,13 +200,8 @@ class ProjectMView: NSView {
             return
         }
         
-        // Use default skin if locked, otherwise use current skin
-        let skin: Skin
-        if WindowManager.shared.lockBrowserProjectMSkin {
-            skin = SkinLoader.shared.loadDefault()
-        } else {
-            skin = WindowManager.shared.currentSkin ?? SkinLoader.shared.loadDefault()
-        }
+        // Use current skin
+        let skin = WindowManager.shared.currentSkin ?? SkinLoader.shared.loadDefault()
         let renderer = SkinRenderer(skin: skin)
         let isActive = window?.isKeyWindow ?? true
         

--- a/Sources/NullPlayer/Windows/Spectrum/SpectrumView.swift
+++ b/Sources/NullPlayer/Windows/Spectrum/SpectrumView.swift
@@ -136,13 +136,8 @@ class SpectrumView: NSView {
     override func draw(_ dirtyRect: NSRect) {
         guard let context = NSGraphicsContext.current?.cgContext else { return }
         
-        // Use default skin if locked, otherwise use current skin
-        let skin: Skin
-        if WindowManager.shared.lockBrowserProjectMSkin {
-            skin = SkinLoader.shared.loadDefault()
-        } else {
-            skin = WindowManager.shared.currentSkin ?? SkinLoader.shared.loadDefault()
-        }
+        // Use current skin
+        let skin = WindowManager.shared.currentSkin ?? SkinLoader.shared.loadDefault()
         let renderer = SkinRenderer(skin: skin)
         let isActive = window?.isKeyWindow ?? true
         


### PR DESCRIPTION
## Summary
- Remove "Get More Skins..." menu item and action from classic skin submenu
- Remove "Lock Browser/ProjectM to Default" toggle and associated `lockBrowserProjectMSkin` property
- Simplify conditional skin loading logic in Browser/ProjectM/Spectrum views

## Test plan
- [ ] Verify classic mode context menu no longer shows "Get More Skins..." option
- [ ] Verify classic mode context menu no longer shows "Lock Browser/ProjectM to Default" option
- [ ] Verify Browser, ProjectM, and Spectrum windows correctly use the current skin


Made with [Cursor](https://cursor.com)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Removed Features**
  * The "Lock Browser/ProjectM Skin" menu option has been removed.
  * The "Get More Skins" menu item has been removed.

* **Improvements**
  * Streamlined skin selection logic across all windows to consistently use the active skin or default fallback, improving predictability and reducing complexity.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->