### PR TITLE
Default BPM multiplier to 0.5x for smoother visualizations

### DIFF
--- a/Sources/NullPlayer/Windows/ModernMainWindow/ModernMainWindowView.swift
+++ b/Sources/NullPlayer/Windows/ModernMainWindow/ModernMainWindowView.swift
@@ -63,7 +63,7 @@ class ModernMainWindowView: NSView {
     private var currentBPM: Int?
     
     /// BPM multiplier cycle state: 0 = normal, 1 = 2x, 2 = 0.5x
-    private var bpmMultiplierState: Int = 0
+    private var bpmMultiplierState: Int = 2
     
     /// Scale factor for hit testing (computed to track double-size changes)
     private var scale: CGFloat { ModernSkinElements.scaleFactor }
@@ -582,7 +582,7 @@ class ModernMainWindowView: NSView {
         self.currentTrack = track
         self.videoTitle = nil
         self.currentBPM = nil  // Reset BPM for new track
-        self.bpmMultiplierState = 0  // Reset multiplier for new track
+        self.bpmMultiplierState = 2  // Reset multiplier for new track (default to 0.5x)
         
         if let track = track {
             marqueeLayer.text = track.displayTitle.uppercased()


### PR DESCRIPTION
## Summary
- Changes the default BPM multiplier state from 1x to 0.5x so visualizations run at half the detected BPM by default
- Provides a smoother, less frenetic visual experience for most music
- Users can still cycle through 1x, 2x, and 0.5x by clicking the BPM display

## Test plan
- [ ] Play a track with BPM detection enabled
- [ ] Verify visualizations start at 0.5x speed (half the detected BPM)
- [ ] Click BPM display to cycle through multipliers (0.5x → 1x → 2x → 0.5x)
- [ ] Change tracks and verify multiplier resets to 0.5x


Made with [Cursor](https://cursor.com)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Updated BPM display initialization behavior to default to 0.5x playback speed instead of normal speed when displaying BPM information.
  * Modified BPM display reset behavior during new track loading to consistently start at 0.5x speed, ensuring uniform behavior when cycling through BPM display options.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->