### PR TITLE
window fixes

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -70,5 +70,3 @@ VLCKit-macos.tar.gz
 libprojectM-*.tar.gz
 libaubio-macos.tar.gz
 Frameworks/libprojectM-4.4.dylib
-# Local agent notes
-CHANGELOG.md

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,81 @@
+# Changelog
+
+## 0.17.0
+
+### Window System
+
+- **Hide Title Bars extended to all windows** — sub-windows (EQ, Playlist, Spectrum) now always hide their titlebars when docked. With Hide Title Bars enabled, all six windows hide titlebars unconditionally. Now defaults to on. The main window shrinks to fill the frame without a gap at the top.
+- **Per-corner window sharpness** — corners automatically sharpen when a window is aligned against a screen edge or adjacent docked window, so the UI looks clean against boundaries without hard corners everywhere else.
+- **XL mode** — the 2X double-size button is now XL at 1.5× scale, giving a more usable intermediate size. State buttons (shuffle, repeat, etc.) are reordered.
+- **Docking fixes** — resolved nine window behavior issues: over-eager snapping, window shift on undock, stack collapse gaps, HT startup sizing, and more.
+- **Menu bar parity** — key player actions are now available from the macOS menu bar with dynamically refreshed checkmarks/state (Windows, UI, Playback, Visuals, Libraries, Output).
+
+### Modern Glass Skins
+
+- **Skin-configurable window opacity** — `window.opacity` in skin.json sets background transparency per-window. Sub-windows can inherit or override independently.
+- **Per-area opacity controls** — skins can set opacity independently for each region (display panel, playlist area, EQ bands, etc.) without affecting the rest of the window.
+- **Text-only opacity** — a separate opacity knob for display text vs background glass, enabling frosted-glass aesthetics where the text reads clearly against a blurred background.
+- **Spectrum opacity override** — the spectrum visualization layer has its own opacity control, independent of window opacity, so glass skins can keep the spectrum vivid.
+- **Glass seam/darkening stability** — improved seam clearing and glass compositing so docked stacks stay visually consistent during moves and resizes.
+- **New bundled skins** — NeonWave (default), SeaGlass, SmoothGlass, BloodGlass, and BananaParty are included.
+
+### Waveform
+
+- **Dockable waveform window** — a new Waveform window can be shown/hidden like other sub-windows and docks into the main stack.
+- **Skin-configurable appearance** — waveform supports transparent background styles in modern skins and integrates with modern UI controls.
+
+### Internet Radio
+
+- **Folder organization** — stations can be organized into an expandable folder tree, visible in both the modern and classic library browsers. Folders persist across sessions. Smart reassignment moves a station's history and ratings when it changes folders.
+- **Station ratings** — rate any internet radio station 1–10 directly in the library. Ratings are stored in a local SQLite database keyed by station URL and survive station edits.
+- **Station artwork** — album art now loads for internet radio stations in both the modern and classic library browsers.
+- **Station search** — search internet radio by metadata (name/genre/region/URL) with click-to-play results.
+- **Expanded built-in catalog** — full SomaFM channel list added as defaults and auto-merged for existing users. Regional stations, jazz stations, verified Boston and scanner feeds included.
+- **Grouped radio history** — playback histories from all sources (Plex, Subsonic, Jellyfin, Emby, local) are now consolidated under a single Radio History menu instead of scattered per-source.
+
+### vis_classic
+
+- **Exact mode** — vis_classic now runs as a faithful Winamp-replica visualizer with full FFT, bar, and color fidelity matching the original Nullsoft implementation.
+- **Scoped profiles** — the main window and spectrum window each maintain their own independent vis_classic profile and fit-to-width setting. Changing one doesn't affect the other.
+- **Skin visualization defaults** — skins can declare a default visualization mode and vis_classic profile in skin.json. The bundled classic skin defaults to the Purple Neon profile.
+- **Bundled profile pack** — a full set of classic vis_classic profiles are included by default for quick switching.
+- **Transparent background controls** — skins can default vis_classic transparency per-window and control its opacity independently for main vs spectrum windows.
+
+### New Visualizations
+
+- **Snow mode** — a new Metal spectrum shader that renders the frequency spectrum as falling snow particles.
+
+### Classic Library UI
+
+- **Local album and artist ratings** — albums and artists in your local library can now be rated directly in the classic browser. Ratings appear in both list view and art view.
+- **Art mode interactions** — single-click an item in art view to rate it; double-click to cycle through its available artwork.
+- **Date sorting parity** — the classic library browser now sorts by date and year using the same logic as the modern UI, consistently across all connected sources.
+- **Replace Queue in library menus** — the "Replace Queue" action was missing from classic library context menus; it is now present alongside Play and Add to Queue.
+- **Source radio parity** — source radio tabs in the classic browser now match the modern UI's behavior including F5 refresh support.
+- **Watch folder manager** — manage watched local-library folders (rescan, reveal in Finder, remove with counts) from a dedicated dialog.
+
+### Modern EQ
+
+- **Preset buttons rework** — the preset button row now stretches to fill the available width, buttons are always enabled regardless of whether the EQ is active, and double-clicking a band's label resets that band to 0 dB.
+
+### Other
+
+- **Natural numeric sorting** — library tracks, albums, and artists sort in natural order (Track 2 before Track 10) consistently across all sources.
+- **Modern skin bundles** — portable modern skins can be imported as `.nsz` (ZIP) bundles via UI → Modern → Load Skin....
+- **Skin import persistence** — imported skins persist and remain selectable in future sessions.
+- **Get More Skins** — a link to the skins directory is now in the Classic UI skin menu.
+- **Credential storage hardened** — server credentials are stored in the data-protection keychain with a reduced attack surface. Dev builds use UserDefaults to avoid repeated Keychain authorization prompts during development.
+- **Licensing/provenance** — added third-party license notices and waveform provenance documentation for distribution.
+
+### Bug Fixes
+
+- Fixed a streaming crossfade deadlock between the crossfade timer and `AVAudioEngine.stop()`
+- Fixed streaming playlist restore by refreshing service-backed track URLs when needed (Plex/Subsonic/Jellyfin/Emby)
+- Fixed audio engine state desync when handing off from cast back to local playback
+- Fixed radio-to-local playback handoff leaving the engine in a stopped state
+- Fixed library multi-remove hanging on large selections; added scoped local library clear actions
+- Fixed classic library browser rendering artifacts (server bar transparency and incorrect text colors)
+- Fixed volume slider not responding to arrow keys in the modern UI
+- Fixed waveform window click-through during async waveform loading
+- Reduced idle CPU and GPU usage across all spectrum visualization modes and during window dragging
+- Improved Jellyfin loading resilience for large libraries (smaller page sizes, duplicate-page guards, background album warming)

--- a/Sources/NullPlayer/Radio/RadioFolderModels.swift
+++ b/Sources/NullPlayer/Radio/RadioFolderModels.swift
@@ -14,9 +14,11 @@ enum RadioFolderKind: Hashable {
     case topRated
     case unrated
     case recentlyPlayed
+    case byChannel
     case byGenre
     case byRegion
     case userFoldersRoot
+    case channel(String)
     case genre(String)
     case region(String)
     case manual(UUID)
@@ -28,9 +30,11 @@ enum RadioFolderKind: Hashable {
         case .topRated: return "radio-folder-top-rated"
         case .unrated: return "radio-folder-unrated"
         case .recentlyPlayed: return "radio-folder-recent"
+        case .byChannel: return "radio-folder-by-channel"
         case .byGenre: return "radio-folder-by-genre"
         case .byRegion: return "radio-folder-by-region"
         case .userFoldersRoot: return "radio-folder-user-root"
+        case .channel(let name): return "radio-folder-channel-\(name.lowercased())"
         case .genre(let name): return "radio-folder-genre-\(name.lowercased())"
         case .region(let name): return "radio-folder-region-\(name.lowercased())"
         case .manual(let folderID): return "radio-folder-manual-\(folderID.uuidString.lowercased())"
@@ -39,9 +43,9 @@ enum RadioFolderKind: Hashable {
 
     var isStationContainer: Bool {
         switch self {
-        case .allStations, .favorites, .topRated, .unrated, .recentlyPlayed, .genre, .region, .manual:
+        case .allStations, .favorites, .topRated, .unrated, .recentlyPlayed, .channel, .genre, .region, .manual:
             return true
-        case .byGenre, .byRegion, .userFoldersRoot:
+        case .byChannel, .byGenre, .byRegion, .userFoldersRoot:
             return false
         }
     }

--- a/Sources/NullPlayer/Radio/RadioManager.swift
+++ b/Sources/NullPlayer/Radio/RadioManager.swift
@@ -129,6 +129,7 @@ class RadioManager {
     private let deletedDefaultsKey = "RadioDeletedDefaults"
     private let smartGenreOverridesKey = "RadioSmartGenreOverrides"
     private let smartRegionOverridesKey = "RadioSmartRegionOverrides"
+    private let defaultGenreMigrationVersionKey = "RadioDefaultGenreMigrationVersion"
     private static let defaultURLAliases: [String: String] = [
         "https://wgbh-live.streamguys1.com/wgbh": "https://wgbh-live.streamguys1.com/wgbh.mp3",
         "https://wgbh-live.streamguys1.com/wgbh.mp3": "https://wgbh-live.streamguys1.com/wgbh"
@@ -264,11 +265,17 @@ class RadioManager {
         guard let data = UserDefaults.standard.data(forKey: stationsKey),
               let decoded = try? JSONDecoder().decode([RadioStation].self, from: data) else {
             // Add some default stations for first-time users
+            UserDefaults.standard.set(Self.defaultGenreMigrationCurrentVersion, forKey: defaultGenreMigrationVersionKey)
             stations = Self.defaultStations
             return
         }
-        stations = decoded
+        var migrated = decoded
+        let changedByMigration = applyDefaultGenreMigrationIfNeeded(to: &migrated)
+        stations = migrated
         NSLog("RadioManager: Loaded %d saved stations", stations.count)
+        if changedByMigration > 0 {
+            NSLog("RadioManager: Migrated %d saved station genres to latest defaults", changedByMigration)
+        }
 
         // Ensure existing users receive newly added defaults while still honoring
         // deleted-default tracking.
@@ -280,6 +287,21 @@ class RadioManager {
         UserDefaults.standard.set(data, forKey: stationsKey)
     }
 
+    @discardableResult
+    private func applyDefaultGenreMigrationIfNeeded(to stations: inout [RadioStation]) -> Int {
+        let defaults = UserDefaults.standard
+        let appliedVersion = defaults.integer(forKey: defaultGenreMigrationVersionKey)
+        guard appliedVersion < Self.defaultGenreMigrationCurrentVersion else { return 0 }
+
+        let migration = Self.applyingDefaultGenreCorrections(to: stations)
+        if migration.changedCount > 0 {
+            stations = migration.stations
+        }
+
+        defaults.set(Self.defaultGenreMigrationCurrentVersion, forKey: defaultGenreMigrationVersionKey)
+        return migration.changedCount
+    }
+
     private func postStationsDidChange() {
         NotificationCenter.default.post(name: Self.stationsDidChangeNotification, object: self)
     }
@@ -289,6 +311,120 @@ class RadioManager {
         let url: String
         let genre: String?
         let iconURL: String?
+    }
+
+    private struct DefaultGenreCorrection {
+        let from: String
+        let to: String
+    }
+
+    static let defaultGenreMigrationCurrentVersion = 1
+
+    private static let defaultGenreCorrections: [String: DefaultGenreCorrection] = [
+        "https://ice5.somafm.com/bossa-128-mp3": DefaultGenreCorrection(from: "Classical", to: "Bossa Nova"),
+        "https://radio11.plathong.net/7138/;stream.mp3": DefaultGenreCorrection(from: "Thai", to: "News"),
+        "https://breakz-2012-high.rautemusik.fm/?ref=radiobrowser-top100-clubcharts": DefaultGenreCorrection(from: "Rap/Hip Hop", to: "Dance/EDM"),
+        "https://0n-indie.radionetz.de/0n-indie.mp3": DefaultGenreCorrection(from: "Rap/Hip Hop", to: "Alternative Rock"),
+        "https://www.radioking.com/play/alternative-radio-1": DefaultGenreCorrection(from: "Rap/Hip Hop", to: "Alternative Rock"),
+        "http://ice.stream101.com:9016/stream": DefaultGenreCorrection(from: "Rap/Hip Hop", to: "Country"),
+        "https://stream.zeno.fm/muzrp86994zuv": DefaultGenreCorrection(from: "Rap/Hip Hop", to: "Afrobeats"),
+        "https://workout-high.rautemusik.fm/?ref=radiobrowser": DefaultGenreCorrection(from: "Nature Sounds", to: "Workout"),
+        "http://bayerwaldradio.deg.net:8000/allesoberkrain": DefaultGenreCorrection(from: "Nature Sounds", to: "Polka/Folk"),
+        "http://fluxfm.streamabc.net/flx-70er-mp3-320-4383769?sABC=6202qr25%230%237osorqnn86p8nnp979o1124290qqo247%23fgernzf.syhksz.qr&amsparams=playerid:streams.fluxfm.de;skey:1644355109": DefaultGenreCorrection(from: "Nature Sounds", to: "Classic Rock"),
+        "https://fluxfm.streamabc.net/flx-80er-mp3-320-9596107?sABC=6202qrr6%230%23sorr1p583723p06268o324o2ps5n399q%23fgernzf.syhksz.qr&amsparams=playerid:streams.fluxfm.de;skey:1644355302": DefaultGenreCorrection(from: "Nature Sounds", to: "Classic Rock"),
+        "http://streams.radiobob.de/bob-90srock/mp3-192/mediaplayer": DefaultGenreCorrection(from: "Nature Sounds", to: "Classic Rock"),
+        "http://streams.radiobob.de/gothic/mp3-192/mediaplayer": DefaultGenreCorrection(from: "Nature Sounds", to: "Gothic Rock"),
+        "http://streams.radiobob.de/bob-metal/mp3-192/mediaplayer": DefaultGenreCorrection(from: "Nature Sounds", to: "Metal"),
+        "http://streams.radiobob.de/metalcore/mp3-192/mediaplayer": DefaultGenreCorrection(from: "Nature Sounds", to: "Metal"),
+        "http://streams.radiobob.de/metallica/mp3-192/mediaplayer/": DefaultGenreCorrection(from: "Nature Sounds", to: "Metal"),
+        "http://streams.radiobob.de/rockparty/mp3-192/mediaplayer/": DefaultGenreCorrection(from: "Nature Sounds", to: "Rock"),
+        "http://streams.radiobob.de/bob-wacken/mp3-192/mediaplayer": DefaultGenreCorrection(from: "Nature Sounds", to: "Metal"),
+        "http://lux.radio.tvstitch.com/kyiv/lux_adv_sd": DefaultGenreCorrection(from: "Nature Sounds", to: "Top 40"),
+        "http://streams.radio.co/s79fbbb432/listen": DefaultGenreCorrection(from: "Nature Sounds", to: "World"),
+        "https://streaming.radiostreamlive.com/miamibeachradio_devices": DefaultGenreCorrection(from: "Nature Sounds", to: "Dance"),
+        "http://streams.radiobob.de/bob-wacken/mp3-192/streams.radiobob.de/": DefaultGenreCorrection(from: "Nature Sounds", to: "Metal"),
+        "http://213.141.131.10:8004/forestpsytrance": DefaultGenreCorrection(from: "Nature Sounds", to: "Psytrance"),
+        "http://195.95.206.13:8000/RadioROKS": DefaultGenreCorrection(from: "Nature Sounds", to: "Rock"),
+        "http://online.radioroks.ua/RadioROKS_Ukr_HD": DefaultGenreCorrection(from: "Nature Sounds", to: "Rock"),
+        "http://www.segenswelle.de:8000/ukrainisch": DefaultGenreCorrection(from: "Nature Sounds", to: "World"),
+        "https://listen9.myradio24.com/6262": DefaultGenreCorrection(from: "Nature Sounds", to: "Easy Listening"),
+        "http://online.hitfm.ua/HitFM_Ukr": DefaultGenreCorrection(from: "Nature Sounds", to: "Top 40"),
+        "https://online-news.radioplayer.ua/RadioNews": DefaultGenreCorrection(from: "Nature Sounds", to: "News"),
+        "https://stream.antiradio.net/radio/8000/mp3": DefaultGenreCorrection(from: "College Indie", to: "Alternative Rock"),
+        "http://stream.laut.fm/deep-house-sounds": DefaultGenreCorrection(from: "College Indie", to: "Deep House"),
+        "https://stream.radiojar.com/cthtwxk5yvduv.mp3": DefaultGenreCorrection(from: "College Indie", to: "Easy Listening"),
+        "http://streams.fluxfm.de/live/mp3-320/audio/": DefaultGenreCorrection(from: "College Indie", to: "Alternative Rock"),
+        "https://orf-live.ors-shoutcast.at/fm4-q1a": DefaultGenreCorrection(from: "College Indie", to: "Alternative Rock"),
+        "http://stream.radio.co/s1cffd7347/listen": DefaultGenreCorrection(from: "College Indie", to: "Hip Hop"),
+        "http://kathy.torontocast.com:2690/stream": DefaultGenreCorrection(from: "College Indie", to: "Alternative Rock"),
+        "http://naxidigital-rock128.streaming.rs:8180/;stream.nsv": DefaultGenreCorrection(from: "College Indie", to: "Rock"),
+        "http://mr-stream.mediaconnect.hu/4737/mr2.aac": DefaultGenreCorrection(from: "College Indie", to: "Alternative Rock"),
+        "http://streams.radiobob.de/bob-alternative/mp3-192/streams.radiobob.de/": DefaultGenreCorrection(from: "College Indie", to: "Alternative Rock"),
+        "http://streams.radiobob.de/bob-bestofrock/mp3-192/streams.radiobob.de/": DefaultGenreCorrection(from: "College Indie", to: "Rock"),
+        "http://stream.zeno.fm/sri2de2qdlivv": DefaultGenreCorrection(from: "College Indie", to: "Top 40"),
+        "http://f121.rndfnk.com/ard/rbb/radioeins/live/mp3/128/stream.mp3?cid=01FC1WH12KJ93TCQPDSE2E5PZ9&sid=38HoeEhwMU9ZjQaArYLcNuLu9LN&token=VXH8C52tOJ6o_G5uLXexxjt84DXyHGfH0RABfQljedk&tvf=8PpblQ7uihhmMTIxLnJuZGZuay5jb20": DefaultGenreCorrection(from: "College Indie", to: "Public Radio"),
+        "http://novazz.ice.infomaniak.ch/novazz-128.mp3": DefaultGenreCorrection(from: "College Indie", to: "Jazz"),
+        "http://stream.radioparadise.com/mellow-320": DefaultGenreCorrection(from: "College Indie", to: "Eclectic"),
+        "http://stream.radioparadise.com/rock-320": DefaultGenreCorrection(from: "College Indie", to: "Rock"),
+        "https://stream.radioparadise.com/rock-flac": DefaultGenreCorrection(from: "College Indie", to: "Rock"),
+        "http://nashe1.hostingradio.ru/ultra-192.mp3": DefaultGenreCorrection(from: "College Indie", to: "Alternative Rock"),
+        "http://media-the.musicradio.com/RadioXUK": DefaultGenreCorrection(from: "College Indie", to: "Alternative Rock"),
+        "http://stream.rockantenne.de/alternative": DefaultGenreCorrection(from: "College Indie", to: "Alternative Rock"),
+        "https://ice5.somafm.com/folkfwd-128-aac": DefaultGenreCorrection(from: "College Indie", to: "Folk"),
+        "https://ice1.somafm.com/folkfwd-128-mp3": DefaultGenreCorrection(from: "College Indie", to: "Folk"),
+        "https://ice6.somafm.com/indiepop-128-aac": DefaultGenreCorrection(from: "College Indie", to: "Alternative/Pop"),
+        "https://ice2.somafm.com/poptron-128-mp3": DefaultGenreCorrection(from: "College Indie", to: "Pop"),
+        "http://live.slovakradio.sk:8000/FM_256.mp3": DefaultGenreCorrection(from: "College Indie", to: "Alternative Rock"),
+        "https://listen.radioking.com/radio/293701/stream/340084": DefaultGenreCorrection(from: "College Indie", to: "Alternative Rock"),
+        "http://stream.tilos.hu/tilos": DefaultGenreCorrection(from: "College Indie", to: "Eclectic"),
+        "https://listen-msmn.sharp-stream.com/nme1.mp3": DefaultGenreCorrection(from: "College Indie", to: "Alternative Rock"),
+        "http://stream.laut.fm/ultradarkradio": DefaultGenreCorrection(from: "College Indie", to: "Gothic Rock"),
+        "https://0n-gothic.radionetz.de/0n-gothic.mp3": DefaultGenreCorrection(from: "Punk/Surf/Hardcore", to: "Gothic Rock"),
+        "https://play-radio0.jump.bg:7049/live": DefaultGenreCorrection(from: "Punk/Surf/Hardcore", to: "Hard Rock"),
+        "http://51.255.235.165:5528/stream": DefaultGenreCorrection(from: "Punk/Surf/Hardcore", to: "Ska"),
+        "http://stream.laut.fm/darkzeroradio": DefaultGenreCorrection(from: "Punk/Surf/Hardcore", to: "Gothic Rock"),
+        "https://nl4.mystreaming.net/er/greenday/icecast.audio": DefaultGenreCorrection(from: "Punk/Surf/Hardcore", to: "Punk Rock"),
+        "https://nl4.mystreaming.net/er/ramones/icecast.audio": DefaultGenreCorrection(from: "Punk/Surf/Hardcore", to: "Punk Rock"),
+        "https://audio-edge-3mayu.fra.h.radiomast.io/73055724-1141-41e2-a69b-24a6ca96c8e7": DefaultGenreCorrection(from: "Punk/Surf/Hardcore", to: "Hard Dance"),
+        "https://www.happyhardcore.com/livestreams/p/u9/": DefaultGenreCorrection(from: "Punk/Surf/Hardcore", to: "Hard Dance"),
+        "http://stream.laut.fm/hardstyle-and-hardcore": DefaultGenreCorrection(from: "Punk/Surf/Hardcore", to: "Hard Dance"),
+        "https://kniteforce.out.airtime.pro/kniteforce_a": DefaultGenreCorrection(from: "Punk/Surf/Hardcore", to: "Hard Dance"),
+        "https://playerservices.streamtheworld.com/api/livestream-redirect/Q_DANCE.mp3": DefaultGenreCorrection(from: "Punk/Surf/Hardcore", to: "Hard Dance"),
+        "http://79.120.12.130:8004/cyberpunk": DefaultGenreCorrection(from: "Punk/Surf/Hardcore", to: "Synthwave"),
+        "https://radiorecord.hostingradio.ru/teo96.aacp": DefaultGenreCorrection(from: "Punk/Surf/Hardcore", to: "Hard Dance"),
+        "http://happyhardcore-high.rautemusik.fm/": DefaultGenreCorrection(from: "Punk/Surf/Hardcore", to: "Hard Dance"),
+        "https://ice4.somafm.com/metal-128-aac": DefaultGenreCorrection(from: "Punk/Surf/Hardcore", to: "Metal"),
+        "http://lw2.mp3.tb-group.fm/tb.mp3": DefaultGenreCorrection(from: "Punk/Surf/Hardcore", to: "Techno"),
+        "http://cast1.asurahosting.com:8621/med": DefaultGenreCorrection(from: "Punk/Surf/Hardcore", to: "Rock"),
+        "https://cast1.torontocast.com:4660/stream": DefaultGenreCorrection(from: "Extreme Music", to: "Metal"),
+        "https://bestofrockfm.stream.vip/metallica/mp3-256/bestofrock.fm/": DefaultGenreCorrection(from: "Extreme Music", to: "Metal"),
+        "http://usa17.fastcast4u.com:5508/stream": DefaultGenreCorrection(from: "Extreme Music", to: "Metalcore"),
+        "http://stream.laut.fm/core-mix": DefaultGenreCorrection(from: "Extreme Music", to: "Metalcore"),
+        "http://streams.radiobob.de/progrock/mp3-192/mediaplayer/": DefaultGenreCorrection(from: "Extreme Music", to: "Progressive Rock"),
+        "https://securestream.us/radio/8050/radio.mp3": DefaultGenreCorrection(from: "Extreme Music", to: "Rock"),
+        "https://streaming.galaxywebsolutions.com:9046/stream": DefaultGenreCorrection(from: "Extreme Music", to: "Doom Metal")
+    ]
+
+    static func correctedDefaultGenre(for stationURL: URL, currentGenre: String?) -> String? {
+        guard let correction = defaultGenreCorrections[stationURL.absoluteString] else { return nil }
+        let normalizedCurrent = (currentGenre ?? "").trimmingCharacters(in: .whitespacesAndNewlines)
+        let normalizedFrom = correction.from.trimmingCharacters(in: .whitespacesAndNewlines)
+        guard normalizedCurrent.compare(normalizedFrom, options: [.caseInsensitive, .diacriticInsensitive]) == .orderedSame else {
+            return nil
+        }
+        return correction.to
+    }
+
+    static func applyingDefaultGenreCorrections(to stations: [RadioStation]) -> (stations: [RadioStation], changedCount: Int) {
+        var changedCount = 0
+        let migrated = stations.map { station -> RadioStation in
+            guard let corrected = correctedDefaultGenre(for: station.url, currentGenre: station.genre) else { return station }
+            var copy = station
+            copy.genre = corrected
+            changedCount += 1
+            return copy
+        }
+        return (migrated, changedCount)
     }
 
     /// Default stations to show for new users

--- a/Sources/NullPlayer/Radio/RadioManager.swift
+++ b/Sources/NullPlayer/Radio/RadioManager.swift
@@ -130,12 +130,219 @@ class RadioManager {
     private let smartGenreOverridesKey = "RadioSmartGenreOverrides"
     private let smartRegionOverridesKey = "RadioSmartRegionOverrides"
     private let defaultGenreMigrationVersionKey = "RadioDefaultGenreMigrationVersion"
+    private let defaultURLMigrationVersionKey = "RadioDefaultURLMigrationVersion"
     private static let defaultURLAliases: [String: String] = [
         "https://wgbh-live.streamguys1.com/wgbh": "https://wgbh-live.streamguys1.com/wgbh.mp3",
         "https://wgbh-live.streamguys1.com/wgbh.mp3": "https://wgbh-live.streamguys1.com/wgbh"
     ]
+    private static let channelSourceURLs: [String: Set<String>] = [
+        "Audiophile.fm": Set([
+            "https://admin.biasradio.com/listen/bias_radio/flac",
+            "https://admin.biasradio.com/listen/bias_radio/live",
+            "https://amp.cesnet.cz:8443/cro3.flac",
+            "https://amp1.cesnet.cz:8443/cro-d-dur.flac",
+            "https://amp1.cesnet.cz:8443/cro-jazz.flac",
+            "https://amp1.cesnet.cz:8443/cro-radio-wave.flac",
+            "https://audio-edge-cmc51.fra.h.radiomast.io/radioblues-flac",
+            "https://audio.opensky.radio:8082/flac",
+            "https://audio.opensky.radio:8082/oise",
+            "https://azura.wbor.org/listen/wbor/flac",
+            "https://azura.wbor.org/listen/wbor/stream",
+            "https://bcast.vigormultimedia.com:48888/sjcompl320mp3",
+            "https://bcast.vigormultimedia.com:48888/sjcomplflac",
+            "https://blueswave.radio:8002/blues320",
+            "https://blueswave.radio:8100/FlacBlues",
+            "https://cdn05.radio.cloud:8128/AIDA-OMNIA-GAI",
+            "https://cdn06-us-east.radio.cloud/80ba63862a97bd69c593cc7a2ccaab1c_hq",
+            "https://cdn1.zetcast.net/flac",
+            "https://cdn1.zetcast.net/stream",
+            "https://dancewave.online/dance.flac.ogg",
+            "https://dancewave.online/dance.mp3",
+            "https://edge2.sr.se/p2-flac",
+            "https://edge62.streamonkey.net/aidaradio-meergefuehl",
+            "https://futura.fm/stream.ogg",
+            "https://gmusto.radioca.st/mp3",
+            "https://http-live.sr.se/p2musik-aac-320",
+            "https://ice.radiorandom.org/WBJM",
+            "https://ice.radiorandom.org/WBJM-FLAC",
+            "https://icecast.centaury.cl:7550/SuperStereo1",
+            "https://icecast.centaury.cl:7550/SuperStereo1Plus",
+            "https://icecast.centaury.cl:7550/SuperStereo2",
+            "https://icecast.centaury.cl:7550/SuperStereo3",
+            "https://icecast.centaury.cl:7550/SuperStereo3Plus",
+            "https://icecast.centaury.cl:7550/SuperStereo4",
+            "https://icecast.centaury.cl:7550/SuperStereo4Plus",
+            "https://icecast.centaury.cl:7550/SuperStereo5",
+            "https://icecast.centaury.cl:7550/SuperStereo6",
+            "https://icecast.centaury.cl:7550/SuperStereo7",
+            "https://icecast.centaury.cl:7570/SuperStereoHiRes1",
+            "https://icecast.centaury.cl:7570/SuperStereoHiRes1Plus",
+            "https://icecast.centaury.cl:7570/SuperStereoHiRes2",
+            "https://icecast.centaury.cl:7570/SuperStereoHiRes3",
+            "https://icecast.centaury.cl:7570/SuperStereoHiRes3Plus",
+            "https://icecast.centaury.cl:7570/SuperStereoHiRes4",
+            "https://icecast.centaury.cl:7570/SuperStereoHiRes4Plus",
+            "https://icecast.centaury.cl:7570/SuperStereoHiRes5",
+            "https://icecast.centaury.cl:7570/SuperStereoHiRes6",
+            "https://icecast.centaury.cl:7570/SuperStereoHiRes7",
+            "https://icecast.radiosega.net/live",
+            "https://icecast.radiosega.net/rs-flac.ogg",
+            "https://iradio.fi/klasu-hi.mp3",
+            "https://iradio.fi/klasu.flac",
+            "https://iradio.fi/klasupro-hi.mp3",
+            "https://iradio.fi/klasupro.flac",
+            "https://listen.teknivalradio.com/listen/teknivalradio/radio.flac",
+            "https://listen.teknivalradio.com/listen/teknivalradio/radio.mp3",
+            "https://live.easyradio.bg/aac?type=.mp3",
+            "https://live.easyradio.bg/flac",
+            "https://manager.dhectar.fr:1065/stream",
+            "https://manager.dhectar.fr:1080/stream",
+            "https://mediacp.jb-radio.net:8001/aac",
+            "https://mediacp.jb-radio.net:8001/flac",
+            "https://mp3.magic-radio.net/320",
+            "https://mp3.magic-radio.net/flac",
+            "https://mscp3.live-streams.nl:8252/class-flac.flac",
+            "https://mscp3.live-streams.nl:8252/class-high.aac",
+            "https://mscp3.live-streams.nl:8342/jazz-flac.flac",
+            "https://mscp3.live-streams.nl:8342/jazz-high.aac",
+            "https://mscp3.live-streams.nl:8362/flac.flac",
+            "https://mscp3.live-streams.nl:8362/high.aac",
+            "https://mscp4.live-streams.nl:8142/flac.ogg",
+            "https://mscp4.live-streams.nl:8142/live.mp3",
+            "https://mscp4.live-streams.nl:8142/lounge.mp3",
+            "https://mscp4.live-streams.nl:8142/lounge.ogg",
+            "https://online.jamminvibezradio.com/listen/caribbean/live.flac",
+            "https://online.jamminvibezradio.com/listen/caribbean/stream",
+            "https://online.jamminvibezradio.com/listen/christmas/live.flac",
+            "https://online.jamminvibezradio.com/listen/christmas/stream",
+            "https://online.jamminvibezradio.com/listen/oldies/live.flac",
+            "https://online.jamminvibezradio.com/listen/oldies/stream",
+            "https://online.jamminvibezradio.com/listen/reggae/live.flac",
+            "https://online.jamminvibezradio.com/listen/reggae/stream",
+            "https://radio.lapfoxradio.com/radio/8000/stream-flac.flac",
+            "https://radio.lapfoxradio.com/radio/8000/stream-mp3-320.mp3",
+            "https://radio3.radio-calico.com:8443/calico",
+            "https://radio3.radio-calico.com:8443/calico.mp3",
+            "https://radioemisoras.cl/distorsion.flac",
+            "https://radioemisoras.cl/distorsion.mp3",
+            "https://radiosputnik.nl:8443",
+            "https://radiosputnik.nl:8443/flac",
+            "https://radiotalas.dckrov.rs/listen/dckrov/aac",
+            "https://radiotalas.dckrov.rs/listen/dckrov/flac",
+            "https://retro.dancewave.online/retrodance.flac.ogg",
+            "https://retro.dancewave.online/retrodance.mp3",
+            "https://rozhlas.stream/ddur.mp3",
+            "https://rozhlas.stream/jazz.mp3",
+            "https://rozhlas.stream/radio_wave.mp3",
+            "https://rozhlas.stream/vltava.mp3",
+            "https://s2.audiostream.hu/bdpstrock_320k",
+            "https://s2.audiostream.hu/bdpstrock_FLAC",
+            "https://s2.audiostream.hu/juventus_320k",
+            "https://s2.audiostream.hu/juventus_FLAC",
+            "https://s2.audiostream.hu/roxy_320k",
+            "https://s2.audiostream.hu/roxy_FLAC",
+            "https://secure.live-streams.nl/flac.ogg",
+            "https://secure.live-streams.nl/live",
+            "https://station.thecheese.co.nz/listen/the_cheese/aac",
+            "https://station.thecheese.co.nz/listen/the_cheese/flac",
+            "https://stream.and-stuff.nl:8443/riverside",
+            "https://stream.and-stuff.nl:8443/riversideMp3",
+            "https://stream.danubiusradio.hu/danubius_320k",
+            "https://stream.danubiusradio.hu/danubius_HiFi",
+            "https://stream.motherearthradio.de/listen/motherearth/motherearth",
+            "https://stream.motherearthradio.de/listen/motherearth/motherearth.aac",
+            "https://stream.motherearthradio.de/listen/motherearth_instrumental/motherearth.instrumental",
+            "https://stream.motherearthradio.de/listen/motherearth_instrumental/motherearth.instrumental.aac",
+            "https://stream.motherearthradio.de/listen/motherearth_jazz/motherearth.jazz",
+            "https://stream.motherearthradio.de/listen/motherearth_jazz/motherearth.jazz.mp4",
+            "https://stream.motherearthradio.de/listen/motherearth_klassik/motherearth.klassik",
+            "https://stream.motherearthradio.de/listen/motherearth_klassik/motherearth.klassik.aac",
+            "https://stream.openbroadcast.ch/16bit.flac",
+            "https://stream.openbroadcast.ch/320.mp3",
+            "https://stream.p-node.org/piano.flac",
+            "https://stream.p-node.org/piano.mp3",
+            "https://stream.radio90.fm:2002/stream",
+            "https://stream.radio90.fm:2002/web",
+            "https://stream.radiobergeijk.nl/listen/radio_bergeijk/flac",
+            "https://stream.radiobergeijk.nl/listen/radio_bergeijk/mp3",
+            "https://stream.radioclub80.cl:8002/clasicos80.flac",
+            "https://stream.radioclub80.cl:8002/clasicos80.mp3",
+            "https://stream.radioclub80.cl:8012/espanol80.flac",
+            "https://stream.radioclub80.cl:8012/live.mp3",
+            "https://stream.radioclub80.cl:8022/retro80.flac",
+            "https://stream.radioclub80.cl:8022/retro80.mp3",
+            "https://stream.radioclub80.cl:8032/stream.euro80flac",
+            "https://stream.radioclub80.cl:8032/stream.euro80mp3",
+            "https://stream.radioclub80.cl:8042/baladas80.flac",
+            "https://stream.radioclub80.cl:8042/baladas80.mp3",
+            "https://stream.radioclub80.cl:8052/trance80.flac",
+            "https://stream.radioclub80.cl:8052/trancelive80.mp3",
+            "https://stream.radioenergy.to/stream",
+            "https://stream.radioparadise.com/aac-320",
+            "https://stream.radioparadise.com/beyond-320",
+            "https://stream.radioparadise.com/beyond-flac",
+            "https://stream.radioparadise.com/flac",
+            "https://stream.radioparadise.com/global-320",
+            "https://stream.radioparadise.com/global-flac",
+            "https://stream.radioparadise.com/mellow-320",
+            "https://stream.radioparadise.com/mellow-flac",
+            "https://stream.radioparadise.com/radio2050-320",
+            "https://stream.radioparadise.com/radio2050-flac",
+            "https://stream.radioparadise.com/rock-320",
+            "https://stream.radioparadise.com/rock-flac",
+            "https://stream.rcs.revma.com/vbp5ag77xs3vv",
+            "https://stream.rjrradio.fr/rjr-dab.flac",
+            "https://stream.rjrradio.fr/rjr.mp3",
+            "https://stream.trance.ie/stream",
+            "https://stream.trance.ie/tpmixes",
+            "https://stream10.xdevel.com/audio13s976748-2017/stream/icecast.audio",
+            "https://stream10.xdevel.com/audio15s976748-2280/stream/icecast.audio",
+            "https://stream10.xdevel.com/audio17s976748-2218/stream/icecast.audio",
+            "https://stream9.xdevel.com/audio1s976748-1515/stream/icecast.audio",
+            "https://streams.95bfm.com/stream112",
+            "https://streams.95bfm.com/stream95",
+            "https://streamserver.pure-isp.eu/listen/pure_radio_holland_-_dance_channel/flac",
+            "https://streamserver.pure-isp.eu/listen/pure_radio_holland_-_dance_channel/ultra",
+            "https://streamserver.pure-isp.eu/listen/pure_radio_holland_-_dj_r.i.ps_podcast/flac",
+            "https://streamserver.pure-isp.eu/listen/pure_radio_holland_-_dj_r.i.ps_podcast/ultra",
+            "https://streamserver.pure-isp.eu/listen/pure_radio_holland_-_downtempo_channel/flac",
+            "https://streamserver.pure-isp.eu/listen/pure_radio_holland_-_downtempo_channel/ultra",
+            "https://streamserver.pure-isp.eu/listen/pure_radio_holland_-_hardcore_channel/flac",
+            "https://streamserver.pure-isp.eu/listen/pure_radio_holland_-_hardcore_channel/ultra",
+            "https://streamserver.pure-isp.eu/listen/pure_radio_holland_-_live-party_channel/flac",
+            "https://streamserver.pure-isp.eu/listen/pure_radio_holland_-_live-party_channel/ultra",
+            "https://streamserver.pure-isp.eu/listen/pure_radio_holland_-_rap__hip-hop_channel/flac",
+            "https://streamserver.pure-isp.eu/listen/pure_radio_holland_-_rap__hip-hop_channel/ultra",
+            "https://streamserver.pure-isp.eu/listen/pure_radio_holland_-_trance-electro_channel/flac",
+            "https://streamserver.pure-isp.eu/listen/pure_radio_holland_-_trance-electro_channel/ultra",
+            "https://streamserver.pure-isp.eu/listen/pure_radio_holland_-_various_channel/flac",
+            "https://streamserver.pure-isp.eu/listen/pure_radio_holland_-_various_channel/ultra",
+            "https://streamserver.pure-isp.eu/listen/pure_radio_holland_the_underground_channel/flac",
+            "https://streamserver.pure-isp.eu/listen/pure_radio_holland_the_underground_channel/ultra",
+            "https://tuneintoradio1.com/listen/vfr_80s/radio.mp3",
+            "https://tuneintoradio1.com/listen/vfr_80s/stream.flac",
+            "https://tuneintoradio1.com/listen/violent_forces_radio/radio.mp3",
+            "https://tuneintoradio1.com/listen/violent_forces_radio/stream.flac",
+            "https://www.streamvortex.com:8444/s/10280",
+        ])
+    ]
+    private static let channelHostAliases: [String: String] = [
+        "somafm.com": "SomaFM",
+        "radioparadise.com": "Radio Paradise",
+        "nightride.fm": "Nightride FM",
+        "ntslive.net": "NTS",
+        "kcrw.com": "KCRW",
+        "wfmu.org": "WFMU",
+        "streamguys1.com": "StreamGuys",
+        "1.fm": "1.FM"
+    ]
     private let ratingsStore = RadioStationRatingsStore.shared
     private let foldersStore = RadioStationFoldersStore.shared
+    private static let defaultURLMigrationCurrentVersion = 2
+    private static let removedDefaultStationURLs: Set<String> = [
+        "https://stream.radioparadise.com/rock-flac",
+        "https://audio-edge-cmc51.fra.h.radiomast.io/radioblues-flac"
+    ]
     
     /// URLs of default stations the user has intentionally deleted (won't be re-added)
     private var deletedDefaultURLs: Set<String> {
@@ -266,13 +473,18 @@ class RadioManager {
               let decoded = try? JSONDecoder().decode([RadioStation].self, from: data) else {
             // Add some default stations for first-time users
             UserDefaults.standard.set(Self.defaultGenreMigrationCurrentVersion, forKey: defaultGenreMigrationVersionKey)
+            UserDefaults.standard.set(Self.defaultURLMigrationCurrentVersion, forKey: defaultURLMigrationVersionKey)
             stations = Self.defaultStations
             return
         }
         var migrated = decoded
+        let changedByURLMigration = applyDefaultURLMigrationIfNeeded(to: &migrated)
         let changedByMigration = applyDefaultGenreMigrationIfNeeded(to: &migrated)
         stations = migrated
         NSLog("RadioManager: Loaded %d saved stations", stations.count)
+        if changedByURLMigration > 0 {
+            NSLog("RadioManager: Migrated %d saved station URLs to latest defaults", changedByURLMigration)
+        }
         if changedByMigration > 0 {
             NSLog("RadioManager: Migrated %d saved station genres to latest defaults", changedByMigration)
         }
@@ -285,6 +497,21 @@ class RadioManager {
     private func saveStations() {
         guard let data = try? JSONEncoder().encode(stations) else { return }
         UserDefaults.standard.set(data, forKey: stationsKey)
+    }
+
+    @discardableResult
+    private func applyDefaultURLMigrationIfNeeded(to stations: inout [RadioStation]) -> Int {
+        let defaults = UserDefaults.standard
+        let appliedVersion = defaults.integer(forKey: defaultURLMigrationVersionKey)
+        guard appliedVersion < Self.defaultURLMigrationCurrentVersion else { return 0 }
+
+        let migration = Self.applyingDefaultURLCorrections(to: stations)
+        if migration.changedCount > 0 {
+            stations = migration.stations
+        }
+
+        defaults.set(Self.defaultURLMigrationCurrentVersion, forKey: defaultURLMigrationVersionKey)
+        return migration.changedCount
     }
 
     @discardableResult
@@ -421,6 +648,46 @@ class RadioManager {
             guard let corrected = correctedDefaultGenre(for: station.url, currentGenre: station.genre) else { return station }
             var copy = station
             copy.genre = corrected
+            changedCount += 1
+            return copy
+        }
+        return (migrated, changedCount)
+    }
+
+    private static func normalizedStationNameKey(_ name: String) -> String {
+        name
+            .folding(options: [.caseInsensitive, .diacriticInsensitive], locale: .current)
+            .trimmingCharacters(in: .whitespacesAndNewlines)
+    }
+
+    static func applyingDefaultURLCorrections(to stations: [RadioStation]) -> (stations: [RadioStation], changedCount: Int) {
+        let legacyAudiophileURLs = channelSourceURLs["Audiophile.fm"] ?? []
+
+        var canonicalURLByName: [String: URL] = [:]
+        for station in defaultStations {
+            let key = normalizedStationNameKey(station.name)
+            if canonicalURLByName[key] == nil {
+                canonicalURLByName[key] = station.url
+            }
+        }
+
+        var changedCount = 0
+        let filtered = stations.filter { station in
+            guard !removedDefaultStationURLs.contains(station.url.absoluteString) else {
+                changedCount += 1
+                return false
+            }
+            return true
+        }
+
+        let migrated = filtered.map { station -> RadioStation in
+            let key = normalizedStationNameKey(station.name)
+            guard let canonicalURL = canonicalURLByName[key] else { return station }
+            guard canonicalURL != station.url else { return station }
+            guard legacyAudiophileURLs.contains(station.url.absoluteString) else { return station }
+
+            var copy = station
+            copy.url = canonicalURL
             changedCount += 1
             return copy
         }
@@ -728,6 +995,7 @@ class RadioManager {
     }
 
     func internetRadioFolderDescriptors() -> [RadioFolderDescriptor] {
+        let channels = availableChannels()
         let genres = availableGenres()
         let regions = availableRegions()
         let userFolders = userRadioFolders()
@@ -777,6 +1045,14 @@ class RadioManager {
                 hasChildren: hasStations(.recentlyPlayed)
             ),
             RadioFolderDescriptor(
+                id: RadioFolderKind.byChannel.id,
+                title: "By Channel",
+                kind: .byChannel,
+                parentID: nil,
+                sortOrder: 80,
+                hasChildren: !channels.isEmpty
+            ),
+            RadioFolderDescriptor(
                 id: RadioFolderKind.byGenre.id,
                 title: "By Genre",
                 kind: .byGenre,
@@ -801,6 +1077,19 @@ class RadioManager {
                 hasChildren: !userFolders.isEmpty
             )
         ]
+
+        for (index, channel) in channels.enumerated() {
+            result.append(
+                RadioFolderDescriptor(
+                    id: RadioFolderKind.channel(channel).id,
+                    title: channel,
+                    kind: .channel(channel),
+                    parentID: RadioFolderKind.byChannel.id,
+                    sortOrder: 900 + index,
+                    hasChildren: hasStations(.channel(channel))
+                )
+            )
+        }
 
         for (index, genre) in genres.enumerated() {
             result.append(
@@ -877,6 +1166,11 @@ class RadioManager {
                 }
                 .sorted { $0.1 > $1.1 }
                 .map(\.0)
+        case .channel(let channel):
+            let filtered = stations.filter {
+                derivedChannel(for: $0).localizedCaseInsensitiveCompare(channel) == .orderedSame
+            }
+            return stationsSortedByName(filtered)
         case .genre(let genre):
             let target = normalizeGenreLabel(genre)
             let filtered = stations.filter {
@@ -896,7 +1190,7 @@ class RadioManager {
                 return false
             }
             return stationsSortedByName(filtered)
-        case .byGenre, .byRegion, .userFoldersRoot:
+        case .byChannel, .byGenre, .byRegion, .userFoldersRoot:
             return []
         }
     }
@@ -938,6 +1232,7 @@ class RadioManager {
             effectiveRegionLabel(for: station),
             station.url.absoluteString
         ]
+        fields.append(derivedChannel(for: station))
         if let host = station.url.host {
             fields.append(host)
         }
@@ -985,6 +1280,48 @@ class RadioManager {
     private func availableRegions() -> [String] {
         let regions = Set(stations.map { effectiveRegionLabel(for: $0) })
         return regions.sorted { $0.localizedCaseInsensitiveCompare($1) == .orderedAscending }
+    }
+
+    private func availableChannels() -> [String] {
+        var counts: [String: Int] = [:]
+        for station in stations {
+            let channel = derivedChannel(for: station)
+            counts[channel, default: 0] += 1
+        }
+
+        let labels = counts
+            .filter { $0.value >= 2 || $0.key == "Audiophile.fm" }
+            .map(\.key)
+
+        return labels.sorted { $0.localizedCaseInsensitiveCompare($1) == .orderedAscending }
+    }
+
+    private func derivedChannel(for station: RadioStation) -> String {
+        let keys = equivalentURLKeys(for: station.url)
+        for (label, urls) in Self.channelSourceURLs where !urls.isDisjoint(with: keys) {
+            return label
+        }
+
+        let host = station.url.host?.lowercased() ?? ""
+        if !host.isEmpty {
+            for (pattern, label) in Self.channelHostAliases where host.contains(pattern) {
+                return label
+            }
+        }
+
+        return normalizedChannelLabel(fromHost: host)
+    }
+
+    private func normalizedChannelLabel(fromHost host: String) -> String {
+        let trimmed = host.trimmingCharacters(in: .whitespacesAndNewlines)
+        guard !trimmed.isEmpty else { return "Unknown Source" }
+
+        let components = trimmed.split(separator: ".")
+        if components.count >= 2 {
+            let label = components.suffix(2).joined(separator: ".")
+            return label.lowercased()
+        }
+        return trimmed.lowercased()
     }
 
     private func derivedRegion(for station: RadioStation) -> String {

--- a/Sources/NullPlayer/Resources/Radio/default_stations.json
+++ b/Sources/NullPlayer/Resources/Radio/default_stations.json
@@ -1515,11 +1515,6 @@
     "genre": "Rock"
   },
   {
-    "name": "Radio Paradise Rock Mix FLAC",
-    "url": "https://stream.radioparadise.com/rock-flac",
-    "genre": "Rock"
-  },
-  {
     "name": "Radio Ultra",
     "url": "http://nashe1.hostingradio.ru/ultra-192.mp3",
     "genre": "Alternative Rock"
@@ -1863,5 +1858,465 @@
     "name": "True Black Metal Radio",
     "url": "http://trueblackmetalradio.com:666/radio",
     "genre": "Extreme Music"
+  },
+  {
+    "name": "Radio Bias",
+    "url": "https://admin.biasradio.com/listen/bias_radio/live",
+    "genre": "Pop"
+  },
+  {
+    "name": "ČRo Vltava",
+    "url": "https://rozhlas.stream/vltava.mp3",
+    "genre": "Jazz"
+  },
+  {
+    "name": "ČRo D-dur",
+    "url": "https://rozhlas.stream/ddur.mp3",
+    "genre": "Classical"
+  },
+  {
+    "name": "ČRo Jazz",
+    "url": "https://rozhlas.stream/jazz.mp3",
+    "genre": "Jazz"
+  },
+  {
+    "name": "ČRo Radio Wave",
+    "url": "https://rozhlas.stream/radio_wave.mp3",
+    "genre": "Electronic"
+  },
+  {
+    "name": "Open Sky Radio",
+    "url": "https://audio.opensky.radio:8082/oise",
+    "genre": "Popular"
+  },
+  {
+    "name": "WBOR Radio",
+    "url": "https://azura.wbor.org/listen/wbor/stream",
+    "genre": "Indie"
+  },
+  {
+    "name": "SmoothJazz.com.pl",
+    "url": "https://bcast.vigormultimedia.com:48888/sjcompl320mp3",
+    "genre": "Smooth Jazz"
+  },
+  {
+    "name": "BluesWave Radio",
+    "url": "https://blueswave.radio:8002/blues320",
+    "genre": "Blues"
+  },
+  {
+    "name": "AIDAradio",
+    "url": "https://edge62.streamonkey.net/aidaradio-meergefuehl",
+    "genre": "Hits"
+  },
+  {
+    "name": "High Fi Dream Radio",
+    "url": "https://www.streamvortex.com:8444/s/10280",
+    "genre": "Pop"
+  },
+  {
+    "name": "60 North Radio",
+    "url": "https://cdn1.zetcast.net/stream",
+    "genre": "Eclectic"
+  },
+  {
+    "name": "Dance Wave!",
+    "url": "https://dancewave.online/dance.mp3",
+    "genre": "Dance"
+  },
+  {
+    "name": "Sveriges Radio: P2",
+    "url": "https://http-live.sr.se/p2musik-aac-320",
+    "genre": "Classical"
+  },
+  {
+    "name": "Futura.FM",
+    "url": "https://stream.rcs.revma.com/vbp5ag77xs3vv",
+    "genre": "80s"
+  },
+  {
+    "name": "Radio Random",
+    "url": "https://ice.radiorandom.org/WBJM",
+    "genre": "Pop"
+  },
+  {
+    "name": "SuperStereo: Signal 1",
+    "url": "https://icecast.centaury.cl:7550/SuperStereo1",
+    "genre": "Yacht Rock"
+  },
+  {
+    "name": "SuperStereo: Signal 1+",
+    "url": "https://icecast.centaury.cl:7550/SuperStereo1Plus",
+    "genre": "Disco"
+  },
+  {
+    "name": "SuperStereo: Signal 2",
+    "url": "https://icecast.centaury.cl:7550/SuperStereo2",
+    "genre": "50s"
+  },
+  {
+    "name": "SuperStereo: Signal 3",
+    "url": "https://icecast.centaury.cl:7550/SuperStereo3",
+    "genre": "80s"
+  },
+  {
+    "name": "SuperStereo: Signal 3+",
+    "url": "https://icecast.centaury.cl:7550/SuperStereo3Plus",
+    "genre": "New Wave"
+  },
+  {
+    "name": "SuperStereo: Signal 4",
+    "url": "https://icecast.centaury.cl:7550/SuperStereo4",
+    "genre": "Ballads"
+  },
+  {
+    "name": "SuperStereo: Signal 4+",
+    "url": "https://icecast.centaury.cl:7550/SuperStereo4Plus",
+    "genre": "Ballads"
+  },
+  {
+    "name": "SuperStereo: Signal 5",
+    "url": "https://icecast.centaury.cl:7550/SuperStereo5",
+    "genre": "Rock"
+  },
+  {
+    "name": "SuperStereo: Signal 6",
+    "url": "https://icecast.centaury.cl:7550/SuperStereo6",
+    "genre": "Instrumental"
+  },
+  {
+    "name": "SuperStereo: Signal 7",
+    "url": "https://icecast.centaury.cl:7550/SuperStereo7",
+    "genre": "Jazz"
+  },
+  {
+    "name": "RadioSEGA",
+    "url": "https://icecast.radiosega.net/live",
+    "genre": "Chiptune"
+  },
+  {
+    "name": "Rondo Classic: Klasu",
+    "url": "https://iradio.fi/klasu-hi.mp3",
+    "genre": "Classical"
+  },
+  {
+    "name": "Rondo Classic: Klasu Pro",
+    "url": "https://iradio.fi/klasupro-hi.mp3",
+    "genre": "Classical"
+  },
+  {
+    "name": "TEKnival Radio",
+    "url": "https://listen.teknivalradio.com/listen/teknivalradio/radio.mp3",
+    "genre": "Rave"
+  },
+  {
+    "name": "Easy Radio",
+    "url": "https://live.easyradio.bg/aac?type=.mp3",
+    "genre": "Pop"
+  },
+  {
+    "name": "Dhectar",
+    "url": "https://manager.dhectar.fr:1065/stream",
+    "genre": "Techno"
+  },
+  {
+    "name": "JB Radio",
+    "url": "https://mediacp.jb-radio.net:8001/aac",
+    "genre": "Rock"
+  },
+  {
+    "name": "Magic Radio",
+    "url": "https://mp3.magic-radio.net/320",
+    "genre": "80s"
+  },
+  {
+    "name": "Naim Classical",
+    "url": "https://mscp3.live-streams.nl:8252/class-high.aac",
+    "genre": "Classical"
+  },
+  {
+    "name": "Naim Jazz",
+    "url": "https://mscp3.live-streams.nl:8342/jazz-high.aac",
+    "genre": "Jazz"
+  },
+  {
+    "name": "Naim Radio",
+    "url": "https://mscp3.live-streams.nl:8362/high.aac",
+    "genre": "Eclectic"
+  },
+  {
+    "name": "Pure Classix Radio",
+    "url": "https://mscp4.live-streams.nl:8142/live.mp3",
+    "genre": "Funk"
+  },
+  {
+    "name": "Pure Lounge Radio",
+    "url": "https://mscp4.live-streams.nl:8142/lounge.mp3",
+    "genre": "Lounge"
+  },
+  {
+    "name": "Jammin Vibez Radio: Caribbean Variety Mix",
+    "url": "https://online.jamminvibezradio.com/listen/caribbean/stream",
+    "genre": "Reggae"
+  },
+  {
+    "name": "Jammin Vibez Radio: Caribbean Christmas Mix",
+    "url": "https://online.jamminvibezradio.com/listen/christmas/stream",
+    "genre": "Reggae"
+  },
+  {
+    "name": "Jammin Vibez Radio: Classic Oldies Mix",
+    "url": "https://online.jamminvibezradio.com/listen/oldies/stream",
+    "genre": "Classic Hits"
+  },
+  {
+    "name": "Jammin Vibez Radio: Reggae Classics Mix",
+    "url": "https://online.jamminvibezradio.com/listen/reggae/stream",
+    "genre": "Reggae"
+  },
+  {
+    "name": "LapFox Radio",
+    "url": "https://radio.lapfoxradio.com/radio/8000/stream-mp3-320.mp3",
+    "genre": "Electronic"
+  },
+  {
+    "name": "Radio Calico",
+    "url": "https://radio3.radio-calico.com:8443/calico.mp3",
+    "genre": "Pop"
+  },
+  {
+    "name": "Distorsion FM",
+    "url": "https://radioemisoras.cl/distorsion.mp3",
+    "genre": "Rock"
+  },
+  {
+    "name": "Radio Sputnik",
+    "url": "https://radiosputnik.nl:8443",
+    "genre": "Techno"
+  },
+  {
+    "name": "Radio Krov",
+    "url": "https://radiotalas.dckrov.rs/listen/dckrov/aac",
+    "genre": "World Music"
+  },
+  {
+    "name": "Dance Wave Retro!",
+    "url": "https://retro.dancewave.online/retrodance.mp3",
+    "genre": "Dance"
+  },
+  {
+    "name": "BDPST Rock",
+    "url": "https://s2.audiostream.hu/bdpstrock_320k",
+    "genre": "Rock"
+  },
+  {
+    "name": "Youventus Radio",
+    "url": "https://s2.audiostream.hu/juventus_320k",
+    "genre": "Pop"
+  },
+  {
+    "name": "Roxy Radio",
+    "url": "https://s2.audiostream.hu/roxy_320k",
+    "genre": "Hits"
+  },
+  {
+    "name": "Intense Radio",
+    "url": "https://secure.live-streams.nl/live",
+    "genre": "Dance"
+  },
+  {
+    "name": "The Cheese",
+    "url": "https://station.thecheese.co.nz/listen/the_cheese/aac",
+    "genre": "Pop"
+  },
+  {
+    "name": "Riverside Radio",
+    "url": "https://stream.and-stuff.nl:8443/riversideMp3",
+    "genre": "Pop"
+  },
+  {
+    "name": "Danubius Radio",
+    "url": "https://stream.danubiusradio.hu/danubius_320k",
+    "genre": "Pop"
+  },
+  {
+    "name": "Mother Earth Radio",
+    "url": "https://stream.motherearthradio.de/listen/motherearth/motherearth.aac",
+    "genre": "Rock"
+  },
+  {
+    "name": "Mother Earth Instrumental",
+    "url": "https://stream.motherearthradio.de/listen/motherearth_instrumental/motherearth.instrumental.aac",
+    "genre": "Instrumental"
+  },
+  {
+    "name": "Mother Earth Jazz",
+    "url": "https://stream.motherearthradio.de/listen/motherearth_jazz/motherearth.jazz.mp4",
+    "genre": "Jazz"
+  },
+  {
+    "name": "Mother Earth Klassik",
+    "url": "https://stream.motherearthradio.de/listen/motherearth_klassik/motherearth.klassik.aac",
+    "genre": "Classical"
+  },
+  {
+    "name": "Open Broadcast Radio",
+    "url": "https://stream.openbroadcast.ch/320.mp3",
+    "genre": "Eclectic"
+  },
+  {
+    "name": "P-Node: Pi ano",
+    "url": "https://stream.p-node.org/piano.mp3",
+    "genre": "Classical"
+  },
+  {
+    "name": "Radio 90FM Valencia",
+    "url": "https://stream.radio90.fm:2002/web",
+    "genre": "Techno"
+  },
+  {
+    "name": "Radio Bergeijk",
+    "url": "https://stream.radiobergeijk.nl/listen/radio_bergeijk/mp3",
+    "genre": "Eclectic"
+  },
+  {
+    "name": "Radio Club 80: Classic Hits",
+    "url": "https://stream.radioclub80.cl:8002/clasicos80.mp3",
+    "genre": "70s"
+  },
+  {
+    "name": "Radio Club 80: Latin Hits",
+    "url": "https://stream.radioclub80.cl:8012/live.mp3",
+    "genre": "Latin Pop"
+  },
+  {
+    "name": "Radio Club 80: Retro",
+    "url": "https://stream.radioclub80.cl:8022/retro80.mp3",
+    "genre": "Disco"
+  },
+  {
+    "name": "Radio Club 80: Euro Hits",
+    "url": "https://stream.radioclub80.cl:8032/stream.euro80mp3",
+    "genre": "00s"
+  },
+  {
+    "name": "Radio Club 80: Ballads",
+    "url": "https://stream.radioclub80.cl:8042/baladas80.mp3",
+    "genre": "Ballads"
+  },
+  {
+    "name": "Radio Club 80: Trance",
+    "url": "https://stream.radioclub80.cl:8052/trancelive80.mp3",
+    "genre": "Trance"
+  },
+  {
+    "name": "Radio Energy",
+    "url": "https://gmusto.radioca.st/mp3",
+    "genre": "Pop"
+  },
+  {
+    "name": "Radio Paradise: Beyond...",
+    "url": "https://stream.radioparadise.com/beyond-320",
+    "genre": "Eclectic"
+  },
+  {
+    "name": "Radio Paradise: Main Mix",
+    "url": "https://stream.radioparadise.com/aac-320",
+    "genre": "Pop"
+  },
+  {
+    "name": "Radio Paradise: Global Mix",
+    "url": "https://stream.radioparadise.com/global-320",
+    "genre": "World Music"
+  },
+  {
+    "name": "Radio Paradise: Mellow Mix",
+    "url": "https://stream.radioparadise.com/mellow-320",
+    "genre": "Acoustic"
+  },
+  {
+    "name": "Radio Paradise 2050",
+    "url": "https://stream.radioparadise.com/radio2050-320",
+    "genre": "Pop"
+  },
+  {
+    "name": "Radio Jeunes Rheims",
+    "url": "https://stream.rjrradio.fr/rjr.mp3",
+    "genre": "Pop"
+  },
+  {
+    "name": "TrancePulse",
+    "url": "https://stream.trance.ie/stream",
+    "genre": "Trance"
+  },
+  {
+    "name": "Djam Radio",
+    "url": "https://stream9.xdevel.com/audio1s976748-1515/stream/icecast.audio",
+    "genre": "World Music"
+  },
+  {
+    "name": "Le Bon Mix",
+    "url": "https://stream10.xdevel.com/audio13s976748-2017/stream/icecast.audio",
+    "genre": "Funk"
+  },
+  {
+    "name": "95bFM Radio",
+    "url": "https://streams.95bfm.com/stream95",
+    "genre": "Indie"
+  },
+  {
+    "name": "Pure Radio Holland: Dance",
+    "url": "https://streamserver.pure-isp.eu/listen/pure_radio_holland_-_dance_channel/ultra",
+    "genre": "Dance"
+  },
+  {
+    "name": "Pure Radio Holland: DJ R.I.P's Podcast",
+    "url": "https://streamserver.pure-isp.eu/listen/pure_radio_holland_-_dj_r.i.ps_podcast/ultra",
+    "genre": "Electronic"
+  },
+  {
+    "name": "Pure Radio Holland: Downtempo",
+    "url": "https://streamserver.pure-isp.eu/listen/pure_radio_holland_-_downtempo_channel/ultra",
+    "genre": "Downtempo"
+  },
+  {
+    "name": "Pure Radio Holland: Hardcore",
+    "url": "https://streamserver.pure-isp.eu/listen/pure_radio_holland_-_hardcore_channel/ultra",
+    "genre": "Hardcore"
+  },
+  {
+    "name": "Pure Radio Holland: Live Party",
+    "url": "https://streamserver.pure-isp.eu/listen/pure_radio_holland_-_live-party_channel/ultra",
+    "genre": "Techno"
+  },
+  {
+    "name": "Pure Radio Holland: Rap & Hip-Hop",
+    "url": "https://streamserver.pure-isp.eu/listen/pure_radio_holland_-_rap__hip-hop_channel/ultra",
+    "genre": "Rap"
+  },
+  {
+    "name": "Pure Radio Holland: Trance-Electro",
+    "url": "https://streamserver.pure-isp.eu/listen/pure_radio_holland_-_trance-electro_channel/ultra",
+    "genre": "Trance"
+  },
+  {
+    "name": "Pure Radio Holland: Various",
+    "url": "https://streamserver.pure-isp.eu/listen/pure_radio_holland_-_various_channel/ultra",
+    "genre": "Eclectic"
+  },
+  {
+    "name": "Pure Radio Holland: Underground",
+    "url": "https://streamserver.pure-isp.eu/listen/pure_radio_holland_the_underground_channel/ultra",
+    "genre": "Electronic"
+  },
+  {
+    "name": "Violent Forces Radio: '80s Thrash",
+    "url": "https://tuneintoradio1.com/listen/vfr_80s/radio.mp3",
+    "genre": "Thrash Metal"
+  },
+  {
+    "name": "Violent Forces Radio: General Thrash",
+    "url": "https://tuneintoradio1.com/listen/violent_forces_radio/radio.mp3",
+    "genre": "Thrash Metal"
   }
 ]

--- a/Sources/NullPlayer/Resources/Radio/default_stations.json
+++ b/Sources/NullPlayer/Resources/Radio/default_stations.json
@@ -107,7 +107,7 @@
   {
     "name": "SomaFM Bossa Beyond",
     "url": "https://ice5.somafm.com/bossa-128-mp3",
-    "genre": "Classical"
+    "genre": "Bossa Nova"
   },
   {
     "name": "Classical KING FM",
@@ -352,7 +352,7 @@
   {
     "name": "106 Family News Radio",
     "url": "https://radio11.plathong.net/7138/;stream.mp3",
-    "genre": "Thai"
+    "genre": "News"
   },
   {
     "name": "SomaFM Boot Liquor",
@@ -1015,7 +1015,7 @@
     "genre": "Classic Rock"
   },
   {
-    "name": "RÃ¡dio Cidade - Rio de Janeiro - 102.9 FM - ZYD462",
+    "name": "Rádio Cidade - Rio de Janeiro - 102.9 FM - ZYD462",
     "url": "https://playerservices.streamtheworld.com/api/livestream-redirect/RADIOCIDADEAAC.aac",
     "genre": "Classic Rock"
   },
@@ -1047,12 +1047,12 @@
   {
     "name": "# TOP 100 CLUB CHARTS - DANCE & DJ MIX RADIO - 24 HOURS NON-STOP MUSIC @ TikTok Hits, Ibiza House, Sunset Lounge, Melodic Music, EDM, Deep House, Dance Music, Techno & Hypertechno, Rave Charts, Top 40 Charts, Latin, Reggaeton Music, Moombahton, Urban Hits, HipHop, Party & Clubbing Radio, Trending Chartmusic, R&B, Urban, Mixtape - & LIVE DJ SET",
     "url": "https://breakz-2012-high.rautemusik.fm/?ref=radiobrowser-top100-clubcharts",
-    "genre": "Rap/Hip Hop"
+    "genre": "Dance/EDM"
   },
   {
     "name": "- 0 N - Indie on Radio",
     "url": "https://0n-indie.radionetz.de/0n-indie.mp3",
-    "genre": "Rap/Hip Hop"
+    "genre": "Alternative Rock"
   },
   {
     "name": "0nlineradio REMIX",
@@ -1087,7 +1087,7 @@
   {
     "name": "Alternative Radio",
     "url": "https://www.radioking.com/play/alternative-radio-1",
-    "genre": "Rap/Hip Hop"
+    "genre": "Alternative Rock"
   },
   {
     "name": "Boss FM Grenada",
@@ -1100,7 +1100,7 @@
     "genre": "Rap/Hip Hop"
   },
   {
-    "name": "Chocolate FM [calidad mÃ³vil-low bandwidth]",
+    "name": "Chocolate FM [calidad móvil-low bandwidth]",
     "url": "http://streaming5.elitecomunicacion.es:8082/live32.aac",
     "genre": "Rap/Hip Hop"
   },
@@ -1115,7 +1115,7 @@
     "genre": "Rap/Hip Hop"
   },
   {
-    "name": "Free RÃ¡dio 107,0 FM Brno",
+    "name": "Free Rádio 107,0 FM Brno",
     "url": "http://icecast8.play.cz/freeradio128.mp3",
     "genre": "Rap/Hip Hop"
   },
@@ -1182,7 +1182,7 @@
   {
     "name": "Today's Hot Country",
     "url": "http://ice.stream101.com:9016/stream",
-    "genre": "Rap/Hip Hop"
+    "genre": "Country"
   },
   {
     "name": "TRAP RADIO TRAP.radio",
@@ -1192,17 +1192,17 @@
   {
     "name": "Uganda DJs",
     "url": "https://stream.zeno.fm/muzrp86994zuv",
-    "genre": "Rap/Hip Hop"
+    "genre": "Afrobeats"
   },
   {
     "name": "__WORKOUT__ by rautemusik (rm.fm)",
     "url": "https://workout-high.rautemusik.fm/?ref=radiobrowser",
-    "genre": "Nature Sounds"
+    "genre": "Workout"
   },
   {
     "name": "Alles Oberkrain",
     "url": "http://bayerwaldradio.deg.net:8000/allesoberkrain",
-    "genre": "Nature Sounds"
+    "genre": "Polka/Folk"
   },
   {
     "name": "Ambi Nature Radio",
@@ -1212,61 +1212,51 @@
   {
     "name": "DrGnu - 70th Rock",
     "url": "http://fluxfm.streamabc.net/flx-70er-mp3-320-4383769?sABC=6202qr25%230%237osorqnn86p8nnp979o1124290qqo247%23fgernzf.syhksz.qr&amsparams=playerid:streams.fluxfm.de;skey:1644355109",
-    "genre": "Nature Sounds"
+    "genre": "Classic Rock"
   },
   {
     "name": "DrGnu - 80th Rock II",
     "url": "https://fluxfm.streamabc.net/flx-80er-mp3-320-9596107?sABC=6202qrr6%230%23sorr1p583723p06268o324o2ps5n399q%23fgernzf.syhksz.qr&amsparams=playerid:streams.fluxfm.de;skey:1644355302",
-    "genre": "Nature Sounds"
+    "genre": "Classic Rock"
   },
   {
     "name": "DrGnu - 90th Rock",
     "url": "http://streams.radiobob.de/bob-90srock/mp3-192/mediaplayer",
-    "genre": "Nature Sounds"
+    "genre": "Classic Rock"
   },
   {
     "name": "DrGnu - Gothic",
     "url": "http://streams.radiobob.de/gothic/mp3-192/mediaplayer",
-    "genre": "Nature Sounds"
+    "genre": "Gothic Rock"
   },
   {
     "name": "DrGnu - Metal 1",
     "url": "http://streams.radiobob.de/bob-metal/mp3-192/mediaplayer",
-    "genre": "Nature Sounds"
+    "genre": "Metal"
   },
   {
     "name": "DrGnu - Metalcore 1",
     "url": "http://streams.radiobob.de/metalcore/mp3-192/mediaplayer",
-    "genre": "Nature Sounds"
+    "genre": "Metal"
   },
   {
     "name": "DrGnu - Metallica",
     "url": "http://streams.radiobob.de/metallica/mp3-192/mediaplayer/",
-    "genre": "Nature Sounds"
+    "genre": "Metal"
   },
   {
     "name": "DrGnu - Rock Party",
     "url": "http://streams.radiobob.de/rockparty/mp3-192/mediaplayer/",
-    "genre": "Nature Sounds"
+    "genre": "Rock"
   },
   {
     "name": "DrGnu - Wacken Radio",
     "url": "http://streams.radiobob.de/bob-wacken/mp3-192/mediaplayer",
-    "genre": "Nature Sounds"
+    "genre": "Metal"
   },
   {
     "name": "Epic Lounge - NATURE SOUNDS",
     "url": "https://stream.epic-lounge.com/nature-sounds?ref=radiobrowser",
-    "genre": "Nature Sounds"
-  },
-  {
-    "name": "Gachi Station #1",
-    "url": "https://stream.zeno.fm/y513614qvzzuv",
-    "genre": "Nature Sounds"
-  },
-  {
-    "name": "Gachi Station (Ukrainian playlist) #1",
-    "url": "https://stream.zeno.fm/bmb6ihzfbpdtv",
     "genre": "Nature Sounds"
   },
   {
@@ -1287,17 +1277,17 @@
   {
     "name": "Lux FM",
     "url": "http://lux.radio.tvstitch.com/kyiv/lux_adv_sd",
-    "genre": "Nature Sounds"
+    "genre": "Top 40"
   },
   {
     "name": "MCF Radio - Kampala - 98.7 FM (MP3)",
     "url": "http://streams.radio.co/s79fbbb432/listen",
-    "genre": "Nature Sounds"
+    "genre": "World"
   },
   {
     "name": "Miami Beach Radio",
     "url": "https://streaming.radiostreamlive.com/miamibeachradio_devices",
-    "genre": "Nature Sounds"
+    "genre": "Dance"
   },
   {
     "name": "MyNoise Ocean Waves",
@@ -1330,24 +1320,14 @@
     "genre": "Nature Sounds"
   },
   {
-    "name": "Phaune radio",
-    "url": "http://stream.phauneradio.com/phaune_128",
-    "genre": "Nature Sounds"
-  },
-  {
     "name": "RADIO BOB! BOBs Wacken Nonstop (192kbit)",
     "url": "http://streams.radiobob.de/bob-wacken/mp3-192/streams.radiobob.de/",
-    "genre": "Nature Sounds"
+    "genre": "Metal"
   },
   {
     "name": "Radio Caprice - Forest Psytrance",
     "url": "http://213.141.131.10:8004/forestpsytrance",
-    "genre": "Nature Sounds"
-  },
-  {
-    "name": "Radio Dreamland",
-    "url": "https://dreamsiteradiocp3.com/proxy/dreamland?mp=/stream",
-    "genre": "Nature Sounds"
+    "genre": "Psytrance"
   },
   {
     "name": "Radio Nature",
@@ -1357,32 +1337,32 @@
   {
     "name": "Radio Rocks",
     "url": "http://195.95.206.13:8000/RadioROKS",
-    "genre": "Nature Sounds"
+    "genre": "Rock"
   },
   {
     "name": "Radio ROKS Ukrainian",
     "url": "http://online.radioroks.ua/RadioROKS_Ukr_HD",
-    "genre": "Nature Sounds"
+    "genre": "Rock"
   },
   {
     "name": "SW-Radio Ukrainisch",
     "url": "http://www.segenswelle.de:8000/ukrainisch",
-    "genre": "Nature Sounds"
+    "genre": "World"
   },
   {
-    "name": "Ð¡Ð¿Ð¾ÐºÐ¾Ð¹Ð½Ð¾Ðµ ÑÐ°Ð´Ð¸Ð¾",
+    "name": "Спокойное радио",
     "url": "https://listen9.myradio24.com/6262",
-    "genre": "Nature Sounds"
+    "genre": "Easy Listening"
   },
   {
-    "name": "Ð¥ÑÑ Ð¤Ð Ð£ÐºÑÐ°ÑÐ½ÑÑÐºÑ ÑÑÑÐ¸",
+    "name": "Хіт ФМ Українські хіти",
     "url": "http://online.hitfm.ua/HitFM_Ukr",
-    "genre": "Nature Sounds"
+    "genre": "Top 40"
   },
   {
-    "name": "ÐÐ´Ð¸Ð½Ñ Ð½Ð¾Ð²Ð¸Ð½Ð¸ 24 - BREAKING - LIVE",
+    "name": "Єдині новини 24 - BREAKING - LIVE",
     "url": "https://online-news.radioplayer.ua/RadioNews",
-    "genre": "Nature Sounds"
+    "genre": "News"
   },
   {
     "name": "# RdMix Classic Rock 70s 80s 90s",
@@ -1432,10 +1412,10 @@
   {
     "name": "Anti Radio",
     "url": "https://stream.antiradio.net/radio/8000/mp3",
-    "genre": "College Indie"
+    "genre": "Alternative Rock"
   },
   {
-    "name": "BDPST ROCK RÃ¡diÃ³ (Hi-Fi / Lossless / FLAC)",
+    "name": "BDPST ROCK Rádió (Hi-Fi / Lossless / FLAC)",
     "url": "http://s2.audiostream.hu:8091/bdpstrock_FLAC",
     "genre": "College Indie"
   },
@@ -1452,7 +1432,7 @@
   {
     "name": "Deep House Sounds",
     "url": "http://stream.laut.fm/deep-house-sounds",
-    "genre": "College Indie"
+    "genre": "Deep House"
   },
   {
     "name": "delta radio Indie",
@@ -1462,27 +1442,27 @@
   {
     "name": "Easy FM 972",
     "url": "https://stream.radiojar.com/cthtwxk5yvduv.mp3",
-    "genre": "College Indie"
+    "genre": "Easy Listening"
   },
   {
     "name": "FluxFM",
     "url": "http://streams.fluxfm.de/live/mp3-320/audio/",
-    "genre": "College Indie"
+    "genre": "Alternative Rock"
   },
   {
     "name": "FM4 | ORF",
     "url": "https://orf-live.ors-shoutcast.at/fm4-q1a",
-    "genre": "College Indie"
+    "genre": "Alternative Rock"
   },
   {
     "name": "Gangstaville Radio",
     "url": "http://stream.radio.co/s1cffd7347/listen",
-    "genre": "College Indie"
+    "genre": "Hip Hop"
   },
   {
     "name": "Indie X FM",
     "url": "http://kathy.torontocast.com:2690/stream",
-    "genre": "College Indie"
+    "genre": "Alternative Rock"
   },
   {
     "name": "KEXP 90.3 Seattle, WA",
@@ -1490,144 +1470,129 @@
     "genre": "College Indie"
   },
   {
-    "name": "M-Stream Indo",
-    "url": "https://stream.zeno.fm/iln4upodbvuuv",
-    "genre": "College Indie"
-  },
-  {
     "name": "naxi radio - rock",
     "url": "http://naxidigital-rock128.streaming.rs:8180/;stream.nsv",
-    "genre": "College Indie"
+    "genre": "Rock"
   },
   {
-    "name": "PetÅfi RÃ¡diÃ³",
+    "name": "Petőfi Rádió",
     "url": "http://mr-stream.mediaconnect.hu/4737/mr2.aac",
-    "genre": "College Indie"
+    "genre": "Alternative Rock"
   },
   {
     "name": "RADIO BOB! BOBs Alternative Rock",
     "url": "http://streams.radiobob.de/bob-alternative/mp3-192/streams.radiobob.de/",
-    "genre": "College Indie"
+    "genre": "Alternative Rock"
   },
   {
     "name": "RADIO BOB! BOBs Best of Rock",
     "url": "http://streams.radiobob.de/bob-bestofrock/mp3-192/streams.radiobob.de/",
-    "genre": "College Indie"
-  },
-  {
-    "name": "RADIO CAKRA 90.5 FM",
-    "url": "https://stream.zeno.fm/yoengdcdzyauv",
-    "genre": "College Indie"
+    "genre": "Rock"
   },
   {
     "name": "RADIO CAROLINA cl",
     "url": "http://stream.zeno.fm/sri2de2qdlivv",
-    "genre": "College Indie"
+    "genre": "Top 40"
   },
   {
     "name": "Radio Eins",
     "url": "http://f121.rndfnk.com/ard/rbb/radioeins/live/mp3/128/stream.mp3?cid=01FC1WH12KJ93TCQPDSE2E5PZ9&sid=38HoeEhwMU9ZjQaArYLcNuLu9LN&token=VXH8C52tOJ6o_G5uLXexxjt84DXyHGfH0RABfQljedk&tvf=8PpblQ7uihhmMTIxLnJuZGZuay5jb20",
-    "genre": "College Indie"
-  },
-  {
-    "name": "Radio FM",
-    "url": "https://icecast.stv.livebox.sk/fm_128.mp3",
-    "genre": "College Indie"
+    "genre": "Public Radio"
   },
   {
     "name": "Radio Nova",
     "url": "http://novazz.ice.infomaniak.ch/novazz-128.mp3",
-    "genre": "College Indie"
+    "genre": "Jazz"
   },
   {
     "name": "Radio Paradise Mellow Mix 320k AAC",
     "url": "http://stream.radioparadise.com/mellow-320",
-    "genre": "College Indie"
+    "genre": "Eclectic"
   },
   {
     "name": "Radio Paradise Rock Mix 320k AAC",
     "url": "http://stream.radioparadise.com/rock-320",
-    "genre": "College Indie"
+    "genre": "Rock"
   },
   {
     "name": "Radio Paradise Rock Mix FLAC",
     "url": "https://stream.radioparadise.com/rock-flac",
-    "genre": "College Indie"
+    "genre": "Rock"
   },
   {
     "name": "Radio Ultra",
     "url": "http://nashe1.hostingradio.ru/ultra-192.mp3",
-    "genre": "College Indie"
+    "genre": "Alternative Rock"
   },
   {
     "name": "Radio X",
     "url": "http://media-the.musicradio.com/RadioXUK",
-    "genre": "College Indie"
+    "genre": "Alternative Rock"
   },
   {
     "name": "ROCK ANTENNE Alternative",
     "url": "http://stream.rockantenne.de/alternative",
-    "genre": "College Indie"
+    "genre": "Alternative Rock"
   },
   {
     "name": "SomaFM Folk Forward (128k AAC)",
     "url": "https://ice5.somafm.com/folkfwd-128-aac",
-    "genre": "College Indie"
+    "genre": "Folk"
   },
   {
     "name": "SomaFM Folk Forward (128k MP3)",
     "url": "https://ice1.somafm.com/folkfwd-128-mp3",
-    "genre": "College Indie"
+    "genre": "Folk"
   },
   {
     "name": "SomaFM Indie Pop Rocks! (128k AAC)",
     "url": "https://ice6.somafm.com/indiepop-128-aac",
-    "genre": "College Indie"
+    "genre": "Alternative/Pop"
   },
   {
     "name": "SomaFM PopTron (128k MP3)",
     "url": "https://ice2.somafm.com/poptron-128-mp3",
-    "genre": "College Indie"
+    "genre": "Pop"
   },
   {
-    "name": "SRo4 RÃ¡dio FM",
+    "name": "SRo4 Rádio FM",
     "url": "http://live.slovakradio.sk:8000/FM_256.mp3",
-    "genre": "College Indie"
+    "genre": "Alternative Rock"
   },
   {
     "name": "The Independent FM",
     "url": "https://listen.radioking.com/radio/293701/stream/340084",
-    "genre": "College Indie"
+    "genre": "Alternative Rock"
   },
   {
-    "name": "Tilos RÃ¡diÃ³",
+    "name": "Tilos Rádió",
     "url": "http://stream.tilos.hu/tilos",
-    "genre": "College Indie"
+    "genre": "Eclectic"
   },
   {
     "name": "TMM 1",
     "url": "https://listen-msmn.sharp-stream.com/nme1.mp3",
-    "genre": "College Indie"
+    "genre": "Alternative Rock"
   },
   {
     "name": "Ultra Dark Radio",
     "url": "http://stream.laut.fm/ultradarkradio",
-    "genre": "College Indie"
+    "genre": "Gothic Rock"
   },
   {
     "name": "- 0 N - Gothic on Radio",
     "url": "https://0n-gothic.radionetz.de/0n-gothic.mp3",
-    "genre": "Punk/Surf/Hardcore"
+    "genre": "Gothic Rock"
   },
   {
     "name": "BadRock Hard & Heavy",
     "url": "https://play-radio0.jump.bg:7049/live",
-    "genre": "Punk/Surf/Hardcore"
+    "genre": "Hard Rock"
   },
   {
     "name": "Bob's Ska Radio",
     "url": "http://51.255.235.165:5528/stream",
-    "genre": "Punk/Surf/Hardcore"
+    "genre": "Ska"
   },
   {
     "name": "CORE Radio!",
@@ -1642,17 +1607,17 @@
   {
     "name": "DARK ZERO RADIO",
     "url": "http://stream.laut.fm/darkzeroradio",
-    "genre": "Punk/Surf/Hardcore"
+    "genre": "Gothic Rock"
   },
   {
     "name": "Exclusively Green Day",
     "url": "https://nl4.mystreaming.net/er/greenday/icecast.audio",
-    "genre": "Punk/Surf/Hardcore"
+    "genre": "Punk Rock"
   },
   {
     "name": "Exclusively Ramones",
     "url": "https://nl4.mystreaming.net/er/ramones/icecast.audio",
-    "genre": "Punk/Surf/Hardcore"
+    "genre": "Punk Rock"
   },
   {
     "name": "Guerrilla Radio",
@@ -1662,12 +1627,12 @@
   {
     "name": "Happy Hardcore",
     "url": "https://audio-edge-3mayu.fra.h.radiomast.io/73055724-1141-41e2-a69b-24a6ca96c8e7",
-    "genre": "Punk/Surf/Hardcore"
+    "genre": "Hard Dance"
   },
   {
     "name": "HappyHardcore.com",
     "url": "https://www.happyhardcore.com/livestreams/p/u9/",
-    "genre": "Punk/Surf/Hardcore"
+    "genre": "Hard Dance"
   },
   {
     "name": "Hardcore Radio",
@@ -1677,22 +1642,17 @@
   {
     "name": "Hardstyle and Hardcore",
     "url": "http://stream.laut.fm/hardstyle-and-hardcore",
-    "genre": "Punk/Surf/Hardcore"
+    "genre": "Hard Dance"
   },
   {
     "name": "Kniteforce Radio",
     "url": "https://kniteforce.out.airtime.pro/kniteforce_a",
-    "genre": "Punk/Surf/Hardcore"
-  },
-  {
-    "name": "NEU RADIO",
-    "url": "https://nr9.newradio.it/proxy/ebaruffa?mp=/stream",
-    "genre": "Punk/Surf/Hardcore"
+    "genre": "Hard Dance"
   },
   {
     "name": "Q-Dance Radio",
     "url": "https://playerservices.streamtheworld.com/api/livestream-redirect/Q_DANCE.mp3",
-    "genre": "Punk/Surf/Hardcore"
+    "genre": "Hard Dance"
   },
   {
     "name": "Radio Blackout",
@@ -1707,17 +1667,17 @@
   {
     "name": "Radio Caprice - Cyberpunk",
     "url": "http://79.120.12.130:8004/cyberpunk",
-    "genre": "Punk/Surf/Hardcore"
+    "genre": "Synthwave"
   },
   {
     "name": "Radio Record Hardstyle",
     "url": "https://radiorecord.hostingradio.ru/teo96.aacp",
-    "genre": "Punk/Surf/Hardcore"
+    "genre": "Hard Dance"
   },
   {
     "name": "RauteMusik Happy Hardcore",
     "url": "http://happyhardcore-high.rautemusik.fm/",
-    "genre": "Punk/Surf/Hardcore"
+    "genre": "Hard Dance"
   },
   {
     "name": "REAL PUNK RADIO",
@@ -1732,12 +1692,12 @@
   {
     "name": "SomaFM Metal Detector (128k AAC)",
     "url": "https://ice4.somafm.com/metal-128-aac",
-    "genre": "Punk/Surf/Hardcore"
+    "genre": "Metal"
   },
   {
     "name": "TechnoBase.FM",
     "url": "http://lw2.mp3.tb-group.fm/tb.mp3",
-    "genre": "Punk/Surf/Hardcore"
+    "genre": "Techno"
   },
   {
     "name": "Teenage Kicks Radio",
@@ -1747,17 +1707,17 @@
   {
     "name": "Weymouth Rocks (Medium Bitrate)",
     "url": "http://cast1.asurahosting.com:8621/med",
-    "genre": "Punk/Surf/Hardcore"
+    "genre": "Rock"
   },
   {
-    "name": "ÐÐ°ÑÐµ Ð Ð°Ð´Ð¸Ð¾ ÐÐ°Ð½ÐºÐ¸-Ð¥ÐÐ!",
+    "name": "Наше Радио Панки-ХОЙ!",
     "url": "http://nashe1.hostingradio.ru/nashepunks.mp3",
     "genre": "Punk/Surf/Hardcore"
   },
   {
     "name": "# 100 GREATEST HEAVY METAL",
     "url": "https://cast1.torontocast.com:4660/stream",
-    "genre": "Extreme Music"
+    "genre": "Metal"
   },
   {
     "name": "beatdownx",
@@ -1767,17 +1727,17 @@
   {
     "name": "Best Of Rock.FM Metallica (mp3-256)",
     "url": "https://bestofrockfm.stream.vip/metallica/mp3-256/bestofrock.fm/",
-    "genre": "Extreme Music"
+    "genre": "Metal"
   },
   {
     "name": "ChroniX Radio Metalcore",
     "url": "http://usa17.fastcast4u.com:5508/stream",
-    "genre": "Extreme Music"
+    "genre": "Metalcore"
   },
   {
     "name": "core-mix",
     "url": "http://stream.laut.fm/core-mix",
-    "genre": "Extreme Music"
+    "genre": "Metalcore"
   },
   {
     "name": "DrGnu - Death Metal",
@@ -1792,7 +1752,7 @@
   {
     "name": "DrGnu - Prog Rock Classics",
     "url": "http://streams.radiobob.de/progrock/mp3-192/mediaplayer/",
-    "genre": "Extreme Music"
+    "genre": "Progressive Rock"
   },
   {
     "name": "laut.fm - Dark Sound United",
@@ -1882,7 +1842,7 @@
   {
     "name": "Rock FM 105.5",
     "url": "https://securestream.us/radio/8050/radio.mp3",
-    "genre": "Extreme Music"
+    "genre": "Rock"
   },
   {
     "name": "SomaFM Metal Detector (32k AAC)",
@@ -1892,7 +1852,7 @@
   {
     "name": "The Voice Of Doom",
     "url": "https://streaming.galaxywebsolutions.com:9046/stream",
-    "genre": "Extreme Music"
+    "genre": "Doom Metal"
   },
   {
     "name": "Thrashking Radio",

--- a/Tests/NullPlayerTests/RadioDefaultStationCatalogTests.swift
+++ b/Tests/NullPlayerTests/RadioDefaultStationCatalogTests.swift
@@ -1,0 +1,123 @@
+import XCTest
+@testable import NullPlayer
+
+final class RadioDefaultStationCatalogTests: XCTestCase {
+
+    private struct DefaultStationSeed: Decodable {
+        let name: String
+        let url: String
+        let genre: String?
+        let iconURL: String?
+    }
+
+    private func defaultStationsFileURL() -> URL {
+        let testFileURL = URL(fileURLWithPath: #filePath)
+        let repoRoot = testFileURL
+            .deletingLastPathComponent()
+            .deletingLastPathComponent()
+            .deletingLastPathComponent()
+        return repoRoot.appendingPathComponent("Sources/NullPlayer/Resources/Radio/default_stations.json")
+    }
+
+    private func loadSeeds() throws -> [DefaultStationSeed] {
+        let data = try Data(contentsOf: defaultStationsFileURL())
+        return try JSONDecoder().decode([DefaultStationSeed].self, from: data)
+    }
+
+    func testDefaultStationsCatalogDecodesAndHasRequiredFields() throws {
+        let seeds = try loadSeeds()
+        XCTAssertFalse(seeds.isEmpty)
+
+        for seed in seeds {
+            XCTAssertFalse(seed.name.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty)
+            XCTAssertFalse(seed.url.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty)
+            XCTAssertNotNil(URL(string: seed.url))
+            XCTAssertFalse((seed.genre ?? "").trimmingCharacters(in: .whitespacesAndNewlines).isEmpty)
+            if let iconURL = seed.iconURL, !iconURL.isEmpty {
+                XCTAssertNotNil(URL(string: iconURL))
+            }
+        }
+    }
+
+    func testDefaultStationsCatalogURLsAreUnique() throws {
+        let seeds = try loadSeeds()
+        let urls = seeds.map(\.url)
+        XCTAssertEqual(Set(urls).count, urls.count)
+    }
+
+    func testDefaultStationsCatalogHasNoMojibakeNames() throws {
+        let seeds = try loadSeeds()
+        let mojibakePattern = try XCTUnwrap(NSRegularExpression(pattern: "Ã|Å|Ð|Ñ"))
+        let offenders = seeds.filter { seed in
+            let range = NSRange(location: 0, length: seed.name.utf16.count)
+            return mojibakePattern.firstMatch(in: seed.name, options: [], range: range) != nil
+        }
+        XCTAssertTrue(offenders.isEmpty, "Found mojibake station names: \(offenders.map(\.name))")
+    }
+
+    func testNatureSoundsBucketRejectsOffGenreSignals() throws {
+        let seeds = try loadSeeds().filter { $0.genre == "Nature Sounds" }
+        let bannedSignals = [
+            "rock",
+            "metal",
+            "wacken",
+            "gothic",
+            "punk",
+            "hiphop",
+            "news",
+            "workout",
+            "radiobob.de",
+            "radioroks",
+            "hitfm.ua",
+            "radioplayer.ua/radionews"
+        ]
+
+        let offenders = seeds.filter { seed in
+            let text = "\(seed.name) \(seed.url)".lowercased()
+            return bannedSignals.contains(where: text.contains)
+        }
+
+        XCTAssertTrue(offenders.isEmpty, "Nature Sounds contains off-genre stations: \(offenders.map(\.name))")
+    }
+
+    func testDefaultGenreMigrationUpdatesOnlyKnownLegacyGenreForMatchingURL() {
+        let stationURL = URL(string: "https://ice5.somafm.com/bossa-128-mp3")!
+
+        XCTAssertEqual(
+            RadioManager.correctedDefaultGenre(for: stationURL, currentGenre: "Classical"),
+            "Bossa Nova"
+        )
+        XCTAssertNil(
+            RadioManager.correctedDefaultGenre(for: stationURL, currentGenre: "Custom Genre")
+        )
+        XCTAssertNil(
+            RadioManager.correctedDefaultGenre(
+                for: URL(string: "https://example.com/not-in-defaults.mp3")!,
+                currentGenre: "Classical"
+            )
+        )
+    }
+
+    func testApplyingDefaultGenreCorrectionsKeepsStationCountAndDoesNotDeleteRemovedDefaults() {
+        let migratedStation = RadioStation(
+            id: UUID(uuidString: "11111111-1111-1111-1111-111111111111")!,
+            name: "SomaFM Bossa Beyond",
+            url: URL(string: "https://ice5.somafm.com/bossa-128-mp3")!,
+            genre: "Classical"
+        )
+        let removedDefaultStation = RadioStation(
+            id: UUID(uuidString: "22222222-2222-2222-2222-222222222222")!,
+            name: "Radio Dreamland",
+            url: URL(string: "https://dreamsiteradiocp3.com/proxy/dreamland?mp=/stream")!,
+            genre: "Nature Sounds"
+        )
+
+        let input = [migratedStation, removedDefaultStation]
+        let result = RadioManager.applyingDefaultGenreCorrections(to: input)
+
+        XCTAssertEqual(result.stations.count, input.count)
+        XCTAssertEqual(result.changedCount, 1)
+        XCTAssertEqual(result.stations[0].genre, "Bossa Nova")
+        XCTAssertEqual(result.stations[1], removedDefaultStation)
+    }
+}

--- a/Tests/NullPlayerTests/RadioDefaultStationCatalogTests.swift
+++ b/Tests/NullPlayerTests/RadioDefaultStationCatalogTests.swift
@@ -120,4 +120,60 @@ final class RadioDefaultStationCatalogTests: XCTestCase {
         XCTAssertEqual(result.stations[0].genre, "Bossa Nova")
         XCTAssertEqual(result.stations[1], removedDefaultStation)
     }
+
+    func testApplyingDefaultURLCorrectionsMigratesLegacyAudiophilePrimaryToCanonicalSecondary() {
+        let legacyAudiophileStation = RadioStation(
+            id: UUID(uuidString: "33333333-3333-3333-3333-333333333333")!,
+            name: "Distorsion FM",
+            url: URL(string: "https://radioemisoras.cl/distorsion.flac")!,
+            genre: "Rock"
+        )
+        let alreadyCanonicalStation = RadioStation(
+            id: UUID(uuidString: "44444444-4444-4444-4444-444444444444")!,
+            name: "Distorsion FM",
+            url: URL(string: "https://radioemisoras.cl/distorsion.mp3")!,
+            genre: "Rock"
+        )
+        let unrelatedNameWithLegacyURL = RadioStation(
+            id: UUID(uuidString: "55555555-5555-5555-5555-555555555555")!,
+            name: "Custom Distorsion Clone",
+            url: URL(string: "https://radioemisoras.cl/distorsion.flac")!,
+            genre: "Rock"
+        )
+
+        let input = [legacyAudiophileStation, alreadyCanonicalStation, unrelatedNameWithLegacyURL]
+        let result = RadioManager.applyingDefaultURLCorrections(to: input)
+
+        XCTAssertEqual(result.stations.count, input.count)
+        XCTAssertEqual(result.changedCount, 1)
+        XCTAssertEqual(result.stations[0].url.absoluteString, "https://radioemisoras.cl/distorsion.mp3")
+        XCTAssertEqual(result.stations[1], alreadyCanonicalStation)
+        XCTAssertEqual(result.stations[2], unrelatedNameWithLegacyURL)
+    }
+
+    func testApplyingDefaultURLCorrectionsRemovesKnownBrokenDefaults() {
+        let removedRockFlac = RadioStation(
+            id: UUID(uuidString: "66666666-6666-6666-6666-666666666666")!,
+            name: "Radio Paradise Rock Mix FLAC",
+            url: URL(string: "https://stream.radioparadise.com/rock-flac")!,
+            genre: "Rock"
+        )
+        let removedBluesFlac = RadioStation(
+            id: UUID(uuidString: "77777777-7777-7777-7777-777777777777")!,
+            name: "Radio Blues Flac",
+            url: URL(string: "https://audio-edge-cmc51.fra.h.radiomast.io/radioblues-flac")!,
+            genre: "Blues"
+        )
+        let keeper = RadioStation(
+            id: UUID(uuidString: "88888888-8888-8888-8888-888888888888")!,
+            name: "Example Keeper",
+            url: URL(string: "https://example.com/stream.mp3")!,
+            genre: "Eclectic"
+        )
+
+        let result = RadioManager.applyingDefaultURLCorrections(to: [removedRockFlac, removedBluesFlac, keeper])
+
+        XCTAssertEqual(result.changedCount, 2)
+        XCTAssertEqual(result.stations, [keeper])
+    }
 }


### PR DESCRIPTION
- **Make modern window opacity skin-configurable and add glass skins**
- **Default hide title bars to enabled**
- **Fix modern HT startup sizing and isolate runtime UI state**
- **Rename glass skins and add SeaGlass modern skin**
- **Group source radio histories under one Radio History menu**
- **Add full SomaFM defaults and auto-merge for existing users**
- **Expand radio defaults and fix metadata/playlist resolution**
- **Add radio station ratings DB and radio genre alignment**
- **Fix windows docking too eagerly by tightening dockThreshold to 2px**
- **Fix docked window shift on undock and wire sthanks in About dialog**
- **Change 2X to XL mode at 1.5x scale and reorder state buttons**
- **Expand bundled radio catalog with regional and jazz stations**
- **Fix volume slider not updating on arrow key in modern UI**
- **Add Internet Radio folder organization across browsers**
- **Implement per-corner sharpness based on window alignment**
- **docs: update radio docs and README for latest features**
- **Fix spectrum fullscreen behavior and reduce JWST/Lightning intensity**
- **Prevent hidden spectrum analyzer from restarting render loop**
- **Reduce CPU/GPU usage across spectrum modes and window dragging**
- **docs: update visualizations skill and CLAUDE.md for CPU/GPU fixes**
- **Refactor internet radio to unified expandable folder tree**
- **Fix modern docked border rendering for offset windows**
- **Tune seamless docked seam suppression to remove gaps**
- **Fix dark interior seam by isolating full-seam border clearing**
- **Rework modern EQ preset buttons: stretch layout, force-enable, per-band reset**
- **docs: update EQ documentation for modern UI preset buttons and controls**
- **Add skin-driven area opacity controls for modern UI**
- **Fix HT stack sizing and dock seam darkness**
- **Add verified Boston and scanner radio defaults**
- **Commit uncommitted AppDelegate changes**
- **Add smart radio folder reassignment and Cambridge region fix**
- **Add internet radio station artwork loading in library browsers**
- **Update app tagline copy**
- **Unify library sorting and add natural numeric ordering**
- **Commit all pending changes**
- **Classic UI: restore skinned playlist/EQ titlebars**
- **Adjust classic large UI scaling**
- **Add Snow spectrum visualization mode**
- **Update docs for Snow visualization mode**
- **Enable classic art-view ratings for all playable sources**
- **Adjust classic library bar edge padding**
- **Document classic library picker behavior**
- **fix(classic-ui): add source-radio parity with modern and F5 refresh coverage**
- **Improve Jellyfin loading resilience and document large-library behavior**
- **perf: reduce idle CPU from animation, debug console, and spectrum renderer**
- **security: harden credential storage and reduce attack surface**
- **Fix glass skin darkening/seams and document in skill guide**
- **fix: auto-detect signed bundle to suppress dev Keychain prompts**
- **Add modern text-only opacity control for glass skins**
- **Finalize modern glass text opacity behavior and skin defaults**
- **Fix modern text opacity isolation and update skinning docs**
- **fix: relaunchApp() now survives parent process exit**
- **Fix local multi-remove hangs and add scoped local library clear actions**
- **fix: eliminate Keychain prompts on relaunch by using data-protection keychain**
- **Add vis_classic exact mode integration, scoped profiles, and docs**
- **Add BananaParty skin resources**
- **Add main-window spectrum opacity override and update glass skins/docs**
- **fix: share keychain credentials between dev build and installed app**
- **fix: always use data-protection keychain, remove signing guard**
- **fix: use UserDefaults for dev builds, keychain only for app bundle**
- **fix: revert build_dmg.sh entitlements signing - broke DMG keychain access**
- **revert: undo keychain changes that broke Navidrome/Jellyfin/Emby auth**
- **fix: use login keychain with permissive ACL for ad-hoc signed DMG builds**
- **docs: document KeychainHelper login-keychain + permissive ACL approach**
- **Revert "docs: document KeychainHelper login-keychain + permissive ACL approach"**
- **docs: note login keychain + permissive ACL requirement in integration skills**
- **Fix radio-to-local playback handoff in AudioEngine**
- **Fix cast handoff playback pipeline mismatch**
- **Fix artist date/year sorting across library sources**
- **Add skin visualization defaults, mappings, and vis_classic skill docs**
- **Set classic skin default vis_classic profile to Purple Neon**
- **Port modern date sorting behavior to classic library browser**
- **Fix streaming crossfade deadlock between timer and AVAudioEngine.stop()**
- **Add missing replace-queue actions in classic library menus**
- **Classic UI: shift Lib field left when ratings are visible**
- **Add local album/artist rating support in Classic library UI**
- **Fix classic center-stack restore gaps and add tests**
- **Library art mode: single-click rates, double-click cycles artwork**
- **Add Get More Skins link to Classic UI menu**
- **Fix AVAudioEngine deadlock, CPU hotpath, and misc improvements**
- **Fix classic library browser: remove transparent server bar, fix white text rendering**
- **Stabilize modern edge occlusion during drag-group moves**
- **Fix SKINNING.md: mark window.opacity as optional with default 1.0**
- **Fix vis_classic transparency behavior across main and spectrum windows**
- **skin: fruity neon text colors for BananaParty**
- **Finalize vis_classic transparency fixes and document scoped behavior**
- **Replace Modern UI HT button with SK skins menu**
- **Add modern .nsz skin bundle format and sample skin**
- **fix: reset local crossfade state**
- **Tune Punch spectrum mode and document skin config**
- **Add menu bar global menus with dynamic refresh and Sonos toolbar parity**
- **Add dockable waveform window**
- **Fix waveform center stack behavior**
- **Add waveform button to modern main window**
- **Update docs for waveform main-window button**
- **Add licensing notices, provenance doc, and DMG notice gate**
- **Add skin-configurable visClassic transparency opacity**
- **Add waveform transparency modes**
- **Tighten classic center stack gaps at runtime**
- **Add radio metadata search and click-to-play search results**
- **Implement streaming playlist recovery after idle**
- **Harden library source switching against stale async loads**
- **Add watch folder manager and cleanup-aware rescans**
- **Fix cast handoff deadlock from waveform observer delivery**
- **README: sync with main**
- **README: sync with origin/main**
- **Fix transparent waveform click-through while loading**
- **Move default radio stations to bundled JSON**
- **Persist imported skins for future selection**
- **Fix default radio genres and add safe migration**
- **Fix radio catalog playback defaults and improve channel grouping**


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added channel-based organization for Internet Radio stations for improved browsing.
  * Expanded default station catalog with new entries across diverse genres.

* **Bug Fixes**
  * Corrected station genre classifications and names for better categorization.
  * Fixed encoding issues in station names.
  * Migrated legacy station URLs to canonical defaults.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->