### PR TITLE
fix: restore Plex streaming tracks after restart + CPU optimizations + Plex Radio History

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -135,7 +135,7 @@ Sources/NullPlayer/
 | Windows | `Windows/MainWindow/`, `Windows/ModernMainWindow/`, `Windows/ModernSpectrum/`, `Windows/ModernPlaylist/`, `Windows/ModernEQ/`, `Windows/ModernProjectM/`, `Windows/ModernLibraryBrowser/`, `Windows/Playlist/`, `Windows/Equalizer/` |
 | Visualization | `Windows/ProjectM/`, `Windows/Spectrum/`, `Visualization/VisualizationGLView.swift`, `Visualization/SpectrumAnalyzerView.swift`, `Visualization/SpectrumShaders.metal`, `Visualization/FlameShaders.metal`, `Visualization/CosmicShaders.metal`, `Visualization/ElectricityShaders.metal`, `Visualization/MatrixShaders.metal`, `Visualization/ProjectMWrapper.swift` |
 | Marquee | `Skin/MarqueeLayer.swift` (classic), `ModernSkin/ModernMarqueeLayer.swift` (modern), `Windows/Playlist/PlaylistView.swift` |
-| Plex | `Plex/PlexManager.swift`, `Plex/PlexServerClient.swift` |
+| Plex | `Plex/PlexManager.swift`, `Plex/PlexServerClient.swift`, `Plex/PlexRadioHistory.swift` |
 | Subsonic | `Subsonic/SubsonicManager.swift`, `Subsonic/SubsonicServerClient.swift`, `Subsonic/SubsonicModels.swift` |
 | Jellyfin | `Jellyfin/JellyfinManager.swift`, `Jellyfin/JellyfinServerClient.swift`, `Jellyfin/JellyfinModels.swift`, `Jellyfin/JellyfinPlaybackReporter.swift` |
 | Emby | `Emby/EmbyManager.swift`, `Emby/EmbyServerClient.swift`, `Emby/EmbyModels.swift`, `Emby/EmbyPlaybackReporter.swift`, `Emby/EmbyVideoPlaybackReporter.swift` |

--- a/README.md
+++ b/README.md
@@ -9,16 +9,19 @@
 
 ## Features
 
-- A Brand new library browser window for Plex, Jellyfin, Emby, Navidrome/Subsonic, and local library files
+- Library browser window for Plex, Jellyfin, Emby, Navidrome/Subsonic, and local library files
 - Plex Media Server integration with PIN-based authentication
 - Plex music and video streaming and playlist support
 - Jellyfin media server integration with music and video streaming, scrobbling, and library browsing
 - Emby media server integration with music and video streaming, scrobbling, and library browsing
+- Navidrome/Subsonic server integration with scrobbling support
+- Local media library with metadata parsing, editing, library management
 - ProjectM visualizations with 100 included. Users can download more
 - Just like PlexAmp, sonic similarity supportuing radio stations populated by Plex API's  (Library, Genre, Decade, Hits, Deep Cuts)
+- Sonos content filtering for unsupported lossless formats. Keeps the music playing by not sending unsupported encodings to Sonos.
 - Much better Sonos playlist support than the current PlexAmp (Jan 2026)
-- Support for classic Winamp skin skins (.wsz files)
-- New Modern V2 UI user skin system
+- Classic V1 UI has full support for classic Winamp skin skins (.wsz files)
+- Modern V2 UI skin system, many v2 skins included. Open format, users can easily make new v2 skins via json
 - Original Spenctrum analysis visualization system
 - Album art visualization system with user selected effects
 - Main player, Playlist editor, and 10-band Equalizer windows
@@ -28,11 +31,7 @@
 - Gapless playback for seamless track transitions
 - Sweet Fades (crossfade) with configurable fade duration
 - Volume normalization for consistent loudness
-- Local media library with metadata parsing
-- Local media library backup and restore
 - Media Drag and drop support
-- Navidrome/Subsonic server integration with scrobbling support
-- Jellyfin server integration with full support
 - Album/Cover/Movie art browser with visualizations
 - IMDB integration
 - Internet radio (Shoutcast/Icecast) with live metadata and auto-reconnect

--- a/README.md
+++ b/README.md
@@ -17,7 +17,8 @@
 - Navidrome/Subsonic server integration with scrobbling support
 - Local media library with metadata parsing, editing, library management
 - ProjectM visualizations with 100 included. Users can download more
-- Just like PlexAmp, sonic similarity supportuing radio stations populated by Plex API's  (Library, Genre, Decade, Hits, Deep Cuts)
+- Sonic similarity radio stations populated by Plex API's  (Library, Genre, Decade, Hits, Deep Cuts)
+- Plex radio track history with configurable exclusion rules. Stop the same songs from being added to your Plex radio stations
 - Sonos content filtering for unsupported lossless formats. Keeps the music playing by not sending unsupported encodings to Sonos.
 - Much better Sonos playlist support than the current PlexAmp (Jan 2026)
 - Classic V1 UI has full support for classic Winamp skin skins (.wsz files)

--- a/Sources/NullPlayer/App/AppDelegate.swift
+++ b/Sources/NullPlayer/App/AppDelegate.swift
@@ -40,7 +40,9 @@ class AppDelegate: NSObject, NSApplicationDelegate {
         
         // Set up audio engine delegate
         windowManager.audioEngine.delegate = self
-        
+        // Main window always shows a mini spectrum overlay — register as permanent consumer
+        windowManager.audioEngine.addSpectrumConsumer("mainWindowSpectrum")
+
         // Load skin from environment variable if set (for testing)
         if let skinPath = ProcessInfo.processInfo.environment["NULLPLAYER_SKIN"] {
             let skinURL = URL(fileURLWithPath: skinPath)
@@ -104,7 +106,8 @@ class AppDelegate: NSObject, NSApplicationDelegate {
         
         // Set up audio engine delegate
         windowManager.audioEngine.delegate = self
-        
+        windowManager.audioEngine.addSpectrumConsumer("mainWindowSpectrum")
+
         // Use default skin for consistent test results
         // Don't load custom skins from environment in test mode
         

--- a/Sources/NullPlayer/App/AppStateManager.swift
+++ b/Sources/NullPlayer/App/AppStateManager.swift
@@ -859,21 +859,33 @@ class AppStateManager {
             adjustedIndex -= skippedBefore
         }
         
+        // Determine if the current track is a streaming placeholder (real URL not yet available)
+        let currentIsPlaceholder = plexIndicesToFetch.contains(where: { $0.1 == adjustedIndex })
+            || subsonicIndicesToFetch.contains(where: { $0.1 == adjustedIndex })
+            || jellyfinIndicesToFetch.contains(where: { $0.1 == adjustedIndex })
+            || embyIndicesToFetch.contains(where: { $0.1 == adjustedIndex })
+
         // Select the current track (load it without playing)
         if adjustedIndex >= 0 && adjustedIndex < allTracks.count {
-            // Use playTrack to load the track, then immediately pause
-            engine.playTrack(at: adjustedIndex)
-            engine.pause()
-            
-            // Seek to saved position after a brief delay to let the track load
-            let savedPosition = state.playbackPosition
-            if savedPosition > 0 {
-                DispatchQueue.main.asyncAfter(deadline: .now() + 0.3) {
-                    engine.seek(to: savedPosition)
-                    NSLog("AppStateManager: Seeked to saved position: %.1fs", savedPosition)
+            if currentIsPlaceholder {
+                // Placeholder — show metadata in UI but defer actual load until async fetch replaces it
+                engine.selectTrackForDisplay(at: adjustedIndex)
+                NSLog("AppStateManager: Current track is a streaming placeholder, deferring load")
+            } else {
+                // Local file or radio — load immediately then pause
+                engine.playTrack(at: adjustedIndex)
+                engine.pause()
+
+                // Seek to saved position after a brief delay to let the track load
+                let savedPosition = state.playbackPosition
+                if savedPosition > 0 {
+                    DispatchQueue.main.asyncAfter(deadline: .now() + 0.3) {
+                        engine.seek(to: savedPosition)
+                        NSLog("AppStateManager: Seeked to saved position: %.1fs", savedPosition)
+                    }
                 }
+                NSLog("AppStateManager: Selected track at index %d", adjustedIndex)
             }
-            NSLog("AppStateManager: Selected track at index %d", adjustedIndex)
         }
         
         // Fetch streaming tracks asynchronously and replace placeholders
@@ -884,7 +896,7 @@ class AppStateManager {
                 var replacements: [(Track, Int)] = []  // (realTrack, playlistIndex)
                 
                 // Fetch Plex tracks
-                if !plexIndicesToFetch.isEmpty, let client = PlexManager.shared.serverClient {
+                if !plexIndicesToFetch.isEmpty, let client = await waitForPlexClient() {
                     for (savedTrack, playlistIndex) in plexIndicesToFetch {
                         if let ratingKey = savedTrack.plexRatingKey {
                             do {
@@ -1022,7 +1034,20 @@ class AppStateManager {
     }
     
     // MARK: - Helpers
-    
+
+    /// Wait up to `timeout` seconds for Plex to connect and return its serverClient.
+    private func waitForPlexClient(timeout: TimeInterval = 15) async -> PlexServerClient? {
+        if let client = PlexManager.shared.serverClient { return client }
+        NSLog("AppStateManager: Waiting for Plex connection to restore streaming tracks...")
+        let deadline = Date().addingTimeInterval(timeout)
+        while Date() < deadline {
+            try? await Task.sleep(nanoseconds: 250_000_000) // poll every 0.25s
+            if let client = PlexManager.shared.serverClient { return client }
+        }
+        NSLog("AppStateManager: Plex did not connect within %.0fs — skipping Plex track restoration", timeout)
+        return nil
+    }
+
     /// Get the custom skin path if a non-default skin is loaded
     private func getCustomSkinPath() -> String? {
         // Return the currently loaded custom skin path tracked by WindowManager

--- a/Sources/NullPlayer/App/AppStateManager.swift
+++ b/Sources/NullPlayer/App/AppStateManager.swift
@@ -85,7 +85,7 @@ class AppStateManager {
         var contentType: String?
         
         /// Create from a Track
-        static func from(_ track: Track, plexServerId: String?) -> SavedTrack {
+        static func from(_ track: Track) -> SavedTrack {
             if track.url.isFileURL {
                 return SavedTrack(
                     localURL: track.url.absoluteString,
@@ -97,7 +97,7 @@ class AppStateManager {
             } else if let plexKey = track.plexRatingKey {
                 return SavedTrack(
                     plexRatingKey: plexKey,
-                    plexServerId: plexServerId,
+                    plexServerId: track.plexServerId,
                     title: track.title,
                     artist: track.artist,
                     album: track.album,
@@ -505,7 +505,7 @@ class AppStateManager {
             
             // Playback state - save all tracks with metadata for restoration
             playlistTracks: engine.playlist.map { track in
-                SavedTrack.from(track, plexServerId: PlexManager.shared.currentServer?.id)
+                SavedTrack.from(track)
             },
             currentTrackIndex: engine.currentIndex,
             playbackPosition: engine.currentTime,
@@ -892,9 +892,9 @@ class AppStateManager {
         let hasStreamingTracks = !plexIndicesToFetch.isEmpty || !subsonicIndicesToFetch.isEmpty || !jellyfinIndicesToFetch.isEmpty || !embyIndicesToFetch.isEmpty
         if hasStreamingTracks {
             let savedCurrentIndex = adjustedIndex
-            Task {
+            Task.detached { [self] in
                 var replacements: [(Track, Int)] = []  // (realTrack, playlistIndex)
-                
+
                 // Fetch Plex tracks
                 if !plexIndicesToFetch.isEmpty, let client = await waitForPlexClient() {
                     for (savedTrack, playlistIndex) in plexIndicesToFetch {
@@ -1044,6 +1044,8 @@ class AppStateManager {
             try? await Task.sleep(nanoseconds: 250_000_000) // poll every 0.25s
             if let client = PlexManager.shared.serverClient { return client }
         }
+        // One final check in case client connected during the last sleep window
+        if let client = PlexManager.shared.serverClient { return client }
         NSLog("AppStateManager: Plex did not connect within %.0fs — skipping Plex track restoration", timeout)
         return nil
     }

--- a/Sources/NullPlayer/App/ContextMenuBuilder.swift
+++ b/Sources/NullPlayer/App/ContextMenuBuilder.swift
@@ -374,9 +374,59 @@ class ContextMenuBuilder {
         artworkBgItem.target = MenuActions.shared
         artworkBgItem.state = wm.showBrowserArtworkBackground ? .on : .off
         optionsMenu.addItem(artworkBgItem)
-        
+
+        // Plex Radio History (only when Plex is connected)
+        if PlexManager.shared.isLinked {
+            optionsMenu.addItem(NSMenuItem.separator())
+
+            let historyItem = NSMenuItem(title: "Plex Radio History", action: nil, keyEquivalent: "")
+            let historyMenu = NSMenu()
+            historyMenu.autoenablesItems = false
+
+            // Retention interval submenu
+            let intervalItem = NSMenuItem(title: "History Interval", action: nil, keyEquivalent: "")
+            let intervalMenu = NSMenu()
+            intervalMenu.autoenablesItems = false
+
+            let currentInterval = PlexRadioHistory.shared.retentionInterval
+            for interval in PlexRadioHistoryInterval.allCases {
+                let item = NSMenuItem(
+                    title: interval.displayName,
+                    action: #selector(MenuActions.setPlexRadioHistoryInterval(_:)),
+                    keyEquivalent: ""
+                )
+                item.target = MenuActions.shared
+                item.representedObject = interval.rawValue
+                item.state = currentInterval == interval ? .on : .off
+                intervalMenu.addItem(item)
+            }
+            intervalItem.submenu = intervalMenu
+            historyMenu.addItem(intervalItem)
+
+            historyMenu.addItem(NSMenuItem.separator())
+
+            let viewItem = NSMenuItem(
+                title: "View Radio History...",
+                action: #selector(MenuActions.viewPlexRadioHistory),
+                keyEquivalent: ""
+            )
+            viewItem.target = MenuActions.shared
+            historyMenu.addItem(viewItem)
+
+            let clearItem = NSMenuItem(
+                title: "Clear Radio History...",
+                action: #selector(MenuActions.clearPlexRadioHistory),
+                keyEquivalent: ""
+            )
+            clearItem.target = MenuActions.shared
+            historyMenu.addItem(clearItem)
+
+            historyItem.submenu = historyMenu
+            optionsMenu.addItem(historyItem)
+        }
+
         optionsMenu.addItem(NSMenuItem.separator())
-        
+
         optionsItem.submenu = optionsMenu
         return optionsItem
     }
@@ -2397,7 +2447,39 @@ class MenuActions: NSObject {
     @objc func toggleBrowserArtworkBackground() {
         WindowManager.shared.showBrowserArtworkBackground.toggle()
     }
-    
+
+    // MARK: - Plex Radio History
+
+    @objc func setPlexRadioHistoryInterval(_ sender: NSMenuItem) {
+        guard let rawValue = sender.representedObject as? String,
+              let interval = PlexRadioHistoryInterval(rawValue: rawValue) else { return }
+        PlexRadioHistory.shared.retentionInterval = interval
+    }
+
+    @objc func viewPlexRadioHistory() {
+        Task {
+            if !LocalMediaServer.shared.isRunning {
+                try? await LocalMediaServer.shared.start()
+            }
+            if let url = PlexRadioHistory.shared.historyPageURL {
+                NSWorkspace.shared.open(url)
+            }
+        }
+    }
+
+    @objc func clearPlexRadioHistory() {
+        let alert = NSAlert()
+        alert.messageText = "Clear Radio History?"
+        alert.informativeText = "This will remove all Plex Radio track history. This cannot be undone."
+        alert.alertStyle = .warning
+        alert.addButton(withTitle: "Clear")
+        alert.addButton(withTitle: "Cancel")
+
+        if alert.runModal() == .alertFirstButtonReturn {
+            PlexRadioHistory.shared.clearHistory()
+        }
+    }
+
     // MARK: - Main Window Visualization Options
     
     @objc func setMainVisMode(_ sender: NSMenuItem) {

--- a/Sources/NullPlayer/Audio/AudioEngine.swift
+++ b/Sources/NullPlayer/Audio/AudioEngine.swift
@@ -2241,6 +2241,15 @@ class AudioEngine {
         delegate?.audioEngineDidChangePlaylist()
     }
     
+    /// Select a track by index for display without loading or playing it.
+    /// Used during state restoration when the real stream URL is pending an async fetch.
+    func selectTrackForDisplay(at index: Int) {
+        guard index >= 0 && index < playlist.count else { return }
+        currentIndex = index
+        currentTrack = playlist[index]
+        delegate?.audioEngineDidChangeTrack(currentTrack)
+    }
+
     /// Replace a track at a specific index without affecting playback.
     /// Used to swap placeholder tracks with fully-resolved streaming tracks
     /// during state restoration.
@@ -2425,7 +2434,13 @@ class AudioEngine {
         defer { isLoadingTrack = false }
         
         let track = playlist[index]
-        
+
+        // Skip about:blank placeholder tracks — streaming URL not yet resolved via async fetch
+        if track.url.absoluteString == "about:blank" {
+            NSLog("loadTrack: skipping placeholder track '%@' — waiting for async URL fetch", track.title ?? "")
+            return
+        }
+
         // Route video tracks to the video player
         if track.mediaType == .video {
             NSLog("AudioEngine: Routing video track to video player: %@", track.title)

--- a/Sources/NullPlayer/Audio/AudioEngine.swift
+++ b/Sources/NullPlayer/Audio/AudioEngine.swift
@@ -1901,7 +1901,12 @@ class AudioEngine {
     private func castTrackDidFinish() {
         // Report track finished to Plex (natural end)
         PlexPlaybackReporter.shared.trackDidStop(at: duration, finished: true)
-        
+
+        // Record to Plex Radio history (track actually finished playing via cast)
+        if let finishedTrack = currentTrack, finishedTrack.plexRatingKey != nil {
+            PlexRadioHistory.shared.recordTrackPlayed(finishedTrack)
+        }
+
         // Prevent multiple calls
         castPlaybackStartDate = nil
         
@@ -2754,6 +2759,11 @@ class AudioEngine {
         // Report stop to Emby
         EmbyPlaybackReporter.shared.trackStopped()
 
+        // Record to Plex Radio history (track actually finished playing)
+        if let finishedTrack = currentTrack, finishedTrack.plexRatingKey != nil {
+            PlexRadioHistory.shared.recordTrackPlayed(finishedTrack)
+        }
+
         // Check if we have a gaplessly pre-scheduled next track (local files)
         if gaplessPlaybackEnabled && nextScheduledFile != nil && nextScheduledTrackIndex >= 0 {
             // Gapless transition - the next file is already scheduled
@@ -3169,6 +3179,11 @@ class AudioEngine {
         let activePlayer = crossfadePlayerIsActive ? crossfadePlayerNode : playerNode
         activePlayer.volume = 1.0
         
+        // Record outgoing track to Plex Radio history (track finished via crossfade)
+        if let outgoingTrack = currentTrack, outgoingTrack.plexRatingKey != nil {
+            PlexRadioHistory.shared.recordTrackPlayed(outgoingTrack)
+        }
+
         // Update state
         audioFile = nextFile
         currentIndex = nextIndex
@@ -3243,30 +3258,35 @@ class AudioEngine {
         // Restore primary player to master volume (crossfade ended at masterVolume * 1.0)
         streamingPlayer?.volume = volume
         
+        // Record outgoing track to Plex Radio history (track finished via streaming crossfade)
+        if let outgoingTrack = currentTrack, outgoingTrack.plexRatingKey != nil {
+            PlexRadioHistory.shared.recordTrackPlayed(outgoingTrack)
+        }
+
         // Update state
         currentIndex = nextIndex
         currentTrack = playlist[nextIndex]
         _currentTime = 0
         lastReportedTime = 0
         playbackStartDate = Date()
-        
+
         // Reset crossfade state
         isCrossfading = false
         crossfadeTargetIndex = -1
-        
+
         // Notify delegate
         delegate?.audioEngineDidChangeTrack(currentTrack)
-        
+
         // Report to Plex/Subsonic
         if let track = currentTrack {
             PlexPlaybackReporter.shared.trackDidStart(track, at: 0)
-            
+
             if let subsonicId = track.subsonicId,
                let serverId = track.subsonicServerId,
                let trackDuration = track.duration {
                 SubsonicPlaybackReporter.shared.trackStarted(trackId: subsonicId, serverId: serverId, duration: trackDuration)
             }
-            
+
             // Report track start to Jellyfin
             if let jellyfinId = track.jellyfinId,
                let serverId = track.jellyfinServerId,

--- a/Sources/NullPlayer/Audio/AudioEngine.swift
+++ b/Sources/NullPlayer/Audio/AudioEngine.swift
@@ -296,8 +296,28 @@ class AudioEngine {
     /// Flag to coalesce main queue PCM dispatches
     private var pendingPcmUpdate = false
     
+    // MARK: - Spectrum Consumer Tracking
+
+    /// Spectrum consumers — FFT is skipped entirely when this set is empty
+    private var spectrumConsumers = Set<String>()
+
+    /// Cached value of modernUIEnabled to avoid 60x/sec UserDefaults reads
+    private var isModernUIEnabled: Bool = UserDefaults.standard.bool(forKey: "modernUIEnabled")
+
+    func addSpectrumConsumer(_ id: String) {
+        spectrumConsumers.insert(id)
+        streamingPlayer?.spectrumNeeded = !spectrumConsumers.isEmpty
+    }
+
+    func removeSpectrumConsumer(_ id: String) {
+        spectrumConsumers.remove(id)
+        streamingPlayer?.spectrumNeeded = !spectrumConsumers.isEmpty
+    }
+
+    var spectrumNeeded: Bool { !spectrumConsumers.isEmpty }
+
     // MARK: - Pre-allocated FFT Buffers (Memory Optimization)
-    
+
     /// Pre-allocated buffers to avoid per-callback allocations
     private var fftSamples = [Float](repeating: 0, count: 2048)
     private var fftWindow = [Float](repeating: 0, count: 2048)
@@ -407,6 +427,14 @@ class AudioEngine {
             name: NSNotification.Name("SpectrumSettingsChanged"),
             object: nil
         )
+
+        // Keep cached isModernUIEnabled in sync when user toggles UI mode
+        NotificationCenter.default.addObserver(
+            self,
+            selector: #selector(handleModernUIChanged),
+            name: UserDefaults.didChangeNotification,
+            object: nil
+        )
         
         setupAudioEngine()
         setupEqualizer()
@@ -431,7 +459,11 @@ class AudioEngine {
             spectrumNormalizationMode = mode
         }
     }
-    
+
+    @objc private func handleModernUIChanged() {
+        isModernUIEnabled = UserDefaults.standard.bool(forKey: "modernUIEnabled")
+    }
+
     // MARK: - Setup
     
     private func setupAudioEngine() {
@@ -669,9 +701,10 @@ class AudioEngine {
     }
     
     private func processAudioBuffer(_ buffer: AVAudioPCMBuffer) {
+        guard spectrumNeeded else { return }
         guard let channelData = buffer.floatChannelData,
               let fftSetup = fftSetup else { return }
-        
+
         let frameCount = Int(buffer.frameLength)
         guard frameCount >= fftSize else { return }
         
@@ -694,7 +727,7 @@ class AudioEngine {
         }
         
         // Feed BPM detector with raw mono samples (before windowing) — modern UI only
-        if UserDefaults.standard.bool(forKey: "modernUIEnabled") {
+        if isModernUIEnabled {
             fftSamples.withUnsafeBufferPointer { ptr in
                 if let base = ptr.baseAddress {
                     bpmDetector.process(samples: base, count: fftSize, sampleRate: buffer.format.sampleRate)
@@ -2612,6 +2645,8 @@ class AudioEngine {
         if streamingPlayer == nil {
             streamingPlayer = StreamingAudioPlayer()
             streamingPlayer?.delegate = self
+            streamingPlayer?.spectrumNeeded = spectrumNeeded
+            streamingPlayer?.isModernUIEnabled = isModernUIEnabled
         }
         
         // Sync EQ settings from main EQ to streaming player
@@ -3201,6 +3236,8 @@ class AudioEngine {
         
         // Set delegate on new primary player
         streamingPlayer?.delegate = self
+        streamingPlayer?.spectrumNeeded = spectrumNeeded
+        streamingPlayer?.isModernUIEnabled = isModernUIEnabled
         // crossfadeStreamingPlayer (old primary) already has nil delegate from above
         
         // Restore primary player to master volume (crossfade ended at masterVolume * 1.0)

--- a/Sources/NullPlayer/Audio/AudioEngine.swift
+++ b/Sources/NullPlayer/Audio/AudioEngine.swift
@@ -2247,6 +2247,9 @@ class AudioEngine {
         guard index >= 0 && index < playlist.count else { return }
         currentIndex = index
         currentTrack = playlist[index]
+        state = .stopped
+        _currentTime = 0
+        lastReportedTime = 0
         delegate?.audioEngineDidChangeTrack(currentTrack)
     }
 

--- a/Sources/NullPlayer/Audio/StreamingAudioPlayer.swift
+++ b/Sources/NullPlayer/Audio/StreamingAudioPlayer.swift
@@ -30,8 +30,13 @@ class StreamingAudioPlayer {
     
     /// Real-time BPM detector for tempo display
     let bpmDetector = BPMDetector()
-    
-    
+
+    /// Whether spectrum FFT should run — bridged from AudioEngine.spectrumNeeded
+    var spectrumNeeded: Bool = false
+
+    /// Cached value of modernUIEnabled to avoid 60x/sec UserDefaults reads
+    var isModernUIEnabled: Bool = UserDefaults.standard.bool(forKey: "modernUIEnabled")
+
     /// FFT setup for spectrum analysis
     private var fftSetup: vDSP_DFT_Setup?
     private let fftSize: Int = 2048
@@ -372,7 +377,8 @@ class StreamingAudioPlayer {
         // Skip FFT processing when paused or stopped to save CPU
         // The frame filter still receives buffers but we don't need to process them
         guard state == .playing else { return }
-        
+        guard spectrumNeeded else { return }
+
         guard let channelData = buffer.floatChannelData,
               let fftSetup = fftSetup else { return }
         
@@ -419,7 +425,7 @@ class StreamingAudioPlayer {
         }
         
         // Feed BPM detector with raw mono samples (before windowing) — modern UI only
-        if UserDefaults.standard.bool(forKey: "modernUIEnabled") {
+        if isModernUIEnabled {
             fftSamples.withUnsafeBufferPointer { ptr in
                 if let base = ptr.baseAddress {
                     bpmDetector.process(samples: base, count: fftSize, sampleRate: buffer.format.sampleRate)

--- a/Sources/NullPlayer/Casting/CastManager.swift
+++ b/Sources/NullPlayer/Casting/CastManager.swift
@@ -276,9 +276,12 @@ class CastManager {
     
     /// Discovery state
     private(set) var isDiscovering: Bool = false
-    
-    /// Discovery refresh timer
+
+    /// Discovery refresh timer (60s periodic device refresh while discovery is active)
     private var discoveryRefreshTimer: Timer?
+
+    /// Idle timeout timer — stops discovery 5 minutes after last cast menu open (if not casting)
+    private var discoveryIdleTimer: Timer?
     
     /// Generation counter for track casting - incremented on each castNewTrack call
     /// Used to detect and discard stale operations when user rapidly changes tracks
@@ -319,14 +322,6 @@ class CastManager {
     private let maxConsecutiveFailures = 3
     
     private init() {
-        // Start discovery automatically
-        startDiscovery()
-        
-        // Refresh discovery periodically (every 60 seconds)
-        discoveryRefreshTimer = Timer.scheduledTimer(withTimeInterval: 60, repeats: true) { [weak self] _ in
-            self?.refreshDevices()
-        }
-        
         // Subscribe to Chromecast status updates for position syncing
         NotificationCenter.default.addObserver(
             self,
@@ -352,6 +347,7 @@ class CastManager {
     
     deinit {
         discoveryRefreshTimer?.invalidate()
+        discoveryIdleTimer?.invalidate()
         sonosPollingTimer?.invalidate()
         topologyRefreshTimer?.invalidate()
         NotificationCenter.default.removeObserver(self)
@@ -418,24 +414,51 @@ class CastManager {
     
     // MARK: - Discovery
     
-    /// Start discovering cast devices on the network
+    /// Start discovering cast devices on the network (lazy — called on demand when cast menu opens)
     func startDiscovery() {
-        guard !isDiscovering else { return }
-        
+        guard !isDiscovering else {
+            // Already discovering — reset idle timeout so discovery stays alive
+            resetDiscoveryIdleTimer()
+            return
+        }
+
         NSLog("CastManager: Starting device discovery...")
         isDiscovering = true
-        
+
         chromecastManager.startDiscovery()
         upnpManager.startDiscovery()
+
+        // Start periodic refresh if not already running
+        if discoveryRefreshTimer == nil {
+            discoveryRefreshTimer = Timer.scheduledTimer(withTimeInterval: 60, repeats: true) { [weak self] _ in
+                self?.refreshDevices()
+            }
+        }
+
+        // Schedule idle timeout — stop discovery after 5 minutes if not casting
+        resetDiscoveryIdleTimer()
     }
-    
+
     /// Stop discovering devices
     func stopDiscovery() {
-        NSLog("CastManager: Stopping device discovery")
+        guard isDiscovering, !isCasting else { return }
+        NSLog("CastManager: Stopping device discovery (idle)")
         isDiscovering = false
-        
+
         chromecastManager.stopDiscovery()
         upnpManager.stopDiscovery()
+
+        discoveryRefreshTimer?.invalidate()
+        discoveryRefreshTimer = nil
+        discoveryIdleTimer?.invalidate()
+        discoveryIdleTimer = nil
+    }
+
+    private func resetDiscoveryIdleTimer() {
+        discoveryIdleTimer?.invalidate()
+        discoveryIdleTimer = Timer.scheduledTimer(withTimeInterval: 300, repeats: false) { [weak self] _ in
+            self?.stopDiscovery()
+        }
     }
     
     /// Refresh device list (restart discovery)

--- a/Sources/NullPlayer/Casting/LocalMediaServer.swift
+++ b/Sources/NullPlayer/Casting/LocalMediaServer.swift
@@ -110,7 +110,28 @@ class LocalMediaServer {
             }
             return await self.handleStreamHeadRequest(request)
         }
-        
+
+        // Plex Radio History web page
+        await server.appendRoute("GET /radio-history") { _ in
+            let html = PlexRadioHistory.shared.generateHistoryHTML()
+            return HTTPResponse(
+                statusCode: .ok,
+                headers: [.contentType: "text/html; charset=utf-8"],
+                body: Data(html.utf8)
+            )
+        }
+
+        // API to delete a single history entry
+        await server.appendRoute("POST /radio-history/delete/*") { request in
+            let path = request.path
+            guard let idString = path.split(separator: "/").last,
+                  let id = Int64(idString) else {
+                return HTTPResponse(statusCode: .badRequest)
+            }
+            PlexRadioHistory.shared.removeEntry(id: id)
+            return HTTPResponse(statusCode: .ok)
+        }
+
         // Start server in background task
         serverTask = Task {
             do {

--- a/Sources/NullPlayer/Data/Models/Track.swift
+++ b/Sources/NullPlayer/Data/Models/Track.swift
@@ -21,6 +21,9 @@ struct Track: Identifiable, Equatable {
     
     /// Plex rating key for play tracking (nil for local files)
     let plexRatingKey: String?
+
+    /// Plex server ID to identify which server the track belongs to
+    let plexServerId: String?
     
     /// Subsonic song ID for scrobbling (nil for non-Subsonic tracks)
     let subsonicId: String?
@@ -169,6 +172,7 @@ struct Track: Identifiable, Equatable {
         self.sampleRate = extractedSampleRate
         self.channels = extractedChannels
         self.plexRatingKey = nil  // Local files don't have Plex rating keys
+        self.plexServerId = nil
         self.subsonicId = nil     // Local files don't have Subsonic IDs
         self.subsonicServerId = nil
         self.jellyfinId = nil     // Local files don't have Jellyfin IDs
@@ -194,6 +198,7 @@ struct Track: Identifiable, Equatable {
          sampleRate: Int? = nil,
          channels: Int? = nil,
          plexRatingKey: String? = nil,
+         plexServerId: String? = nil,
          subsonicId: String? = nil,
          subsonicServerId: String? = nil,
          jellyfinId: String? = nil,
@@ -214,6 +219,7 @@ struct Track: Identifiable, Equatable {
         self.sampleRate = sampleRate
         self.channels = channels
         self.plexRatingKey = plexRatingKey
+        self.plexServerId = plexServerId
         self.subsonicId = subsonicId
         self.subsonicServerId = subsonicServerId
         self.jellyfinId = jellyfinId

--- a/Sources/NullPlayer/ModernSkin/ModernSkinAnimation.swift
+++ b/Sources/NullPlayer/ModernSkin/ModernSkinAnimation.swift
@@ -224,7 +224,23 @@ class ModernSkinAnimation {
     private func updateColorCycleAnimation(_ anim: ActiveAnimation, duration: CGFloat) {
         // Value cycles 0 to 1 over duration
         anim.value = anim.time.truncatingRemainder(dividingBy: duration) / duration
-        
+
         onAnimationUpdate?(anim.elementId, anim.value)
+    }
+
+    // MARK: - Occlusion Handling
+
+    private var pausedForOcclusion = false
+
+    func pauseForOcclusion() {
+        guard isRunning else { return }
+        pausedForOcclusion = true
+        stopDisplayLink()
+    }
+
+    func resumeFromOcclusion() {
+        guard pausedForOcclusion else { return }
+        pausedForOcclusion = false
+        startDisplayLink()
     }
 }

--- a/Sources/NullPlayer/Plex/PlexManager.swift
+++ b/Sources/NullPlayer/Plex/PlexManager.swift
@@ -801,11 +801,12 @@ class PlexManager {
             sampleRate: sampleRate,
             channels: channels,
             plexRatingKey: plexTrack.id,  // Store rating key for play tracking
+            plexServerId: currentServer?.id,
             artworkThumb: plexTrack.thumb,
             genre: plexTrack.genre
         )
     }
-    
+
     /// Convert multiple Plex tracks to AudioEngine-compatible Tracks
     func convertToTracks(_ plexTracks: [PlexTrack]) -> [Track] {
         plexTracks.compactMap { convertToTrack($0) }
@@ -828,11 +829,12 @@ class PlexManager {
             sampleRate: movie.media.first?.audioSampleRate,
             channels: movie.media.first?.audioChannels,
             plexRatingKey: movie.id,
+            plexServerId: currentServer?.id,
             artworkThumb: movie.thumb,
             mediaType: .video
         )
     }
-    
+
     /// Convert a Plex episode to an AudioEngine-compatible Track (video type)
     func convertToTrack(_ episode: PlexEpisode) -> Track? {
         guard let streamURL = streamURL(for: episode) else {
@@ -854,11 +856,12 @@ class PlexManager {
             sampleRate: episode.media.first?.audioSampleRate,
             channels: episode.media.first?.audioChannels,
             plexRatingKey: episode.id,
+            plexServerId: currentServer?.id,
             artworkThumb: episode.thumb,
             mediaType: .video
         )
     }
-    
+
     /// Convert multiple Plex movies to AudioEngine-compatible Tracks
     func convertToTracks(_ movies: [PlexMovie]) -> [Track] {
         movies.compactMap { convertToTrack($0) }

--- a/Sources/NullPlayer/Plex/PlexManager.swift
+++ b/Sources/NullPlayer/Plex/PlexManager.swift
@@ -891,7 +891,7 @@ class PlexManager {
             
             let tracks = convertToTracks(plexTracks)
             NSLog("PlexManager: Track radio created with %d tracks", tracks.count)
-            return tracks
+            return PlexRadioHistory.shared.filterOutHistoryTracks(tracks)
         } catch {
             NSLog("PlexManager: Failed to create track radio: %@", error.localizedDescription)
             return []
@@ -918,7 +918,7 @@ class PlexManager {
             
             let tracks = convertToTracks(plexTracks)
             NSLog("PlexManager: Artist radio created with %d tracks", tracks.count)
-            return tracks
+            return PlexRadioHistory.shared.filterOutHistoryTracks(tracks)
         } catch {
             NSLog("PlexManager: Failed to create artist radio: %@", error.localizedDescription)
             return []
@@ -945,7 +945,7 @@ class PlexManager {
             
             let tracks = convertToTracks(plexTracks)
             NSLog("PlexManager: Album radio created with %d tracks", tracks.count)
-            return tracks
+            return PlexRadioHistory.shared.filterOutHistoryTracks(tracks)
         } catch {
             NSLog("PlexManager: Failed to create album radio: %@", error.localizedDescription)
             return []
@@ -1056,7 +1056,13 @@ class PlexManager {
         
         return result
     }
-    
+
+    /// Apply history filtering + artist variety filtering to radio tracks
+    private func applyRadioFilters(_ tracks: [Track], limit: Int, maxPerArtist: Int = RadioConfig.maxTracksPerArtist) -> [Track] {
+        let historyFiltered = PlexRadioHistory.shared.filterOutHistoryTracks(tracks)
+        return filterForArtistVariety(historyFiltered, limit: limit, maxPerArtist: maxPerArtist)
+    }
+
     /// Get a seed track for sonic radio: currently playing Plex track, or random from library
     private func getSonicSeedTrackID() async -> String? {
         // Check if currently playing track is a Plex track
@@ -1109,7 +1115,7 @@ class PlexManager {
             let fetchLimit = limit * RadioConfig.overFetchMultiplier
             let plexTracks = try await client.createLibraryRadio(libraryID: library.id, limit: fetchLimit)
             let allTracks = convertToTracks(plexTracks)
-            let tracks = filterForArtistVariety(allTracks, limit: limit)
+            let tracks = applyRadioFilters(allTracks, limit: limit)
             NSLog("PlexManager: Library radio created with %d tracks", tracks.count)
             return tracks
         } catch {
@@ -1135,7 +1141,7 @@ class PlexManager {
             let plexTracks = try await client.createLibraryRadioSonic(trackID: seedTrackID, libraryID: library.id, limit: fetchLimit)
             let allTracks = convertToTracks(plexTracks)
             // Sonic: limit to 1 track per artist for maximum variety
-            let tracks = filterForArtistVariety(allTracks, limit: limit, maxPerArtist: 1)
+            let tracks = applyRadioFilters(allTracks, limit: limit, maxPerArtist: 1)
             NSLog("PlexManager: Library radio (sonic) created with %d tracks", tracks.count)
             return tracks
         } catch {
@@ -1157,7 +1163,7 @@ class PlexManager {
             let fetchLimit = limit * RadioConfig.overFetchMultiplier
             let plexTracks = try await client.createGenreRadio(genre: genre, libraryID: library.id, limit: fetchLimit)
             let allTracks = convertToTracks(plexTracks)
-            let tracks = filterForArtistVariety(allTracks, limit: limit)
+            let tracks = applyRadioFilters(allTracks, limit: limit)
             NSLog("PlexManager: Genre radio (%@) created with %d tracks", genre, tracks.count)
             return tracks
         } catch {
@@ -1183,7 +1189,7 @@ class PlexManager {
             let plexTracks = try await client.createGenreRadioSonic(genre: genre, trackID: seedTrackID, libraryID: library.id, limit: fetchLimit)
             let allTracks = convertToTracks(plexTracks)
             // Sonic: limit to 1 track per artist for maximum variety
-            let tracks = filterForArtistVariety(allTracks, limit: limit, maxPerArtist: 1)
+            let tracks = applyRadioFilters(allTracks, limit: limit, maxPerArtist: 1)
             NSLog("PlexManager: Genre radio (sonic) (%@) created with %d tracks", genre, tracks.count)
             return tracks
         } catch {
@@ -1205,7 +1211,7 @@ class PlexManager {
             let fetchLimit = limit * RadioConfig.overFetchMultiplier
             let plexTracks = try await client.createDecadeRadio(startYear: startYear, endYear: endYear, libraryID: library.id, limit: fetchLimit)
             let allTracks = convertToTracks(plexTracks)
-            let tracks = filterForArtistVariety(allTracks, limit: limit)
+            let tracks = applyRadioFilters(allTracks, limit: limit)
             NSLog("PlexManager: Decade radio (%d-%d) created with %d tracks", startYear, endYear, tracks.count)
             return tracks
         } catch {
@@ -1231,7 +1237,7 @@ class PlexManager {
             let plexTracks = try await client.createDecadeRadioSonic(startYear: startYear, endYear: endYear, trackID: seedTrackID, libraryID: library.id, limit: fetchLimit)
             let allTracks = convertToTracks(plexTracks)
             // Sonic: limit to 1 track per artist for maximum variety
-            let tracks = filterForArtistVariety(allTracks, limit: limit, maxPerArtist: 1)
+            let tracks = applyRadioFilters(allTracks, limit: limit, maxPerArtist: 1)
             NSLog("PlexManager: Decade radio (sonic) (%d-%d) created with %d tracks", startYear, endYear, tracks.count)
             return tracks
         } catch {
@@ -1253,7 +1259,7 @@ class PlexManager {
             let fetchLimit = limit * RadioConfig.overFetchMultiplier
             let plexTracks = try await client.createHitsRadio(libraryID: library.id, limit: fetchLimit)
             let allTracks = convertToTracks(plexTracks)
-            let tracks = filterForArtistVariety(allTracks, limit: limit)
+            let tracks = applyRadioFilters(allTracks, limit: limit)
             NSLog("PlexManager: Hits radio created with %d tracks", tracks.count)
             return tracks
         } catch {
@@ -1279,7 +1285,7 @@ class PlexManager {
             let plexTracks = try await client.createHitsRadioSonic(trackID: seedTrackID, libraryID: library.id, limit: fetchLimit)
             let allTracks = convertToTracks(plexTracks)
             // Sonic: limit to 1 track per artist for maximum variety
-            let tracks = filterForArtistVariety(allTracks, limit: limit, maxPerArtist: 1)
+            let tracks = applyRadioFilters(allTracks, limit: limit, maxPerArtist: 1)
             NSLog("PlexManager: Hits radio (sonic) created with %d tracks", tracks.count)
             return tracks
         } catch {
@@ -1301,7 +1307,7 @@ class PlexManager {
             let fetchLimit = limit * RadioConfig.overFetchMultiplier
             let plexTracks = try await client.createDeepCutsRadio(libraryID: library.id, limit: fetchLimit)
             let allTracks = convertToTracks(plexTracks)
-            let tracks = filterForArtistVariety(allTracks, limit: limit)
+            let tracks = applyRadioFilters(allTracks, limit: limit)
             NSLog("PlexManager: Deep cuts radio created with %d tracks", tracks.count)
             return tracks
         } catch {
@@ -1327,7 +1333,7 @@ class PlexManager {
             let plexTracks = try await client.createDeepCutsRadioSonic(trackID: seedTrackID, libraryID: library.id, limit: fetchLimit)
             let allTracks = convertToTracks(plexTracks)
             // Sonic: limit to 1 track per artist for maximum variety
-            let tracks = filterForArtistVariety(allTracks, limit: limit, maxPerArtist: 1)
+            let tracks = applyRadioFilters(allTracks, limit: limit, maxPerArtist: 1)
             NSLog("PlexManager: Deep cuts radio (sonic) created with %d tracks", tracks.count)
             return tracks
         } catch {
@@ -1353,7 +1359,7 @@ class PlexManager {
             let fetchLimit = limit * RadioConfig.overFetchMultiplier
             let plexTracks = try await client.createRatingRadio(minRating: minRating, libraryID: library.id, limit: fetchLimit)
             let allTracks = convertToTracks(plexTracks)
-            let tracks = filterForArtistVariety(allTracks, limit: limit)
+            let tracks = applyRadioFilters(allTracks, limit: limit)
             NSLog("PlexManager: Rating radio (%.1f+ stars) created with %d tracks", minRating / 2, tracks.count)
             return tracks
         } catch {
@@ -1383,7 +1389,7 @@ class PlexManager {
             let plexTracks = try await client.createRatingRadioSonic(minRating: minRating, trackID: seedTrackID, libraryID: library.id, limit: fetchLimit)
             let allTracks = convertToTracks(plexTracks)
             // Sonic: limit to 1 track per artist for maximum variety
-            let tracks = filterForArtistVariety(allTracks, limit: limit, maxPerArtist: 1)
+            let tracks = applyRadioFilters(allTracks, limit: limit, maxPerArtist: 1)
             NSLog("PlexManager: Rating radio (sonic, %.1f+ stars) created with %d tracks", minRating / 2, tracks.count)
             return tracks
         } catch {

--- a/Sources/NullPlayer/Plex/PlexRadioHistory.swift
+++ b/Sources/NullPlayer/Plex/PlexRadioHistory.swift
@@ -1,0 +1,357 @@
+import Foundation
+import SQLite
+
+// MARK: - Retention Interval Enum
+
+enum PlexRadioHistoryInterval: String, CaseIterable {
+    case off = "off"
+    case twoWeeks = "2weeks"
+    case oneMonth = "1month"
+    case threeMonths = "3months"
+    case sixMonths = "6months"
+
+    var displayName: String {
+        switch self {
+        case .off: return "Off"
+        case .twoWeeks: return "2 Weeks"
+        case .oneMonth: return "1 Month"
+        case .threeMonths: return "3 Months"
+        case .sixMonths: return "6 Months"
+        }
+    }
+
+    var timeInterval: TimeInterval? {
+        switch self {
+        case .off: return nil
+        case .twoWeeks: return 14 * 24 * 3600
+        case .oneMonth: return 30 * 24 * 3600
+        case .threeMonths: return 90 * 24 * 3600
+        case .sixMonths: return 180 * 24 * 3600
+        }
+    }
+}
+
+// MARK: - History Entry Struct
+
+struct PlexRadioHistoryEntry {
+    let id: Int64
+    let plexRatingKey: String
+    let title: String
+    let artist: String?
+    let album: String?
+    let plexServerId: String?
+    let playedAt: Date
+}
+
+// MARK: - PlexRadioHistory
+
+class PlexRadioHistory {
+    static let shared = PlexRadioHistory()
+
+    private var db: Connection?
+
+    // Table
+    private let table = Table("plex_radio_history")
+
+    // Columns
+    private let colId = Expression<Int64>("id")
+    private let colRatingKey = Expression<String>("plex_rating_key")
+    private let colTitle = Expression<String>("title")
+    private let colArtist = Expression<String?>("artist")
+    private let colAlbum = Expression<String?>("album")
+    private let colServerId = Expression<String>("plex_server_id")
+    private let colPlayedAt = Expression<Double>("played_at")
+    private let colNormalizedKey = Expression<String>("normalized_key")
+
+    private init() {
+        setupDatabase()
+    }
+
+    // MARK: - Setup
+
+    private func setupDatabase() {
+        guard let appSupport = FileManager.default.urls(for: .applicationSupportDirectory, in: .userDomainMask).first else {
+            NSLog("PlexRadioHistory: Cannot locate Application Support directory")
+            return
+        }
+        let dir = appSupport.appendingPathComponent("NullPlayer")
+        try? FileManager.default.createDirectory(at: dir, withIntermediateDirectories: true)
+        let dbPath = dir.appendingPathComponent("plex_radio_history.db").path
+
+        do {
+            let connection = try Connection(dbPath)
+            db = connection
+            try createTableIfNeeded(connection)
+            NSLog("PlexRadioHistory: Database ready at %@", dbPath)
+        } catch {
+            NSLog("PlexRadioHistory: Failed to open database: %@", error.localizedDescription)
+        }
+    }
+
+    private func createTableIfNeeded(_ connection: Connection) throws {
+        try connection.run(table.create(ifNotExists: true) { t in
+            t.column(colId, primaryKey: .autoincrement)
+            t.column(colRatingKey)
+            t.column(colTitle)
+            t.column(colArtist)
+            t.column(colAlbum)
+            t.column(colServerId)
+            t.column(colPlayedAt)
+            t.column(colNormalizedKey)
+            t.unique(colRatingKey, colServerId)
+        })
+        try connection.run(
+            "CREATE INDEX IF NOT EXISTS idx_history_played_at ON plex_radio_history (played_at)"
+        )
+        try connection.run(
+            "CREATE INDEX IF NOT EXISTS idx_history_normalized_key ON plex_radio_history (normalized_key)"
+        )
+    }
+
+    // MARK: - Retention Interval
+
+    var retentionInterval: PlexRadioHistoryInterval {
+        get {
+            let raw = UserDefaults.standard.string(forKey: "plexRadioHistoryInterval") ?? PlexRadioHistoryInterval.oneMonth.rawValue
+            return PlexRadioHistoryInterval(rawValue: raw) ?? .oneMonth
+        }
+        set {
+            UserDefaults.standard.set(newValue.rawValue, forKey: "plexRadioHistoryInterval")
+        }
+    }
+
+    var isEnabled: Bool { retentionInterval != .off }
+
+    // MARK: - Normalized Key
+
+    static func normalizedKey(title: String?, artist: String?) -> String {
+        let t = (title ?? "").trimmingCharacters(in: .whitespacesAndNewlines).lowercased()
+        let a = (artist ?? "").trimmingCharacters(in: .whitespacesAndNewlines).lowercased()
+        return "\(a)|\(t)"
+    }
+
+    // MARK: - Record
+
+    func recordTrackPlayed(_ track: Track) {
+        guard let db = db,
+              let ratingKey = track.plexRatingKey else { return }
+
+        let serverId = PlexManager.shared.currentServer?.id ?? ""
+        let nKey = PlexRadioHistory.normalizedKey(title: track.title, artist: track.artist)
+        let playedAt = Date().timeIntervalSince1970
+
+        do {
+            try db.run(table.insert(
+                or: .replace,
+                colRatingKey <- ratingKey,
+                colTitle <- (track.title ?? ""),
+                colArtist <- track.artist,
+                colAlbum <- track.album,
+                colServerId <- serverId,
+                colPlayedAt <- playedAt,
+                colNormalizedKey <- nKey
+            ))
+        } catch {
+            NSLog("PlexRadioHistory: Failed to record track: %@", error.localizedDescription)
+        }
+    }
+
+    // MARK: - Filter
+
+    func filterOutHistoryTracks(_ tracks: [Track]) -> [Track] {
+        guard isEnabled, let db = db else { return tracks }
+
+        let cutoff: Double
+        if let interval = retentionInterval.timeInterval {
+            cutoff = Date().timeIntervalSince1970 - interval
+        } else {
+            return tracks
+        }
+
+        do {
+            let rows = try db.prepare(
+                table.select(colRatingKey, colNormalizedKey)
+                     .filter(colPlayedAt >= cutoff)
+            )
+            var ratingKeys = Set<String>()
+            var normalizedKeys = Set<String>()
+            for row in rows {
+                ratingKeys.insert(row[colRatingKey])
+                normalizedKeys.insert(row[colNormalizedKey])
+            }
+
+            return tracks.filter { track in
+                if let rk = track.plexRatingKey, ratingKeys.contains(rk) {
+                    NSLog("PlexRadioHistory: Filtered out '%@' by '%@' (rating key match: %@)",
+                          track.title ?? "", track.artist ?? "", rk)
+                    return false
+                }
+                let nk = PlexRadioHistory.normalizedKey(title: track.title, artist: track.artist)
+                if normalizedKeys.contains(nk) {
+                    NSLog("PlexRadioHistory: Filtered out '%@' by '%@' (normalized key match: %@)",
+                          track.title ?? "", track.artist ?? "", nk)
+                    return false
+                }
+                return true
+            }
+        } catch {
+            NSLog("PlexRadioHistory: Failed to query history for filtering: %@", error.localizedDescription)
+            return tracks
+        }
+    }
+
+    // MARK: - Fetch
+
+    func fetchHistory() -> [PlexRadioHistoryEntry] {
+        guard let db = db else { return [] }
+        do {
+            let rows = try db.prepare(table.order(colPlayedAt.desc))
+            return rows.map { row in
+                PlexRadioHistoryEntry(
+                    id: row[colId],
+                    plexRatingKey: row[colRatingKey],
+                    title: row[colTitle],
+                    artist: row[colArtist],
+                    album: row[colAlbum],
+                    plexServerId: row[colServerId],
+                    playedAt: Date(timeIntervalSince1970: row[colPlayedAt])
+                )
+            }
+        } catch {
+            NSLog("PlexRadioHistory: Failed to fetch history: %@", error.localizedDescription)
+            return []
+        }
+    }
+
+    // MARK: - Remove
+
+    func removeEntry(id: Int64) {
+        guard let db = db else { return }
+        do {
+            try db.run(table.filter(colId == id).delete())
+        } catch {
+            NSLog("PlexRadioHistory: Failed to remove entry %lld: %@", id, error.localizedDescription)
+        }
+    }
+
+    func clearHistory() {
+        guard let db = db else { return }
+        do {
+            try db.run(table.delete())
+        } catch {
+            NSLog("PlexRadioHistory: Failed to clear history: %@", error.localizedDescription)
+        }
+    }
+
+    // MARK: - Web
+
+    var historyPageURL: URL? { URL(string: "http://127.0.0.1:8765/radio-history") }
+
+    func generateHistoryHTML() -> String {
+        let entries = fetchHistory()
+        let interval = retentionInterval
+        let count = entries.count
+
+        let df = DateFormatter()
+        df.dateStyle = .medium
+        df.timeStyle = .short
+
+        var rows = ""
+        for entry in entries {
+            let title = htmlEscape(entry.title)
+            let artist = htmlEscape(entry.artist ?? "—")
+            let album = htmlEscape(entry.album ?? "—")
+            let trackId = htmlEscape(entry.plexRatingKey)
+            let date = htmlEscape(df.string(from: entry.playedAt))
+            let id = entry.id
+            rows += """
+            <tr id="row-\(id)">
+              <td>\(title)</td>
+              <td>\(artist)</td>
+              <td>\(album)</td>
+              <td class="track-id">\(trackId)</td>
+              <td>\(date)</td>
+              <td><button class="remove-btn" onclick="removeEntry(\(id))">Remove</button></td>
+            </tr>
+            """
+        }
+
+        return """
+        <!DOCTYPE html>
+        <html lang="en">
+        <head>
+        <meta charset="utf-8">
+        <meta name="viewport" content="width=device-width, initial-scale=1">
+        <title>Plex Radio History</title>
+        <style>
+          * { box-sizing: border-box; margin: 0; padding: 0; }
+          body { background: #1a1a2e; color: #e0e0e0; font-family: -apple-system, BlinkMacSystemFont, "Segoe UI", sans-serif; padding: 24px; }
+          h1 { color: #00d4ff; font-size: 1.5rem; margin-bottom: 8px; }
+          .meta { color: #888; font-size: 0.85rem; margin-bottom: 20px; }
+          table { width: 100%; border-collapse: collapse; }
+          th { background: #12122b; color: #00d4ff; text-align: left; padding: 10px 12px; cursor: pointer; user-select: none; white-space: nowrap; }
+          th:hover { background: #1c1c3a; }
+          th::after { content: " ⇅"; opacity: 0.4; font-size: 0.75em; }
+          th.asc::after { content: " ↑"; opacity: 1; }
+          th.desc::after { content: " ↓"; opacity: 1; }
+          td { padding: 9px 12px; border-bottom: 1px solid #2a2a4a; vertical-align: middle; }
+          tr:hover td { background: #1e1e38; }
+          .remove-btn { background: #3a0a0a; border: 1px solid #7a1a1a; color: #ff7070; padding: 4px 10px; border-radius: 4px; cursor: pointer; font-size: 0.8rem; }
+          .remove-btn:hover { background: #5a1a1a; }
+          .empty { text-align: center; color: #555; padding: 40px; font-size: 1.1rem; }
+          .track-id { color: #888; font-size: 0.82rem; font-variant-numeric: tabular-nums; }
+        </style>
+        </head>
+        <body>
+        <h1>Plex Radio History</h1>
+        <div class="meta">Retention: \(interval.displayName) &nbsp;·&nbsp; \(count) track\(count == 1 ? "" : "s")</div>
+        <table id="historyTable">
+          <thead>
+            <tr>
+              <th onclick="sortTable(0)">Track</th>
+              <th onclick="sortTable(1)">Artist</th>
+              <th onclick="sortTable(2)">Album</th>
+              <th onclick="sortTable(3)">Track ID</th>
+              <th onclick="sortTable(4)">Played</th>
+              <th></th>
+            </tr>
+          </thead>
+          <tbody>
+          \(rows.isEmpty ? "<tr><td colspan=\"6\" class=\"empty\">No history yet.</td></tr>" : rows)
+          </tbody>
+        </table>
+        <script>
+        var sortCol = -1, sortAsc = true;
+        function sortTable(col) {
+          var table = document.getElementById('historyTable');
+          var ths = table.querySelectorAll('th');
+          var tbody = table.querySelector('tbody');
+          var rows = Array.from(tbody.querySelectorAll('tr'));
+          if (sortCol === col) { sortAsc = !sortAsc; } else { sortCol = col; sortAsc = true; }
+          ths.forEach(function(th, i) { th.classList.remove('asc','desc'); });
+          ths[col].classList.add(sortAsc ? 'asc' : 'desc');
+          rows.sort(function(a, b) {
+            var aText = a.cells[col] ? a.cells[col].innerText : '';
+            var bText = b.cells[col] ? b.cells[col].innerText : '';
+            return sortAsc ? aText.localeCompare(bText) : bText.localeCompare(aText);
+          });
+          rows.forEach(function(r) { tbody.appendChild(r); });
+        }
+        function removeEntry(id) {
+          fetch('/radio-history/delete/' + id, {method: 'POST'})
+            .then(function(r) { if (r.ok) { var row = document.getElementById('row-' + id); if (row) row.remove(); } });
+        }
+        </script>
+        </body>
+        </html>
+        """
+    }
+
+    private func htmlEscape(_ string: String) -> String {
+        string
+            .replacingOccurrences(of: "&", with: "&amp;")
+            .replacingOccurrences(of: "<", with: "&lt;")
+            .replacingOccurrences(of: ">", with: "&gt;")
+            .replacingOccurrences(of: "\"", with: "&quot;")
+    }
+}

--- a/Sources/NullPlayer/Plex/PlexRadioHistory.swift
+++ b/Sources/NullPlayer/Plex/PlexRadioHistory.swift
@@ -136,7 +136,7 @@ class PlexRadioHistory {
         guard let db = db,
               let ratingKey = track.plexRatingKey else { return }
 
-        let serverId = PlexManager.shared.currentServer?.id ?? ""
+        let serverId = track.plexServerId ?? PlexManager.shared.currentServer?.id ?? ""
         let nKey = PlexRadioHistory.normalizedKey(title: track.title, artist: track.artist)
         let playedAt = Date().timeIntervalSince1970
 

--- a/Sources/NullPlayer/Resources/Info.plist
+++ b/Sources/NullPlayer/Resources/Info.plist
@@ -15,7 +15,7 @@
     <key>CFBundleIconFile</key>
     <string>AppIcon</string>
     <key>CFBundleShortVersionString</key>
-    <string>0.16.1</string>
+    <string>0.16.2</string>
     <key>CFBundleVersion</key>
     <string>1</string>
     <key>LSMinimumSystemVersion</key>

--- a/Sources/NullPlayer/TopLevelFolderPickerDelegate.swift
+++ b/Sources/NullPlayer/TopLevelFolderPickerDelegate.swift
@@ -1,0 +1,23 @@
+import AppKit
+
+/// NSOpenPanel delegate that prevents the user from drilling into subdirectories.
+/// Only folders at the level the panel is currently showing can be selected.
+final class TopLevelFolderPickerDelegate: NSObject, NSOpenSavePanelDelegate {
+    private var lastDirectory: URL?
+
+    func panelCurrentDirectoryDidChange(_ sender: Any) {
+        guard let panel = sender as? NSOpenPanel,
+              let current = panel.directoryURL else { return }
+
+        if let last = lastDirectory {
+            let lastPath = last.standardized.path
+            let currentPath = current.standardized.path
+            // Navigated INTO a subdirectory of the last location → bounce back
+            if currentPath.hasPrefix(lastPath + "/") {
+                panel.directoryURL = last
+                return
+            }
+        }
+        lastDirectory = current
+    }
+}

--- a/Sources/NullPlayer/Visualization/VisualizationGLView.swift
+++ b/Sources/NullPlayer/Visualization/VisualizationGLView.swift
@@ -32,6 +32,9 @@ class VisualizationGLView: NSOpenGLView {
     /// Whether rendering is currently active
     private(set) var isRendering = false
 
+    /// Track if rendering was stopped due to window occlusion (vs. idle)
+    private var stoppedDueToOcclusion: Bool = false
+
     /// Current visualization engine
     private var engine: VisualizationEngine?
 
@@ -553,13 +556,51 @@ class VisualizationGLView: NSOpenGLView {
     
     override func viewDidMoveToWindow() {
         super.viewDidMoveToWindow()
-        
-        if window != nil {
-            // Start rendering when added to a window
+
+        if let window = window {
+            NotificationCenter.default.addObserver(self, selector: #selector(windowDidChangeOcclusionState(_:)),
+                name: NSWindow.didChangeOcclusionStateNotification, object: window)
+            NotificationCenter.default.addObserver(self, selector: #selector(windowDidMiniaturize(_:)),
+                name: NSWindow.didMiniaturizeNotification, object: window)
+            NotificationCenter.default.addObserver(self, selector: #selector(windowDidDeminiaturize(_:)),
+                name: NSWindow.didDeminiaturizeNotification, object: window)
             startRendering()
         } else {
-            // Stop rendering when removed from window
+            NotificationCenter.default.removeObserver(self, name: NSWindow.didChangeOcclusionStateNotification, object: nil)
+            NotificationCenter.default.removeObserver(self, name: NSWindow.didMiniaturizeNotification, object: nil)
+            NotificationCenter.default.removeObserver(self, name: NSWindow.didDeminiaturizeNotification, object: nil)
             stopRendering()
+        }
+    }
+
+    @objc private func windowDidChangeOcclusionState(_ notification: Notification) {
+        guard notification.object as? NSWindow == window else { return }
+        if window?.occlusionState.contains(.visible) == true {
+            if stoppedDueToOcclusion {
+                stoppedDueToOcclusion = false
+                startRendering()
+            }
+        } else {
+            if isRendering {
+                stoppedDueToOcclusion = true
+                stopRendering()
+            }
+        }
+    }
+
+    @objc private func windowDidMiniaturize(_ notification: Notification) {
+        guard notification.object as? NSWindow == window else { return }
+        if isRendering {
+            stoppedDueToOcclusion = true
+            stopRendering()
+        }
+    }
+
+    @objc private func windowDidDeminiaturize(_ notification: Notification) {
+        guard notification.object as? NSWindow == window else { return }
+        if stoppedDueToOcclusion {
+            stoppedDueToOcclusion = false
+            startRendering()
         }
     }
     

--- a/Sources/NullPlayer/Windows/ModernLibraryBrowser/ModernLibraryBrowserView.swift
+++ b/Sources/NullPlayer/Windows/ModernLibraryBrowser/ModernLibraryBrowserView.swift
@@ -1313,8 +1313,9 @@ class ModernLibraryBrowserView: NSView {
         
         guard visibleStart < visibleEnd else {
             context.restoreGState()
+            let alphabetHeight = listAreaHeight - (headerColumns != nil ? columnHeaderHeight : 0)
             let alphabetRect = NSRect(x: bounds.width - Layout.borderWidth - Layout.scrollbarWidth - alphabetWidth,
-                                     y: listAreaY, width: alphabetWidth, height: listAreaHeight)
+                                     y: listAreaY, width: alphabetWidth, height: alphabetHeight)
             drawAlphabetIndex(in: context, rect: alphabetRect, skin: skin)
             return
         }
@@ -1386,9 +1387,10 @@ class ModernLibraryBrowserView: NSView {
         
         context.restoreGState()
         
-        // Draw alphabet index
+        // Draw alphabet index (exclude column header zone so # appears below column headers)
+        let alphabetHeight = listAreaHeight - (headerColumns != nil ? columnHeaderHeight : 0)
         let alphabetRect = NSRect(x: bounds.width - Layout.borderWidth - Layout.scrollbarWidth - alphabetWidth,
-                                 y: listAreaY, width: alphabetWidth, height: listAreaHeight)
+                                 y: listAreaY, width: alphabetWidth, height: alphabetHeight)
         drawAlphabetIndex(in: context, rect: alphabetRect, skin: skin)
     }
     
@@ -2309,9 +2311,11 @@ class ModernLibraryBrowserView: NSView {
         var contentTopY = bounds.height - Layout.titleBarHeight - Layout.serverBarHeight - Layout.tabBarHeight
         if browseMode == .search { contentTopY -= Layout.searchBarHeight }
         let listHeight = contentTopY - Layout.statusBarHeight
+        let hasColumns = displayItems.contains { columnsForItem($0) != nil }
+        let effectiveHeight = listHeight - (hasColumns ? columnHeaderHeight : 0)
         let alphabetX = bounds.width - Layout.borderWidth - Layout.scrollbarWidth - Layout.alphabetWidth
         return point.x >= alphabetX && point.x < alphabetX + Layout.alphabetWidth &&
-               point.y >= Layout.statusBarHeight && point.y < Layout.statusBarHeight + listHeight
+               point.y >= Layout.statusBarHeight && point.y < Layout.statusBarHeight + effectiveHeight
     }
     
     private func hitTestContentArea(at point: NSPoint) -> Bool {
@@ -2557,6 +2561,8 @@ class ModernLibraryBrowserView: NSView {
         let point = convert(event.locationInWindow, from: nil)
         if hitTestColumnResize(at: point) != nil {
             NSCursor.resizeLeftRight.set()
+        } else if hitTestAlphabetIndex(at: point) {
+            NSCursor.pointingHand.set()
         } else {
             NSCursor.arrow.set()
         }
@@ -2666,12 +2672,14 @@ class ModernLibraryBrowserView: NSView {
         var contentTopY = bounds.height - Layout.titleBarHeight - Layout.serverBarHeight - Layout.tabBarHeight
         if browseMode == .search { contentTopY -= Layout.searchBarHeight }
         let listHeight = contentTopY - Layout.statusBarHeight
-        
+        let hasColumns = displayItems.contains { columnsForItem($0) != nil }
+        let effectiveHeight = listHeight - (hasColumns ? columnHeaderHeight : 0)
+
         let itemTop = CGFloat(index) * itemHeight
         let itemBottom = itemTop + itemHeight
-        
+
         if itemTop < scrollOffset { scrollOffset = itemTop }
-        else if itemBottom > scrollOffset + listHeight { scrollOffset = itemBottom - listHeight }
+        else if itemBottom > scrollOffset + effectiveHeight { scrollOffset = itemBottom - effectiveHeight }
     }
 
     private func applyPendingArtistScroll() {
@@ -2893,13 +2901,16 @@ class ModernLibraryBrowserView: NSView {
         var contentTopY = bounds.height - Layout.titleBarHeight - Layout.serverBarHeight - Layout.tabBarHeight
         if browseMode == .search { contentTopY -= Layout.searchBarHeight }
         let listHeight = contentTopY - Layout.statusBarHeight
-        
+        let hasColumns = displayItems.contains { columnsForItem($0) != nil }
+        let effectiveHeight = listHeight - (hasColumns ? columnHeaderHeight : 0)
+        let alphabetTopY = Layout.statusBarHeight + effectiveHeight
+
         // Bottom-left: # at top, Z at bottom
-        let relativeFromTop = contentTopY - point.y
+        let relativeFromTop = alphabetTopY - point.y
         let letterCount = CGFloat(alphabetLetters.count)
-        let letterHeight = listHeight / letterCount
+        let letterHeight = effectiveHeight / letterCount
         let letterIndex = Int(relativeFromTop / letterHeight)
-        
+
         guard letterIndex >= 0 && letterIndex < alphabetLetters.count else { return }
         scrollToLetter(alphabetLetters[letterIndex])
     }
@@ -2927,7 +2938,9 @@ class ModernLibraryBrowserView: NSView {
                 var contentTopY = bounds.height - Layout.titleBarHeight - Layout.serverBarHeight - Layout.tabBarHeight
                 if browseMode == .search { contentTopY -= Layout.searchBarHeight }
                 let listHeight = contentTopY - Layout.statusBarHeight
-                let maxScroll = max(0, CGFloat(displayItems.count) * itemHeight - listHeight)
+                let hasColumns = displayItems.contains { columnsForItem($0) != nil }
+                let effectiveHeight = listHeight - (hasColumns ? columnHeaderHeight : 0)
+                let maxScroll = max(0, CGFloat(displayItems.count) * itemHeight - effectiveHeight)
                 scrollOffset = min(maxScroll, CGFloat(index) * itemHeight)
                 selectedIndices = [index]; needsDisplay = true; return
             }

--- a/Sources/NullPlayer/Windows/ModernLibraryBrowser/ModernLibraryBrowserView.swift
+++ b/Sources/NullPlayer/Windows/ModernLibraryBrowser/ModernLibraryBrowserView.swift
@@ -5231,6 +5231,7 @@ class ModernLibraryBrowserView: NSView {
     
     private func startVisualizerTimer() {
         visualizerTime = 0; silenceFrames = 0; visualizerTimer?.invalidate()
+        WindowManager.shared.audioEngine.addSpectrumConsumer("modernLibraryBrowserVisualizer")
         let timer = Timer(timeInterval: 1.0/30.0, repeats: true) { [weak self] _ in self?.handleVisualizerTimerTick() }
         RunLoop.main.add(timer, forMode: .common); visualizerTimer = timer
         if visMode == .cycle { startCycleTimer() }
@@ -5265,6 +5266,7 @@ class ModernLibraryBrowserView: NSView {
     private func stopVisualizerTimer() {
         visualizerTimer?.invalidate(); visualizerTimer = nil
         cycleTimer?.invalidate(); cycleTimer = nil
+        WindowManager.shared.audioEngine.removeSpectrumConsumer("modernLibraryBrowserVisualizer")
     }
     
     private func startCycleTimer() {

--- a/Sources/NullPlayer/Windows/ModernLibraryBrowser/ModernLibraryBrowserView.swift
+++ b/Sources/NullPlayer/Windows/ModernLibraryBrowser/ModernLibraryBrowserView.swift
@@ -3783,10 +3783,20 @@ class ModernLibraryBrowserView: NSView {
         }
     }
     @objc private func addWatchFolder() {
-        let panel = NSOpenPanel(); panel.canChooseDirectories = true; panel.canChooseFiles = false
+        let panel = NSOpenPanel()
+        panel.canChooseDirectories = true
+        panel.canChooseFiles = false
+        panel.allowsMultipleSelection = false
         panel.message = "Select a folder to add to your library"
-        if panel.runModal() == .OK, let url = panel.url {
-            MediaLibrary.shared.addWatchFolder(url); MediaLibrary.shared.scanFolder(url)
+
+        let folderDelegate = TopLevelFolderPickerDelegate()
+        panel.delegate = folderDelegate
+
+        withExtendedLifetime(folderDelegate) {
+            if panel.runModal() == .OK, let url = panel.url {
+                MediaLibrary.shared.addWatchFolder(url)
+                MediaLibrary.shared.scanFolder(url)
+            }
         }
     }
     @objc private func showAddRadioStationDialog() {

--- a/Sources/NullPlayer/Windows/ModernMainWindow/ModernMainWindowView.swift
+++ b/Sources/NullPlayer/Windows/ModernMainWindow/ModernMainWindowView.swift
@@ -192,6 +192,23 @@ class ModernMainWindowView: NSView {
         super.viewDidMoveToWindow()
         layer?.isOpaque = false
         updateCornerMask()
+        // Register/unregister occlusion observer when window association changes
+        NotificationCenter.default.removeObserver(self, name: NSWindow.didChangeOcclusionStateNotification, object: nil)
+        if let window = window {
+            NotificationCenter.default.addObserver(self, selector: #selector(windowDidChangeOcclusionState(_:)),
+                name: NSWindow.didChangeOcclusionStateNotification, object: window)
+        }
+    }
+
+    @objc private func windowDidChangeOcclusionState(_ notification: Notification) {
+        guard notification.object as? NSWindow == window else { return }
+        if window?.occlusionState.contains(.visible) == true {
+            ModernSkinEngine.shared.animationEngine.resumeFromOcclusion()
+            marqueeLayer.resumeScrolling()
+        } else {
+            ModernSkinEngine.shared.animationEngine.pauseForOcclusion()
+            marqueeLayer.pauseScrolling()
+        }
     }
 
     private func updateCornerMask() {

--- a/Sources/NullPlayer/Windows/ModernProjectM/ModernProjectMView.swift
+++ b/Sources/NullPlayer/Windows/ModernProjectM/ModernProjectMView.swift
@@ -115,7 +115,8 @@ class ModernProjectMView: NSView {
         ) { [weak self] notification in
             self?.handleSpectrumUpdate(notification)
         }
-        
+        WindowManager.shared.audioEngine.addSpectrumConsumer("modernProjectMView")
+
         // Subscribe to playback state changes (for idle/active visualization mode)
         playbackStateObserver = NotificationCenter.default.addObserver(
             forName: .audioPlaybackStateChanged,
@@ -153,6 +154,7 @@ class ModernProjectMView: NSView {
             NotificationCenter.default.removeObserver(observer)
         }
         NotificationCenter.default.removeObserver(self)
+        WindowManager.shared.audioEngine.removeSpectrumConsumer("modernProjectMView")
         stopPresetCycleTimer()
         visualizationGLView?.stopRendering()
     }

--- a/Sources/NullPlayer/Windows/ModernSpectrum/ModernSpectrumView.swift
+++ b/Sources/NullPlayer/Windows/ModernSpectrum/ModernSpectrumView.swift
@@ -81,7 +81,8 @@ class ModernSpectrumView: NSView {
         ) { [weak self] notification in
             self?.handleSpectrumUpdate(notification)
         }
-        
+        WindowManager.shared.audioEngine.addSpectrumConsumer("modernSpectrumView")
+
         // Observe skin changes
         NotificationCenter.default.addObserver(self, selector: #selector(modernSkinDidChange),
                                                 name: ModernSkinEngine.skinDidChangeNotification, object: nil)
@@ -106,6 +107,7 @@ class ModernSpectrumView: NSView {
             NotificationCenter.default.removeObserver(observer)
         }
         NotificationCenter.default.removeObserver(self)
+        WindowManager.shared.audioEngine.removeSpectrumConsumer("modernSpectrumView")
     }
     
     // MARK: - Setup

--- a/Sources/NullPlayer/Windows/PlexBrowser/PlexBrowserView.swift
+++ b/Sources/NullPlayer/Windows/PlexBrowser/PlexBrowserView.swift
@@ -7333,14 +7333,19 @@ class PlexBrowserView: NSView {
         panel.canChooseFiles = false
         panel.allowsMultipleSelection = false
         panel.message = "Select a folder to add to your library"
-        
-        if panel.runModal() == .OK, let url = panel.url {
-            MediaLibrary.shared.addWatchFolder(url)
-            MediaLibrary.shared.scanFolder(url)
-            
-            // Switch to local source if not already
-            if case .plex = currentSource {
-                currentSource = .local
+
+        let folderDelegate = TopLevelFolderPickerDelegate()
+        panel.delegate = folderDelegate
+
+        withExtendedLifetime(folderDelegate) {
+            if panel.runModal() == .OK, let url = panel.url {
+                MediaLibrary.shared.addWatchFolder(url)
+                MediaLibrary.shared.scanFolder(url)
+
+                // Switch to local source if not already
+                if case .plex = currentSource {
+                    currentSource = .local
+                }
             }
         }
     }

--- a/Sources/NullPlayer/Windows/PlexBrowser/PlexBrowserView.swift
+++ b/Sources/NullPlayer/Windows/PlexBrowser/PlexBrowserView.swift
@@ -1059,6 +1059,7 @@ class PlexBrowserView: NSView {
         visualizerTime = 0
         silenceFrames = 0
         visualizerTimer?.invalidate()
+        WindowManager.shared.audioEngine.addSpectrumConsumer("plexBrowserVisualizer")
         // 30fps for smooth effects (reduced from 60fps for CPU efficiency - still looks great)
         // Use .common run loop mode so timer continues during context menu display
         let timer = Timer(timeInterval: 1.0/30.0, repeats: true) { [weak self] _ in
@@ -1174,6 +1175,7 @@ class PlexBrowserView: NSView {
         visualizerTimer = nil
         cycleTimer?.invalidate()
         cycleTimer = nil
+        WindowManager.shared.audioEngine.removeSpectrumConsumer("plexBrowserVisualizer")
     }
     
     /// Start cycle mode timer

--- a/Sources/NullPlayer/Windows/ProjectM/ProjectMView.swift
+++ b/Sources/NullPlayer/Windows/ProjectM/ProjectMView.swift
@@ -102,6 +102,7 @@ class ProjectMView: NSView {
         ) { [weak self] notification in
             self?.handleSpectrumUpdate(notification)
         }
+        WindowManager.shared.audioEngine.addSpectrumConsumer("projectMView")
 
         // Subscribe to playback state changes (for idle/active visualization mode)
         playbackStateObserver = NotificationCenter.default.addObserver(
@@ -162,6 +163,7 @@ class ProjectMView: NSView {
         if let observer = playbackStateObserver {
             NotificationCenter.default.removeObserver(observer)
         }
+        WindowManager.shared.audioEngine.removeSpectrumConsumer("projectMView")
         stopPresetCycleTimer()
         visualizationGLView?.stopRendering()
     }

--- a/Sources/NullPlayer/Windows/Spectrum/SpectrumView.swift
+++ b/Sources/NullPlayer/Windows/Spectrum/SpectrumView.swift
@@ -65,6 +65,7 @@ class SpectrumView: NSView {
         ) { [weak self] notification in
             self?.handleSpectrumUpdate(notification)
         }
+        WindowManager.shared.audioEngine.addSpectrumConsumer("spectrumView")
     }
     
     private func setupSpectrumAnalyzerView() {
@@ -109,6 +110,7 @@ class SpectrumView: NSView {
         if let observer = spectrumObserver {
             NotificationCenter.default.removeObserver(observer)
         }
+        WindowManager.shared.audioEngine.removeSpectrumConsumer("spectrumView")
     }
     
     // MARK: - Accessibility

--- a/TASKS.md
+++ b/TASKS.md
@@ -1,12 +1,19 @@
-# Move Yellow Text Colors to skin.json
+# Track History for Plex Radio
 
-## Findings
-- Default yellow `#d9d900` is hardcoded in `ModernSkinConfig.swift:70` as `defaultTimeColor`
-- Applies to: `timeColor`, `marqueeColor`, `dataColor`, `eqMid`
-- NeonWave `skin.json` has no explicit entries for these — falls back to Swift hardcoded default
-- Glow effects confirmed: time digits, marquee, EQ values all use `setShadow` blur glow (no code changes needed)
+## Phase 1 — Core Database Layer
+- [x] Create `Sources/NullPlayer/Plex/PlexRadioHistory.swift` with SQLite schema, CRUD, HTML generation
 
-## Tasks
+## Phase 2 — Recording Hooks
+- [x] Modify `AudioEngine.swift` — add `recordTrackPlayed` calls in `trackDidFinish`, `completeCrossfade`, `completeStreamingCrossfade`
 
-- [x] Add explicit `timeColor`, `marqueeColor`, `dataColor`, and `eqMid` to `NeonWave/skin.json`
-- [x] Check EmeraldForge, IndustrialSignal, ArcticMinimal skin.json files and add missing color entries where needed
+## Phase 3 — Radio Filtering
+- [x] Modify `PlexManager.swift` — add `applyRadioFilters` helper, replace all `filterForArtistVariety` calls (12 calls + 3 early-return paths)
+
+## Phase 4 — Menu UI
+- [x] Modify `ContextMenuBuilder.swift` — add Plex Radio History submenu + `MenuActions` methods
+
+## Phase 5 — Web Server Routes
+- [x] Modify `LocalMediaServer.swift` — add `GET /radio-history` and `POST /radio-history/delete/*` routes
+
+## Phase 6 — Build Verification
+- [x] Run `swift build -c release` and confirm clean compile

--- a/Tests/NullPlayerTests/NullPlayerTests.swift
+++ b/Tests/NullPlayerTests/NullPlayerTests.swift
@@ -2665,7 +2665,7 @@ final class NullPlayerTests: XCTestCase {
     }
     
     func testJellyfinMusicLibraryCreation() {
-        let library = JellyfinMusicLibrary(id: "lib-1", name: "Music")
+        let library = JellyfinMusicLibrary(id: "lib-1", name: "Music", collectionType: "music")
         XCTAssertEqual(library.id, "lib-1")
         XCTAssertEqual(library.name, "Music")
     }

--- a/scripts/bootstrap.sh
+++ b/scripts/bootstrap.sh
@@ -13,15 +13,15 @@ RELEASE_TAG="deps-v2"
 
 # Framework definitions
 VLCKIT_FILE="VLCKit-macos.tar.gz"
-VLCKIT_SHA256="c59bbb9cfeb4b12b621a88eb6c5b3b5e65185026560be7bdf6b2e339a6855c70"
+VLCKIT_SHA256="b36a06d9169fba85101dae8264be24ab3d92c0f2976001524d60f79e8fdece93"
 VLCKIT_TARGET="Frameworks/VLCKit.framework"
 
 PROJECTM_FILE="libprojectM-4.1.6-macos.tar.gz"
-PROJECTM_SHA256="0bcdf100b837ec89101912dcd5bb21da4eae15902f136afa67140a0728aad0ee"
+PROJECTM_SHA256="c85addde0f7afb6132c619a6f081ef14fc806e1afbf3767ec04c9470e9c9a7b1"
 PROJECTM_TARGET="Frameworks/libprojectM-4.dylib"
 
 AUBIO_FILE="libaubio-macos.tar.gz"
-AUBIO_SHA256="37fa52b7c57bed321ce8148bdea19d129ee3ac876e644703cae838cc478a4045"
+AUBIO_SHA256="0fbcdfcea459e6f8278bfef134e4eddafad4a7764389bc6147428e59b25933d0"
 AUBIO_TARGET="Frameworks/libaubio.5.dylib"
 
 # Colors for output

--- a/skills/plex-integration/SKILL.md
+++ b/skills/plex-integration/SKILL.md
@@ -252,6 +252,60 @@ http://192.168.0.102:32400/library/parts/653835/1723508508/file.flac?X-Plex-Toke
 - **Sonic analysis enabled** on the music library
 - Tracks must be analyzed (check for `musicAnalysisVersion` attribute)
 
+## Plex Radio History
+
+Tracks played during Plex Radio sessions are recorded in a local SQLite database so they can be filtered out of future radio queues (preventing repeats) and viewed by the user.
+
+### Storage
+
+- **Database**: `~/Library/Application Support/NullPlayer/plex_radio_history.db`
+- **Table**: `plex_radio_history`
+- **Unique constraint**: `(plex_rating_key, plex_server_id)` — one record per track per server, upserted on each play (updates `played_at`)
+- **Indexes**: `played_at` (for retention cutoff queries), `normalized_key` (for fallback matching)
+
+### Deduplication / Normalized Key
+
+Radio library rescans can change a track's `ratingKey`. To still suppress known tracks, a `normalized_key` (`"artist|title"` lowercased, trimmed) is stored alongside the rating key. `filterOutHistoryTracks` does a two-pass filter:
+1. Match by `plexRatingKey` (exact)
+2. Match by `normalized_key` (fuzzy fallback)
+
+### Retention
+
+Configurable via `PlexRadioHistoryInterval` enum:
+
+| Value | Duration |
+|-------|----------|
+| `off` | Disabled (no filtering) |
+| `twoWeeks` | 2 weeks |
+| `oneMonth` | 1 month (default) |
+| `threeMonths` | 3 months |
+| `sixMonths` | 6 months |
+
+Stored in `UserDefaults` key `plexRadioHistoryInterval`. When `off`, `filterOutHistoryTracks` returns the input unchanged.
+
+### Recording
+
+`PlexRadioHistory.shared.recordTrackPlayed(_:)` is called from `AudioEngine` when a Plex track finishes — at natural track completion and during gapless crossfade. Uses `track.plexServerId` (set by `PlexManager.convertToTrack`), falling back to `PlexManager.shared.currentServer?.id`.
+
+### Filtering
+
+`PlexRadioHistory.shared.filterOutHistoryTracks(_:)` is called inside `PlexManager` when building radio queues — after fetching tracks from the Plex API, before returning them to the engine.
+
+### Context Menu (User UI)
+
+Under the Plex Radio context menu:
+- **History Retention** submenu — sets `retentionInterval` (Off / 2 Weeks / 1 Month / 3 Months / 6 Months)
+- **View Radio History** — opens `http://127.0.0.1:8765/radio-history` in the default browser
+- **Clear Radio History** — confirmation dialog, then `clearHistory()`
+
+### Web History Page
+
+Served by `LocalMediaServer` on port 8765. Routes:
+- `GET /radio-history` — returns HTML from `generateHistoryHTML()`
+- `POST /radio-history/delete/:id` — removes a single entry by `rowid`
+
+The page is a dark-themed sortable table (Track / Artist / Album / Track ID / Played). Each row has a **Remove** button that calls the delete endpoint via `fetch()`. No page reload needed.
+
 ## Key Source Files
 
 | File | Purpose |
@@ -261,6 +315,7 @@ http://192.168.0.102:32400/library/parts/653835/1723508508/file.flac?X-Plex-Toke
 | `Plex/PlexModels.swift` | Domain models (Server, Artist, Album, Track, etc.) |
 | `Plex/PlexPlaybackReporter.swift` | Audio scrobbling and "now playing" reporting |
 | `Plex/PlexVideoPlaybackReporter.swift` | Video scrobbling with periodic timeline updates |
+| `Plex/PlexRadioHistory.swift` | SQLite-backed play history for Plex Radio — recording, filtering, web UI |
 
 ## References
 


### PR DESCRIPTION
## Summary

- **Fix: Plex streaming tracks never load after restart** — placeholder tracks created during state restoration stayed dead because `PlexManager.shared.serverClient` was always `nil` at check time (Plex connects asynchronously). Now polls via `waitForPlexClient()` every 250ms for up to 15s. Also adds `selectTrackForDisplay()` to show placeholder metadata without loading the URL, and skips `about:blank` in `loadTrack` to prevent spurious errors during the async fetch.
- **5 CPU optimizations** — FFT guard (skip spectrum analysis when visualization is hidden), occlusion stops (pause Metal renders when window is occluded/miniaturized), lazy cast discovery (defer UPnP scans until first use)
- **Plex Radio History** — record, filter, and view recently played Plex Radio tracks with a dedicated history panel

## Test plan

- [ ] Add a Plex streaming track, make it current, quit the app — relaunch and confirm track loads (not stuck as placeholder)
- [ ] Confirm `AppStateManager: Waiting for Plex connection` log appears on relaunch
- [ ] Confirm seek position is restored after placeholder replacement
- [ ] Verify CPU usage is reduced when spectrum/ProjectM windows are hidden or occluded
- [ ] Verify Plex Radio History records played tracks and filters work

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Plex Radio History: retention settings, web history view, context-menu controls, and in-app history management.
  * Local media library support and Navidrome/Subsonic integration with scrobbling.
  * Modern V2 UI skin system (many v2 skins included) and full classic Winamp V1 skin support.
  * Persistent mini-spectrum/visualizer support across windows.

* **Bug Fixes & Improvements**
  * Improved playback restoration for streams/placeholders and radio filtering to avoid recent tracks.
  * Visualizers pause/resume on window occlusion; device discovery auto-stops after idle.

* **Documentation**
  * Reworded Features header and clarified UI skin and Sonos notes.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->