### PR TITLE
Fix shade mode text inconsistency for ProjectM and Spectrum windows

### DIFF
--- a/Sources/NullPlayer/Skin/SkinRenderer.swift
+++ b/Sources/NullPlayer/Skin/SkinRenderer.swift
@@ -2381,8 +2381,7 @@ class SkinRenderer {
             x += tile.width
         }
         
-        // Draw "PROJECTM" text using GenFont with dark background gap
-        drawGenFontTitleText("PROJECTM", in: context, bounds: bounds, titleHeight: shadeHeight, isActive: isActive)
+        // Note: Custom text removed - let the skin's title bar show through
         
         // Close button pressed state
         if pressedButton == .close {


### PR DESCRIPTION
## Summary
Fixes inconsistent behavior where custom text appears/disappears when toggling shade mode on ProjectM and Spectrum Analyzer windows.

## Issue
PR #93 removed custom text overlays from normal mode title bars, but the shade mode functions (`drawProjectMShade` and `drawSpectrumAnalyzerShade`) still had `drawGenFontTitleText` calls, causing text to appear only in shade mode.

## Changes
- Remove `drawGenFontTitleText("PROJECTM", ...)` from `drawProjectMShade`
- Remove `drawGenFontTitleText("NULLPLAYER ANALYZER", ...)` from `drawSpectrumAnalyzerShade`

## Test plan
- [x] Verify no text appears on ProjectM title bar in normal mode
- [x] Verify no text appears on ProjectM title bar in shade mode
- [x] Verify no text appears on Spectrum Analyzer title bar in normal mode
- [x] Verify no text appears on Spectrum Analyzer title bar in shade mode
- [x] Verify title bar sprites still display correctly

Made with [Cursor](https://cursor.com)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Bug Fixes**
  * Improved title bar rendering to allow skin-specific decorations to display properly in the main window. Skins now have full control over the title area appearance instead of generic application text being rendered.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->