### PR TITLE
Feat: replace distance-based undock with hold-duration drag rules

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,14 @@
 # Changelog
 
+## 0.17.3
+
+### Window System
+
+- **Hold-to-group drag** — windows now use a time-based drag model instead of a distance threshold. A quick drag (< 400 ms hold) separates the grabbed window from its group; a longer hold (≥ 400 ms) moves all connected windows together.
+- **Drag group preview** — connected peer windows show a subtle highlight overlay at mouseDown so it's clear which windows will move as a group before the drag begins.
+- **Group screen-edge clamping** — when dragging a connected group, the entire group is clamped so no window is pushed off-screen at the top of the display.
+- **ProjectM suspend during drag** — ProjectM rendering is suspended for the duration of a window drag to prevent WindowServer stalls on Apple Silicon.
+
 ## 0.17.2
 
 ### Waveform

--- a/Sources/NullPlayer/App/WindowManager.swift
+++ b/Sources/NullPlayer/App/WindowManager.swift
@@ -2351,13 +2351,15 @@ class WindowManager {
         draggingWindow = window
         dragStartOrigin = window.frame.origin
         isTitleBarDrag = fromTitleBar
+        holdStartTime = CACurrentMediaTime()
+        dragMode = .pending
 
         // Find all windows that are docked to this window
         dockedWindowsToMove = findDockedWindows(to: window)
-        
-        // Store relative offsets from dragging window's origin
-        // This ensures we maintain exact relative positions during fast movement
+
+        // Store relative offsets from dragging window's origin (prevents drift during fast movement)
         dockedWindowOffsets.removeAll()
+        dockedWindowOriginalOrigins.removeAll()
         let dragOrigin = window.frame.origin
         for dockedWindow in dockedWindowsToMove {
             let offset = NSPoint(
@@ -2365,12 +2367,13 @@ class WindowManager {
                 y: dockedWindow.frame.origin.y - dragOrigin.y
             )
             dockedWindowOffsets[ObjectIdentifier(dockedWindow)] = offset
+            dockedWindowOriginalOrigins[ObjectIdentifier(dockedWindow)] = dockedWindow.frame.origin
         }
 
-        // Also store absolute origins so we can restore positions if the window undocks
-        dockedWindowOriginalOrigins.removeAll()
-        for dockedWindow in dockedWindowsToMove {
-            dockedWindowOriginalOrigins[ObjectIdentifier(dockedWindow)] = dockedWindow.frame.origin
+        // Highlight connected peers so user can see which windows would move together
+        if !dockedWindowsToMove.isEmpty {
+            postConnectedWindowHighlight(Set(dockedWindowsToMove))
+            highlightWasPosted = true
         }
     }
     
@@ -2380,6 +2383,12 @@ class WindowManager {
         dockedWindowsToMove.removeAll()
         dockedWindowOffsets.removeAll()
         dockedWindowOriginalOrigins.removeAll()
+        holdStartTime = nil
+        dragMode = .pending
+        if highlightWasPosted {
+            postConnectedWindowHighlight([])
+            highlightWasPosted = false
+        }
         _ = tightenClassicCenterStackIfNeeded()
         postLayoutChangeNotification()
         updateDockedChildWindows()
@@ -2416,16 +2425,19 @@ class WindowManager {
         // If this is a new drag, find docked windows
         if draggingWindow !== window {
             windowWillStartDragging(window)
+            dragMode = .group  // mid-flight detection: hold measurement unavailable, default to group
         }
-        
-        // Check if we should undock (break free from the group)
-        // Only non-main windows can undock when dragged by title bar
-        // Main window ALWAYS moves the entire docked group - it never detaches
-        let isMainWindow = window === mainWindowController?.window
-        if !isMainWindow && isTitleBarDrag && !dockedWindowsToMove.isEmpty {
-            let dragDistance = hypot(newOrigin.x - dragStartOrigin.x, newOrigin.y - dragStartOrigin.y)
-            if dragDistance > undockThreshold {
-                // Restore co-moved windows to their original positions before breaking the dock
+
+        // NEW — determine mode on first drag movement
+        if dragMode == .pending {
+            let mode = WindowManager.determineDragMode(
+                holdStart: holdStartTime,
+                currentTime: CACurrentMediaTime(),
+                threshold: holdThreshold
+            )
+            dragMode = mode
+            if mode == .separate {
+                // Restore peers to their pre-drag positions before breaking the dock
                 isMovingDockedWindows = true
                 for dockedWindow in dockedWindowsToMove {
                     if let origin = dockedWindowOriginalOrigins[ObjectIdentifier(dockedWindow)] {
@@ -2436,6 +2448,10 @@ class WindowManager {
                 dockedWindowsToMove.removeAll()
                 dockedWindowOffsets.removeAll()
                 dockedWindowOriginalOrigins.removeAll()
+                if highlightWasPosted {
+                    postConnectedWindowHighlight([])
+                    highlightWasPosted = false
+                }
             }
         }
         
@@ -2804,6 +2820,16 @@ class WindowManager {
         edgeOcclusionSegmentsCache.removeAll(keepingCapacity: true)
         sharpCornersCache.removeAll(keepingCapacity: true)
         NotificationCenter.default.post(name: .windowLayoutDidChange, object: nil)
+    }
+
+    /// Post a connectedWindowHighlightDidChange notification.
+    /// - Parameter windows: The windows to highlight. Pass an empty set to clear all highlights.
+    private func postConnectedWindowHighlight(_ windows: Set<NSWindow>) {
+        NotificationCenter.default.post(
+            name: .connectedWindowHighlightDidChange,
+            object: nil,
+            userInfo: ["highlightedWindows": windows]
+        )
     }
 
     /// Compute joined edge intervals in window-local coordinates for modern seamless border rendering.

--- a/Sources/NullPlayer/App/WindowManager.swift
+++ b/Sources/NullPlayer/App/WindowManager.swift
@@ -2435,7 +2435,9 @@ class WindowManager {
         // If this is a new drag, find docked windows
         if draggingWindow !== window {
             windowWillStartDragging(window)
-            dragMode = .group  // mid-flight detection: hold measurement unavailable, default to group
+            // windowWillStartDragging sets holdStartTime to now, so determineDragMode would see
+            // elapsed ≈ 0 → .separate. Override to .group: mid-flight drag is always group move.
+            dragMode = .group
         }
 
         // NEW — determine mode on first drag movement

--- a/Sources/NullPlayer/App/WindowManager.swift
+++ b/Sources/NullPlayer/App/WindowManager.swift
@@ -2419,8 +2419,10 @@ class WindowManager {
             return newOrigin
         }
         
-        // Ignore if this is a docked window being moved programmatically
-        if isMovingDockedWindows && dockedWindowsToMove.contains(where: { $0 === window }) {
+        // Ignore all window movement while we're programmatically repositioning docked windows.
+        // This covers both the docked windows themselves and windows AppKit moves automatically
+        // as child windows of a docked window (e.g. the dragging window is a child of main).
+        if isMovingDockedWindows {
             return newOrigin
         }
 
@@ -2768,7 +2770,24 @@ class WindowManager {
         if let vSnap = bestVerticalSnap {
             snappedY = round(vSnap.value)
         }
-        
+
+        // Hard-clamp to screen top: macOS enforces this on setFrameOrigin to keep the
+        // title bar visible. If we don't clamp first, the main window ends up at a
+        // different Y than the docked windows we already repositioned → they detach.
+        // Also clamp so that docked windows above the dragging window don't go off-screen:
+        // when a lower window is dragged upward, its docked peers above (positive Y offset)
+        // get placed at snappedY + offset.y and can exceed the screen top.
+        if let screen = window.screen ?? NSScreen.main {
+            var maxAllowedY = screen.visibleFrame.maxY - frame.height
+            for dockedWindow in dockedWindowsToMove {
+                if let offset = dockedWindowOffsets[ObjectIdentifier(dockedWindow)], offset.y > 0 {
+                    let clampForDocked = screen.visibleFrame.maxY - offset.y - dockedWindow.frame.height
+                    maxAllowedY = min(maxAllowedY, clampForDocked)
+                }
+            }
+            snappedY = min(snappedY, maxAllowedY)
+        }
+
         return NSPoint(x: snappedX, y: snappedY)
     }
     

--- a/Sources/NullPlayer/App/WindowManager.swift
+++ b/Sources/NullPlayer/App/WindowManager.swift
@@ -6,6 +6,7 @@ extension Notification.Name {
     static let timeDisplayModeDidChange = Notification.Name("timeDisplayModeDidChange")
     static let doubleSizeDidChange = Notification.Name("doubleSizeDidChange")
     static let windowLayoutDidChange = Notification.Name("windowLayoutDidChange")
+    static let connectedWindowHighlightDidChange = Notification.Name("connectedWindowHighlightDidChange")
 }
 
 // MARK: - Time Display Mode
@@ -13,6 +14,13 @@ extension Notification.Name {
 enum TimeDisplayMode: String {
     case elapsed
     case remaining
+}
+
+/// Determines how a window drag affects its connected group.
+enum DragMode {
+    case pending   // mouseDown received, drag not yet started
+    case separate  // drag started before holdThreshold — window moves alone
+    case group     // holdThreshold elapsed before drag — connected windows move together
 }
 
 /// Joined edge intervals for seamless modern window border suppression.
@@ -310,8 +318,17 @@ class WindowManager {
     /// Should be small (≤2) so only truly touching windows are grouped
     private let dockThreshold: CGFloat = 2
     
-    /// Undock threshold - how far you need to drag a window to break it free from the group
-    private let undockThreshold: CGFloat = 10
+    /// Hold threshold - how long (seconds) before a drag moves the connected group
+    private let holdThreshold: TimeInterval = 0.4
+
+    /// Time when current drag's mouseDown was received
+    private var holdStartTime: CFTimeInterval?
+
+    /// Current drag mode, determined on first windowWillMove call
+    private var dragMode: DragMode = .pending
+
+    /// Whether a connectedWindowHighlightDidChange notification was posted for this drag
+    private var highlightWasPosted = false
     
     /// Track which window is currently being dragged
     private var draggingWindow: NSWindow?

--- a/Sources/NullPlayer/App/WindowManager.swift
+++ b/Sources/NullPlayer/App/WindowManager.swift
@@ -378,6 +378,14 @@ class WindowManager {
         
         // Load default skin
         loadDefaultSkin()
+
+        // Clean up drag state if a window closes mid-drag
+        NotificationCenter.default.addObserver(
+            self,
+            selector: #selector(handleWindowWillClose(_:)),
+            name: NSWindow.willCloseNotification,
+            object: nil
+        )
     }
     
     /// Register default preference values
@@ -2373,6 +2381,12 @@ class WindowManager {
         }
     }
     
+    @objc private func handleWindowWillClose(_ notification: Notification) {
+        guard let closingWindow = notification.object as? NSWindow,
+              closingWindow === draggingWindow else { return }
+        windowDidFinishDragging(closingWindow)
+    }
+
     /// Called when a window drag ends
     func windowDidFinishDragging(_ window: NSWindow) {
         draggingWindow = nil

--- a/Sources/NullPlayer/App/WindowManager.swift
+++ b/Sources/NullPlayer/App/WindowManager.swift
@@ -7,6 +7,8 @@ extension Notification.Name {
     static let doubleSizeDidChange = Notification.Name("doubleSizeDidChange")
     static let windowLayoutDidChange = Notification.Name("windowLayoutDidChange")
     static let connectedWindowHighlightDidChange = Notification.Name("connectedWindowHighlightDidChange")
+    static let windowDragDidBegin = Notification.Name("windowDragDidBegin")
+    static let windowDragDidEnd = Notification.Name("windowDragDidEnd")
 }
 
 // MARK: - Time Display Mode
@@ -2379,6 +2381,7 @@ class WindowManager {
             postConnectedWindowHighlight(Set(dockedWindowsToMove))
             highlightWasPosted = true
         }
+        NotificationCenter.default.post(name: .windowDragDidBegin, object: nil)
     }
     
     @objc private func handleWindowWillClose(_ notification: Notification) {
@@ -2399,6 +2402,7 @@ class WindowManager {
             postConnectedWindowHighlight([])
             highlightWasPosted = false
         }
+        NotificationCenter.default.post(name: .windowDragDidEnd, object: nil)
         _ = tightenClassicCenterStackIfNeeded()
         postLayoutChangeNotification()
         updateDockedChildWindows()

--- a/Sources/NullPlayer/App/WindowManager.swift
+++ b/Sources/NullPlayer/App/WindowManager.swift
@@ -333,10 +333,7 @@ class WindowManager {
     /// Track which window is currently being dragged
     private var draggingWindow: NSWindow?
     
-    /// Track original position at drag start for undock detection
-    private var dragStartOrigin: NSPoint = .zero
-    
-    /// Track if current drag is from title bar (only title bar drags can undock)
+    /// Track if current drag is from title bar (retained for context; does not gate separation logic)
     private var isTitleBarDrag = false
     
     /// Track the last drag delta for grouped movement
@@ -349,7 +346,7 @@ class WindowManager {
     /// This prevents drift during fast movement by maintaining exact relative positions
     private var dockedWindowOffsets: [ObjectIdentifier: NSPoint] = [:]
 
-    /// Store absolute origins of docked windows at drag start, for position restoration on undock
+    /// Store absolute origins of docked windows at drag start, for position restoration on separation
     private var dockedWindowOriginalOrigins: [ObjectIdentifier: NSPoint] = [:]
     
     /// Flag to prevent feedback loop when moving docked windows programmatically
@@ -2346,10 +2343,9 @@ class WindowManager {
     /// Called when a window drag begins
     /// - Parameters:
     ///   - window: The window being dragged
-    ///   - fromTitleBar: If true, this drag can undock the window from its group
+    ///   - fromTitleBar: Whether the drag originated from the title bar (recorded for reference)
     func windowWillStartDragging(_ window: NSWindow, fromTitleBar: Bool = false) {
         draggingWindow = window
-        dragStartOrigin = window.frame.origin
         isTitleBarDrag = fromTitleBar
         holdStartTime = CACurrentMediaTime()
         dragMode = .pending

--- a/Sources/NullPlayer/App/WindowManager.swift
+++ b/Sources/NullPlayer/App/WindowManager.swift
@@ -2327,7 +2327,22 @@ class WindowManager {
     }
     
     // MARK: - Window Snapping & Docking
-    
+
+    /// Pure timing function: determines drag mode from hold duration.
+    /// - Parameters:
+    ///   - holdStart: The CACurrentMediaTime() value captured at mouseDown, or nil if unavailable.
+    ///   - currentTime: The current CACurrentMediaTime() value.
+    ///   - threshold: The hold duration threshold in seconds.
+    /// - Returns: `.separate` if elapsed time is below threshold; `.group` otherwise.
+    static func determineDragMode(
+        holdStart: CFTimeInterval?,
+        currentTime: CFTimeInterval,
+        threshold: TimeInterval
+    ) -> DragMode {
+        guard let start = holdStart else { return .group }
+        return (currentTime - start) < threshold ? .separate : .group
+    }
+
     /// Called when a window drag begins
     /// - Parameters:
     ///   - window: The window being dragged

--- a/Sources/NullPlayer/Resources/Info.plist
+++ b/Sources/NullPlayer/Resources/Info.plist
@@ -15,7 +15,7 @@
     <key>CFBundleIconFile</key>
     <string>AppIcon</string>
     <key>CFBundleShortVersionString</key>
-    <string>0.17.2</string>
+    <string>0.17.3</string>
     <key>CFBundleVersion</key>
     <string>2</string>
     <key>LSMinimumSystemVersion</key>

--- a/Sources/NullPlayer/Visualization/VisualizationGLView.swift
+++ b/Sources/NullPlayer/Visualization/VisualizationGLView.swift
@@ -66,6 +66,18 @@ class VisualizationGLView: NSOpenGLView {
     /// Idle beat sensitivity (used when audio is not playing for calmer visualization)
     private let idleBeatSensitivity: Float = 0.2
     
+    /// Pending NSOpenGLView surface update (window moved/resized).
+    /// Set on main thread by AppKit via update(); cleared on render thread after openGLContext?.update().
+    /// nonisolated(unsafe): Bool write/read is word-aligned; worst case is a one-frame-late update.
+    private nonisolated(unsafe) var needsSurfaceUpdate = false
+
+    /// Suppresses rendering during window drag to eliminate WindowServer contention.
+    /// Moving an NSOpenGLView window while actively flushing OpenGL frames forces WindowServer
+    /// to synchronize the surface position, stalling the main thread's setFrameOrigin calls.
+    /// Pausing frame production eliminates this contention without stopping the CVDisplayLink.
+    /// nonisolated(unsafe): main thread writes, render thread reads; worst case is one extra frame.
+    private nonisolated(unsafe) var isDragSuspended = false
+
     /// Local copy of PCM data for thread-safe access
     /// Using nonisolated(unsafe) because we manually manage thread safety via dataLock
     private nonisolated(unsafe) var localPCM: [Float] = Array(repeating: 0, count: 512)
@@ -344,11 +356,27 @@ class VisualizationGLView: NSOpenGLView {
         }
         
         CVDisplayLinkSetOutputCallback(displayLink, callback, retainedContext.toOpaque())
-        
+
         // Set the display link to the display of the OpenGL context
         if let cglContext = openGLContext?.cglContextObj,
            let cglPixelFormat = pixelFormat?.cglPixelFormatObj {
             CVDisplayLinkSetCurrentCGDisplayFromOpenGLContext(displayLink, cglContext, cglPixelFormat)
+        }
+
+        // Suspend rendering during window drags to prevent WindowServer stalls.
+        NotificationCenter.default.addObserver(self, selector: #selector(handleWindowDragDidBegin),
+                                               name: .windowDragDidBegin, object: nil)
+        NotificationCenter.default.addObserver(self, selector: #selector(handleWindowDragDidEnd),
+                                               name: .windowDragDidEnd, object: nil)
+    }
+
+    @objc private func handleWindowDragDidBegin() { isDragSuspended = true }
+    @objc private func handleWindowDragDidEnd() {
+        isDragSuspended = false
+        // Apply any deferred surface update now that drag is over.
+        if needsSurfaceUpdate {
+            needsSurfaceUpdate = false
+            openGLContext?.update()
         }
     }
     
@@ -478,6 +506,11 @@ class VisualizationGLView: NSOpenGLView {
     // MARK: - Frame Rendering
     
     private func renderFrame() {
+        // Suspend rendering while a window drag is in progress. Moving an NSOpenGLView
+        // window while the GPU is flushing forces WindowServer to stall on surface
+        // position synchronization, which backs up the main thread's setFrameOrigin calls.
+        guard !isDragSuspended else { return }
+
         // Frame skipping in low power mode: render every other frame (30fps instead of 60fps)
         // This halves CPU usage while still providing smooth visualization
         if isLowPowerMode {
@@ -494,9 +527,8 @@ class VisualizationGLView: NSOpenGLView {
         // Make context current on this thread
         context.makeCurrentContext()
 
-        // Lock focus
-        CGLLockContext(context.cglContextObj!)
-        defer { CGLUnlockContext(context.cglContextObj!) }
+        let cglCtx = context.cglContextObj!
+        CGLLockContext(cglCtx)
 
         // Initialize engine on first render (ensures correct GL context)
         if engineNeedsSetup {
@@ -523,6 +555,20 @@ class VisualizationGLView: NSOpenGLView {
 
         // Swap buffers
         context.flushBuffer()
+
+        // Release CGL lock before the surface update dispatch so main thread never
+        // contends for it inside openGLContext?.update().
+        CGLUnlockContext(cglCtx)
+
+        // Apply pending surface update (window moved/resized) on the main thread.
+        // Must run after releasing CGLLockContext — openGLContext.update() acquires
+        // it internally, and calling it while we hold the lock would deadlock.
+        if needsSurfaceUpdate {
+            needsSurfaceUpdate = false
+            DispatchQueue.main.async { [weak self] in
+                self?.openGLContext?.update()
+            }
+        }
     }
 
     /// Render a frame using the current visualization engine
@@ -623,6 +669,15 @@ class VisualizationGLView: NSOpenGLView {
         // Making GL calls from the main thread while CVDisplayLink is rendering
         // can corrupt OpenGL state and cause projectM crashes (null texture pointer
         // in libprojectM::Renderer::Texture::Empty()).
+    }
+
+    override func update() {
+        // AppKit calls update() on the main thread whenever the window moves or resizes.
+        // The default super.update() acquires CGLLockContext, which the CVDisplayLink
+        // render thread holds during each frame — causing the main thread to stall until
+        // the current frame completes (and vice versa). Instead, just flag the need;
+        // renderFrame() applies the surface update while already holding CGLLockContext.
+        needsSurfaceUpdate = true
     }
     
     // MARK: - Hit Testing

--- a/Sources/NullPlayer/Windows/Equalizer/EQView.swift
+++ b/Sources/NullPlayer/Windows/Equalizer/EQView.swift
@@ -37,6 +37,7 @@ class EQView: NSView {
     
     /// Button being pressed
     private var pressedButton: ButtonType?
+    private var isHighlighted = false
     
     /// Region manager for hit testing
     private let regionManager = RegionManager.shared
@@ -112,9 +113,20 @@ class EQView: NSView {
             name: .audioTrackDidChange,
             object: nil
         )
+        NotificationCenter.default.addObserver(self, selector: #selector(connectedWindowHighlightDidChange(_:)),
+                                               name: .connectedWindowHighlightDidChange, object: nil)
     }
     
     /// Handle track change for Auto EQ
+    @objc private func connectedWindowHighlightDidChange(_ notification: Notification) {
+        let highlighted = notification.userInfo?["highlightedWindows"] as? Set<NSWindow> ?? []
+        let newValue = highlighted.contains { $0 === window }
+        if isHighlighted != newValue {
+            isHighlighted = newValue
+            needsDisplay = true
+        }
+    }
+
     @objc private func handleTrackChange(_ notification: Notification) {
         applyAutoEQForCurrentTrack()
     }
@@ -367,8 +379,13 @@ class EQView: NSView {
         }
         
         context.restoreGState()
+
+        if isHighlighted {
+            NSColor.white.withAlphaComponent(0.15).setFill()
+            bounds.fill()
+        }
     }
-    
+
     /// Draw normal (non-shade) mode
     private func drawNormalMode(renderer: SkinRenderer, context: CGContext, isActive: Bool, drawBounds: NSRect) {
         // Draw EQ background

--- a/Sources/NullPlayer/Windows/MainWindow/MainWindowView.swift
+++ b/Sources/NullPlayer/Windows/MainWindow/MainWindowView.swift
@@ -239,7 +239,9 @@ class MainWindowView: NSView {
         // immediately update main-window skin drawing behind the Metal overlay.
         NotificationCenter.default.addObserver(self, selector: #selector(handleVisClassicProfileCommand(_:)),
                                                name: .visClassicProfileCommand, object: nil)
-        
+        NotificationCenter.default.addObserver(self, selector: #selector(connectedWindowHighlightDidChange(_:)),
+                                               name: .connectedWindowHighlightDidChange, object: nil)
+
     }
     
     // MARK: - Accessibility
@@ -754,6 +756,15 @@ class MainWindowView: NSView {
         needsDisplay = true
     }
 
+    @objc private func connectedWindowHighlightDidChange(_ notification: Notification) {
+        let highlighted = notification.userInfo?["highlightedWindows"] as? Set<NSWindow> ?? []
+        let newValue = highlighted.contains { $0 === window }
+        if isHighlighted != newValue {
+            isHighlighted = newValue
+            needsDisplay = true
+        }
+    }
+
     @objc private func handleVisClassicProfileCommand(_ notification: Notification) {
         guard let userInfo = notification.userInfo,
               let command = userInfo["command"] as? String,
@@ -950,6 +961,11 @@ class MainWindowView: NSView {
         // Draw loading overlay if casting local file
         if isCastingLocalFile {
             drawLoadingOverlay(in: context)
+        }
+
+        if isHighlighted {
+            NSColor.white.withAlphaComponent(0.15).setFill()
+            bounds.fill()
         }
     }
     
@@ -1310,6 +1326,7 @@ class MainWindowView: NSView {
     
     /// Track if we're dragging the window
     private var isDraggingWindow = false
+    private var isHighlighted = false
     private var windowDragStartPoint: NSPoint = .zero
     
     /// Allow clicking even when window is not active

--- a/Sources/NullPlayer/Windows/ModernEQ/ModernEQView.swift
+++ b/Sources/NullPlayer/Windows/ModernEQ/ModernEQView.swift
@@ -63,6 +63,9 @@ class ModernEQView: NSView {
     private var sharpCorners: CACornerMask = [] { didSet { updateCornerMask() } }
     private var edgeOcclusionSegments: EdgeOcclusionSegments = .empty
 
+    /// Highlight state for drag-mode visual feedback
+    private var isHighlighted = false
+
     // MARK: - Layout Constants
     
     private var titleBarHeight: CGFloat {
@@ -173,7 +176,9 @@ class ModernEQView: NSView {
         // Observe track changes for Auto EQ
         NotificationCenter.default.addObserver(self, selector: #selector(handleTrackChange(_:)),
                                                 name: .audioTrackDidChange, object: nil)
-        
+        NotificationCenter.default.addObserver(self, selector: #selector(connectedWindowHighlightDidChange(_:)),
+                                                name: .connectedWindowHighlightDidChange, object: nil)
+
         // Set accessibility
         setAccessibilityIdentifier("modernEqualizerView")
         setAccessibilityRole(.group)
@@ -228,8 +233,17 @@ class ModernEQView: NSView {
         needsDisplay = true
     }
     
+    @objc private func connectedWindowHighlightDidChange(_ notification: Notification) {
+        let highlighted = notification.userInfo?["highlightedWindows"] as? Set<NSWindow> ?? []
+        let newValue = highlighted.contains { $0 === window }
+        if isHighlighted != newValue {
+            isHighlighted = newValue
+            needsDisplay = true
+        }
+    }
+
     // MARK: - Auto EQ
-    
+
     @objc private func handleTrackChange(_ notification: Notification) {
         applyAutoEQForCurrentTrack()
     }
@@ -397,24 +411,29 @@ class ModernEQView: NSView {
         withContextAlpha(mainOpacity.content, context: context) {
             if !WindowManager.shared.effectiveHideTitleBars(for: self.window) {
                 renderer.drawTitleBar(in: titleBarBaseRect, title: "NULLPLAYER EQUALIZER", prefix: "eq_", context: context)
-                
+
                 // Draw close button
                 let closeState = (pressedButton == "eq_btn_close") ? "pressed" : "normal"
                 renderer.drawWindowControlButton("eq_btn_close", state: closeState,
                                                  in: closeBtnBaseRect, context: context)
-                
+
                 // Draw shade button
                 let shadeState = (pressedButton == "eq_btn_shade") ? "pressed" : "normal"
                 renderer.drawWindowControlButton("eq_btn_shade", state: shadeState,
                                                  in: shadeBtnBaseRect, context: context)
             }
-            
+
             if isShadeMode {
                 return
             }
-            
+
             // Draw EQ content
             drawEQContent(in: context)
+        }
+
+        if isHighlighted {
+            NSColor.white.withAlphaComponent(0.15).setFill()
+            bounds.fill()
         }
     }
     

--- a/Sources/NullPlayer/Windows/ModernMainWindow/ModernMainWindowView.swift
+++ b/Sources/NullPlayer/Windows/ModernMainWindow/ModernMainWindowView.swift
@@ -83,6 +83,9 @@ class ModernMainWindowView: NSView {
     private var sharpCorners: CACornerMask = [] { didSet { updateCornerMask() } }
     private var edgeOcclusionSegments: EdgeOcclusionSegments = .empty
 
+    /// Highlight state for drag-mode visual feedback
+    private var isHighlighted = false
+
     // MARK: - Initialization
     
     override init(frame frameRect: NSRect) {
@@ -143,7 +146,9 @@ class ModernMainWindowView: NSView {
                                                 name: NSNotification.Name("MainWindowVisChanged"), object: nil)
         NotificationCenter.default.addObserver(self, selector: #selector(handleVisClassicProfileCommand(_:)),
                                                 name: .visClassicProfileCommand, object: nil)
-        
+        NotificationCenter.default.addObserver(self, selector: #selector(connectedWindowHighlightDidChange(_:)),
+                                                name: .connectedWindowHighlightDidChange, object: nil)
+
         // Set accessibility
         setAccessibilityIdentifier("ModernMainWindowView")
         setAccessibilityRole(.group)
@@ -300,6 +305,10 @@ class ModernMainWindowView: NSView {
         
         if isShadeMode {
             drawShadeMode(in: windowBounds, context: context)
+            if isHighlighted {
+                NSColor.white.withAlphaComponent(0.15).setFill()
+                bounds.fill()
+            }
             return
         }
         
@@ -459,6 +468,11 @@ class ModernMainWindowView: NSView {
                     drawVolumeSlider(context: context)
                 }
             }
+        }
+
+        if isHighlighted {
+            NSColor.white.withAlphaComponent(0.15).setFill()
+            bounds.fill()
         }
     }
     
@@ -1075,6 +1089,15 @@ class ModernMainWindowView: NSView {
         }
     }
     
+    @objc private func connectedWindowHighlightDidChange(_ notification: Notification) {
+        let highlighted = notification.userInfo?["highlightedWindows"] as? Set<NSWindow> ?? []
+        let newValue = highlighted.contains { $0 === window }
+        if isHighlighted != newValue {
+            isHighlighted = newValue
+            needsDisplay = true
+        }
+    }
+
     @objc private func mainVisSettingsChanged() {
         if let savedMode = UserDefaults.standard.string(forKey: "mainWindowVisMode"),
            let mode = MainWindowVisMode(rawValue: savedMode) {

--- a/Sources/NullPlayer/Windows/ModernPlaylist/ModernPlaylistView.swift
+++ b/Sources/NullPlayer/Windows/ModernPlaylist/ModernPlaylistView.swift
@@ -78,7 +78,10 @@ class ModernPlaylistView: NSView {
     private var adjacentEdges: AdjacentEdges = [] { didSet { updateCornerMask() } }
     private var sharpCorners: CACornerMask = [] { didSet { updateCornerMask() } }
     private var edgeOcclusionSegments: EdgeOcclusionSegments = .empty
-    
+
+    /// Highlight state for drag-mode visual feedback
+    private var isHighlighted = false
+
     // MARK: - Initialization
     
     override init(frame frameRect: NSRect) {
@@ -141,7 +144,9 @@ class ModernPlaylistView: NSView {
                                                name: .audioPlaybackStateChanged, object: nil)
         NotificationCenter.default.addObserver(self, selector: #selector(handleTrackDidChange),
                                                name: .audioTrackDidChange, object: nil)
-        
+        NotificationCenter.default.addObserver(self, selector: #selector(connectedWindowHighlightDidChange(_:)),
+                                               name: .connectedWindowHighlightDidChange, object: nil)
+
         // Set accessibility
         setAccessibilityIdentifier("modernPlaylistView")
         setAccessibilityRole(.group)
@@ -289,6 +294,15 @@ class ModernPlaylistView: NSView {
         }
     }
 
+    @objc private func connectedWindowHighlightDidChange(_ notification: Notification) {
+        let highlighted = notification.userInfo?["highlightedWindows"] as? Set<NSWindow> ?? []
+        let newValue = highlighted.contains { $0 === window }
+        if isHighlighted != newValue {
+            isHighlighted = newValue
+            needsDisplay = true
+        }
+    }
+
     @objc private func playbackStateDidChange(_ note: Notification) {
         let isPlaying = WindowManager.shared.audioEngine.state == .playing
         // Pause marquee scrolling when not playing (save CPU)
@@ -350,13 +364,22 @@ class ModernPlaylistView: NSView {
         }
         
         if isShadeMode {
+            if isHighlighted {
+                NSColor.white.withAlphaComponent(0.15).setFill()
+                bounds.fill()
+            }
             return
         }
-        
+
         // Draw track list
         drawTrackList(in: context)
+
+        if isHighlighted {
+            NSColor.white.withAlphaComponent(0.15).setFill()
+            bounds.fill()
+        }
     }
-    
+
     /// Base rects in the 275x116 coordinate space (renderer scales them)
     private var titleBarBaseRect: NSRect {
         let scale = ModernSkinElements.scaleFactor

--- a/Sources/NullPlayer/Windows/ModernSpectrum/ModernSpectrumView.swift
+++ b/Sources/NullPlayer/Windows/ModernSpectrum/ModernSpectrumView.swift
@@ -60,6 +60,9 @@ class ModernSpectrumView: NSView {
     private var sharpCorners: CACornerMask = [] { didSet { updateCornerMask() } }
     private var edgeOcclusionSegments: EdgeOcclusionSegments = .empty
 
+    /// Highlight state for drag-mode visual feedback
+    private var isHighlighted = false
+
     // MARK: - Initialization
     
     override init(frame frameRect: NSRect) {
@@ -104,7 +107,9 @@ class ModernSpectrumView: NSView {
         // Observe window layout changes for seamless docked borders
         NotificationCenter.default.addObserver(self, selector: #selector(windowLayoutDidChange),
                                                 name: .windowLayoutDidChange, object: nil)
-        
+        NotificationCenter.default.addObserver(self, selector: #selector(connectedWindowHighlightDidChange(_:)),
+                                               name: .connectedWindowHighlightDidChange, object: nil)
+
         // Set accessibility
         setAccessibilityIdentifier("modernSpectrumView")
         setAccessibilityRole(.group)
@@ -197,7 +202,16 @@ class ModernSpectrumView: NSView {
         // Draw shade mode title bar content if in shade mode
         if isShadeMode {
             // Just the title bar - no content area
+            if isHighlighted {
+                NSColor.white.withAlphaComponent(0.15).setFill()
+                bounds.fill()
+            }
             return
+        }
+
+        if isHighlighted {
+            NSColor.white.withAlphaComponent(0.15).setFill()
+            bounds.fill()
         }
     }
     
@@ -239,7 +253,16 @@ class ModernSpectrumView: NSView {
             needsLayout = true
         }
     }
-    
+
+    @objc private func connectedWindowHighlightDidChange(_ notification: Notification) {
+        let highlighted = notification.userInfo?["highlightedWindows"] as? Set<NSWindow> ?? []
+        let newValue = highlighted.contains { $0 === window }
+        if isHighlighted != newValue {
+            isHighlighted = newValue
+            needsDisplay = true
+        }
+    }
+
     // MARK: - Spectrum Data
     
     private func handleSpectrumUpdate(_ notification: Notification) {

--- a/Sources/NullPlayer/Windows/ModernSpectrum/ModernSpectrumView.swift
+++ b/Sources/NullPlayer/Windows/ModernSpectrum/ModernSpectrumView.swift
@@ -199,16 +199,6 @@ class ModernSpectrumView: NSView {
                                              in: ModernSkinElements.spectrumBtnClose.defaultRect, context: context)
         }
         
-        // Draw shade mode title bar content if in shade mode
-        if isShadeMode {
-            // Just the title bar - no content area
-            if isHighlighted {
-                NSColor.white.withAlphaComponent(0.15).setFill()
-                bounds.fill()
-            }
-            return
-        }
-
         if isHighlighted {
             NSColor.white.withAlphaComponent(0.15).setFill()
             bounds.fill()

--- a/Sources/NullPlayer/Windows/ModernWaveform/ModernWaveformView.swift
+++ b/Sources/NullPlayer/Windows/ModernWaveform/ModernWaveformView.swift
@@ -14,6 +14,9 @@ class ModernWaveformView: BaseWaveformView {
     private var sharpCorners: CACornerMask = [] { didSet { updateCornerMask() } }
     private var edgeOcclusionSegments: EdgeOcclusionSegments = .empty
 
+    /// Highlight state for drag-mode visual feedback
+    private var isHighlighted = false
+
     private var titleBarHeight: CGFloat {
         WindowManager.shared.effectiveHideTitleBars(for: window) ? borderWidth : ModernSkinElements.waveformTitleBarHeight
     }
@@ -101,6 +104,8 @@ class ModernWaveformView: BaseWaveformView {
                                                name: .doubleSizeDidChange, object: nil)
         NotificationCenter.default.addObserver(self, selector: #selector(windowLayoutDidChange),
                                                name: .windowLayoutDidChange, object: nil)
+        NotificationCenter.default.addObserver(self, selector: #selector(connectedWindowHighlightDidChange(_:)),
+                                               name: .connectedWindowHighlightDidChange, object: nil)
 
         setAccessibilityIdentifier("modernWaveformView")
         setAccessibilityRole(.group)
@@ -142,6 +147,15 @@ class ModernWaveformView: BaseWaveformView {
         }
     }
 
+    @objc private func connectedWindowHighlightDidChange(_ notification: Notification) {
+        let highlighted = notification.userInfo?["highlightedWindows"] as? Set<NSWindow> ?? []
+        let newValue = highlighted.contains { $0 === window }
+        if isHighlighted != newValue {
+            isHighlighted = newValue
+            needsDisplay = true
+        }
+    }
+
     override func acceptsFirstMouse(for event: NSEvent?) -> Bool {
         true
     }
@@ -175,6 +189,11 @@ class ModernWaveformView: BaseWaveformView {
         }
 
         drawWaveform(in: context)
+
+        if isHighlighted {
+            NSColor.white.withAlphaComponent(0.15).setFill()
+            bounds.fill()
+        }
     }
 
     override func mouseDown(with event: NSEvent) {

--- a/Sources/NullPlayer/Windows/Playlist/PlaylistView.swift
+++ b/Sources/NullPlayer/Windows/Playlist/PlaylistView.swift
@@ -40,6 +40,7 @@ class PlaylistView: NSView {
     /// Window dragging state
     private var isDraggingWindow = false
     private var windowDragStartPoint: NSPoint = .zero
+    private var isHighlighted = false
     
     /// Scrollbar dragging state
     private var isDraggingScrollbar = false
@@ -118,6 +119,8 @@ class PlaylistView: NSView {
         // Observe track changes to update selection highlight
         NotificationCenter.default.addObserver(self, selector: #selector(handleTrackDidChange),
                                                name: .audioTrackDidChange, object: nil)
+        NotificationCenter.default.addObserver(self, selector: #selector(connectedWindowHighlightDidChange(_:)),
+                                               name: .connectedWindowHighlightDidChange, object: nil)
     }
     
     override func viewDidMoveToWindow() {
@@ -145,6 +148,15 @@ class PlaylistView: NSView {
     }
     
     /// Update selection to follow the currently playing track
+    @objc private func connectedWindowHighlightDidChange(_ notification: Notification) {
+        let highlighted = notification.userInfo?["highlightedWindows"] as? Set<NSWindow> ?? []
+        let newValue = highlighted.contains { $0 === window }
+        if isHighlighted != newValue {
+            isHighlighted = newValue
+            needsDisplay = true
+        }
+    }
+
     @objc private func handleTrackDidChange(_ notification: Notification) {
         let engine = WindowManager.shared.audioEngine
         let currentIndex = engine.currentIndex
@@ -386,8 +398,13 @@ class PlaylistView: NSView {
         }
         
         context.restoreGState()
+
+        if isHighlighted {
+            NSColor.white.withAlphaComponent(0.15).setFill()
+            bounds.fill()
+        }
     }
-    
+
     /// Map PlaylistButtonType to ButtonType for shade mode
     private func mapToButtonType(_ plButton: SkinRenderer.PlaylistButtonType?) -> ButtonType? {
         guard let btn = plButton else { return nil }

--- a/Sources/NullPlayer/Windows/Spectrum/SpectrumView.swift
+++ b/Sources/NullPlayer/Windows/Spectrum/SpectrumView.swift
@@ -29,6 +29,7 @@ class SpectrumView: NSView {
     /// Window dragging state
     private var isDraggingWindow = false
     private var windowDragStartPoint: NSPoint = .zero
+    private var isHighlighted = false
     
     /// Observer for spectrum data notifications
     private var spectrumObserver: NSObjectProtocol?
@@ -70,6 +71,8 @@ class SpectrumView: NSView {
         }
         NotificationCenter.default.addObserver(self, selector: #selector(handleVisClassicProfileCommand(_:)),
                                                name: .visClassicProfileCommand, object: nil)
+        NotificationCenter.default.addObserver(self, selector: #selector(connectedWindowHighlightDidChange(_:)),
+                                               name: .connectedWindowHighlightDidChange, object: nil)
         WindowManager.shared.audioEngine.addSpectrumConsumer("spectrumView")
     }
     
@@ -184,6 +187,11 @@ class SpectrumView: NSView {
            spectrumAnalyzerView?.visClassicTransparentBackgroundEnabled() == true {
             context.clear(calculateContentArea())
         }
+
+        if isHighlighted {
+            NSColor.white.withAlphaComponent(0.15).setFill()
+            bounds.fill()
+        }
     }
     
     // MARK: - Spectrum Data
@@ -201,6 +209,15 @@ class SpectrumView: NSView {
         
         // Forward spectrum data to Metal view
         spectrumAnalyzerView?.updateSpectrum(spectrum)
+    }
+
+    @objc private func connectedWindowHighlightDidChange(_ notification: Notification) {
+        let highlighted = notification.userInfo?["highlightedWindows"] as? Set<NSWindow> ?? []
+        let newValue = highlighted.contains { $0 === window }
+        if isHighlighted != newValue {
+            isHighlighted = newValue
+            needsDisplay = true
+        }
     }
 
     @objc private func handleVisClassicProfileCommand(_ notification: Notification) {

--- a/Sources/NullPlayer/Windows/Spectrum/SpectrumView.swift
+++ b/Sources/NullPlayer/Windows/Spectrum/SpectrumView.swift
@@ -190,6 +190,8 @@ class SpectrumView: NSView {
         // so transparent pixels reveal what's behind the window instead of painted chrome.
         // This runs after the highlight overlay so the clear punches through it in the
         // content area, leaving the overlay only on the surrounding window chrome.
+        // Known limitation: the group-drag highlight is invisible over the content area
+        // in this mode; it appears only on the surrounding chrome border.
         if spectrumAnalyzerView?.qualityMode == .visClassicExact,
            spectrumAnalyzerView?.visClassicTransparentBackgroundEnabled() == true {
             context.clear(calculateContentArea())

--- a/Sources/NullPlayer/Windows/Spectrum/SpectrumView.swift
+++ b/Sources/NullPlayer/Windows/Spectrum/SpectrumView.swift
@@ -181,16 +181,18 @@ class SpectrumView: NSView {
         
         context.restoreGState()
 
-        // In standalone vis_classic transparent mode, clear the analyzer content area
-        // so transparent pixels reveal what's behind the window instead of painted chrome.
-        if spectrumAnalyzerView?.qualityMode == .visClassicExact,
-           spectrumAnalyzerView?.visClassicTransparentBackgroundEnabled() == true {
-            context.clear(calculateContentArea())
-        }
-
         if isHighlighted {
             NSColor.white.withAlphaComponent(0.15).setFill()
             bounds.fill()
+        }
+
+        // In standalone vis_classic transparent mode, clear the analyzer content area
+        // so transparent pixels reveal what's behind the window instead of painted chrome.
+        // This runs after the highlight overlay so the clear punches through it in the
+        // content area, leaving the overlay only on the surrounding window chrome.
+        if spectrumAnalyzerView?.qualityMode == .visClassicExact,
+           spectrumAnalyzerView?.visClassicTransparentBackgroundEnabled() == true {
+            context.clear(calculateContentArea())
         }
     }
     

--- a/Sources/NullPlayer/Windows/Waveform/WaveformView.swift
+++ b/Sources/NullPlayer/Windows/Waveform/WaveformView.swift
@@ -5,6 +5,7 @@ class WaveformView: BaseWaveformView {
     private var pressedClose = false
     private var isDraggingWindow = false
     private var windowDragStartPoint: NSPoint = .zero
+    private var isHighlighted = false
 
     private var windowScale: CGFloat {
         bounds.width / max(SkinElements.WaveformWindow.windowSize.width, 1)
@@ -49,6 +50,8 @@ class WaveformView: BaseWaveformView {
         setAccessibilityIdentifier("waveformView")
         setAccessibilityRole(.group)
         setAccessibilityLabel("NullPlayer Waveform")
+        NotificationCenter.default.addObserver(self, selector: #selector(connectedWindowHighlightDidChange(_:)),
+                                               name: .connectedWindowHighlightDidChange, object: nil)
     }
 
     required init?(coder: NSCoder) {
@@ -58,11 +61,14 @@ class WaveformView: BaseWaveformView {
         setAccessibilityIdentifier("waveformView")
         setAccessibilityRole(.group)
         setAccessibilityLabel("NullPlayer Waveform")
+        NotificationCenter.default.addObserver(self, selector: #selector(connectedWindowHighlightDidChange(_:)),
+                                               name: .connectedWindowHighlightDidChange, object: nil)
     }
 
     deinit {
         stopAppearanceObservation()
         stopLoadingForHide()
+        NotificationCenter.default.removeObserver(self)
     }
 
     override func acceptsFirstMouse(for event: NSEvent?) -> Bool {
@@ -102,6 +108,20 @@ class WaveformView: BaseWaveformView {
         context.restoreGState()
 
         drawWaveform(in: context)
+
+        if isHighlighted {
+            NSColor.white.withAlphaComponent(0.15).setFill()
+            bounds.fill()
+        }
+    }
+
+    @objc private func connectedWindowHighlightDidChange(_ notification: Notification) {
+        let highlighted = notification.userInfo?["highlightedWindows"] as? Set<NSWindow> ?? []
+        let newValue = highlighted.contains { $0 === window }
+        if isHighlighted != newValue {
+            isHighlighted = newValue
+            needsDisplay = true
+        }
     }
 
     override func mouseDown(with event: NSEvent) {

--- a/Tests/NullPlayerTests/WindowManagerDragModeTests.swift
+++ b/Tests/NullPlayerTests/WindowManagerDragModeTests.swift
@@ -34,7 +34,9 @@ final class WindowManagerDragModeTests: XCTestCase {
     }
 
     func testNilHoldStartReturnsGroup() {
-        // nil holdStart (mid-flight detection fallback) → group
+        // nil holdStart → group (defensive guard inside determineDragMode; the actual mid-flight
+        // path in windowWillMove calls windowWillStartDragging first which sets holdStartTime,
+        // so nil is never passed there — this tests the function's own defensive fallback)
         let mode = WindowManager.determineDragMode(
             holdStart: nil,
             currentTime: 1000.0,

--- a/Tests/NullPlayerTests/WindowManagerDragModeTests.swift
+++ b/Tests/NullPlayerTests/WindowManagerDragModeTests.swift
@@ -24,10 +24,10 @@ final class WindowManagerDragModeTests: XCTestCase {
     }
 
     func testExactThresholdReturnsGroup() {
-        // Elapsed == threshold → group
+        // Elapsed == threshold → group (use small base to avoid floating-point precision loss)
         let mode = WindowManager.determineDragMode(
-            holdStart: 1000.0,
-            currentTime: 1000.4,
+            holdStart: 0.0,
+            currentTime: 0.4,
             threshold: 0.4
         )
         XCTAssertEqual(mode, .group)

--- a/Tests/NullPlayerTests/WindowManagerDragModeTests.swift
+++ b/Tests/NullPlayerTests/WindowManagerDragModeTests.swift
@@ -1,0 +1,55 @@
+import XCTest
+@testable import NullPlayer
+
+final class WindowManagerDragModeTests: XCTestCase {
+
+    func testShortHoldReturnsSeparate() {
+        // Elapsed 0.1s < 0.4s threshold → separate
+        let mode = WindowManager.determineDragMode(
+            holdStart: 1000.0,
+            currentTime: 1000.1,
+            threshold: 0.4
+        )
+        XCTAssertEqual(mode, .separate)
+    }
+
+    func testLongHoldReturnsGroup() {
+        // Elapsed 0.5s >= 0.4s threshold → group
+        let mode = WindowManager.determineDragMode(
+            holdStart: 1000.0,
+            currentTime: 1000.5,
+            threshold: 0.4
+        )
+        XCTAssertEqual(mode, .group)
+    }
+
+    func testExactThresholdReturnsGroup() {
+        // Elapsed == threshold → group
+        let mode = WindowManager.determineDragMode(
+            holdStart: 1000.0,
+            currentTime: 1000.4,
+            threshold: 0.4
+        )
+        XCTAssertEqual(mode, .group)
+    }
+
+    func testNilHoldStartReturnsGroup() {
+        // nil holdStart (mid-flight detection fallback) → group
+        let mode = WindowManager.determineDragMode(
+            holdStart: nil,
+            currentTime: 1000.0,
+            threshold: 0.4
+        )
+        XCTAssertEqual(mode, .group)
+    }
+
+    func testZeroElapsedReturnsSeparate() {
+        // Elapsed 0s → separate
+        let mode = WindowManager.determineDragMode(
+            holdStart: 1000.0,
+            currentTime: 1000.0,
+            threshold: 0.4
+        )
+        XCTAssertEqual(mode, .separate)
+    }
+}

--- a/docs/superpowers/plans/2026-03-15-connected-window-drag-rules.md
+++ b/docs/superpowers/plans/2026-03-15-connected-window-drag-rules.md
@@ -1,0 +1,665 @@
+# Connected Window Drag Rules Implementation Plan
+
+> **For agentic workers:** REQUIRED: Use superpowers:subagent-driven-development (if subagents available) or superpowers:executing-plans to implement this plan. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Replace the distance-based undock mechanism with a time-based hold model — short hold (<400ms) detaches a window from its group, long hold (≥400ms) moves all connected windows together — and add visual highlight on connected peers during the hold phase.
+
+**Architecture:** `WindowManager` gains a `DragMode` state machine evaluated at the first `windowWillMove` call. A `connectedWindowHighlightDidChange` notification is posted at drag start and cleared when mode is determined or drag ends. All 10 dockable window views subscribe to the notification and draw a semi-transparent overlay when highlighted.
+
+**Tech Stack:** Swift, AppKit, NotificationCenter, `CACurrentMediaTime` (CoreVideo timing)
+
+**Spec:** `docs/superpowers/specs/2026-03-15-connected-window-drag-rules-design.md`
+
+---
+
+## Chunk 1: WindowManager State Machine
+
+### Task 1: Add DragMode enum, new state, notification name; remove undockThreshold
+
+**Files:**
+- Modify: `Sources/NullPlayer/App/WindowManager.swift`
+
+No test yet — this task is additive scaffolding only. The testable logic is extracted in Task 2.
+
+- [ ] **Step 1: Add notification name**
+
+In `WindowManager.swift` at the top-level `extension Notification.Name` block (around line 5), add:
+
+```swift
+static let connectedWindowHighlightDidChange = Notification.Name("connectedWindowHighlightDidChange")
+```
+
+- [ ] **Step 2: Add DragMode enum**
+
+After the `TimeDisplayMode` enum (early in the file, before the `WindowManager` class), add:
+
+```swift
+/// Determines how a window drag affects its connected group.
+enum DragMode {
+    case pending   // mouseDown received, drag not yet started
+    case separate  // drag started before holdThreshold — window moves alone
+    case group     // holdThreshold elapsed before drag — connected windows move together
+}
+```
+
+- [ ] **Step 3: Replace undockThreshold with hold state**
+
+In `WindowManager.swift` around line 314, replace:
+```swift
+/// Undock threshold - how far you need to drag a window to break it free from the group
+private let undockThreshold: CGFloat = 10
+```
+with:
+```swift
+/// Hold threshold - how long (seconds) before a drag moves the connected group
+let holdThreshold: TimeInterval = 0.4
+
+/// Time when current drag's mouseDown was received
+private var holdStartTime: CFTimeInterval?
+
+/// Current drag mode, determined on first windowWillMove call
+private var dragMode: DragMode = .pending
+
+/// Whether a connectedWindowHighlightDidChange notification was posted for this drag
+private var highlightWasPosted = false
+```
+
+All new properties are `private`. Tests only use the `static func determineDragMode(holdStart:currentTime:threshold:)` which takes threshold as a parameter — no instance property access needed.
+
+- [ ] **Step 4: Build to confirm no errors**
+
+```bash
+cd /Users/ad/Projects/nullplayer && swift build 2>&1 | head -40
+```
+Expected: build succeeds (undockThreshold reference in windowWillMove will cause an error — that's expected; it's replaced in Task 3).
+
+> **Timing design note:** Mode is intentionally evaluated at the first `mouseDragged` event (first `windowWillMove` call), not via a timer. The time elapsed between `mouseDown` and first mouse movement IS the hold duration. If the user presses down and immediately moves → short hold → separate. If the user holds 500ms before moving → long hold → group. This is correct per spec. Brief highlight flash on short-hold drags is acknowledged acceptable.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add Sources/NullPlayer/App/WindowManager.swift
+git commit -m "feat: add DragMode enum and hold state to WindowManager"
+```
+
+---
+
+### Task 2: Extract determineDragMode() static function (TDD)
+
+**Files:**
+- Modify: `Sources/NullPlayer/App/WindowManager.swift`
+- Create: `Tests/NullPlayerTests/WindowManagerDragModeTests.swift`
+
+- [ ] **Step 1: Write the failing test**
+
+Create `Tests/NullPlayerTests/WindowManagerDragModeTests.swift`:
+
+```swift
+import XCTest
+@testable import NullPlayer
+
+final class WindowManagerDragModeTests: XCTestCase {
+
+    func testShortHoldReturnsSeparate() {
+        // Elapsed 0.1s < 0.4s threshold → separate
+        let mode = WindowManager.determineDragMode(
+            holdStart: 1000.0,
+            currentTime: 1000.1,
+            threshold: 0.4
+        )
+        XCTAssertEqual(mode, .separate)
+    }
+
+    func testLongHoldReturnsGroup() {
+        // Elapsed 0.5s >= 0.4s threshold → group
+        let mode = WindowManager.determineDragMode(
+            holdStart: 1000.0,
+            currentTime: 1000.5,
+            threshold: 0.4
+        )
+        XCTAssertEqual(mode, .group)
+    }
+
+    func testExactThresholdReturnsGroup() {
+        // Elapsed == threshold → group
+        let mode = WindowManager.determineDragMode(
+            holdStart: 1000.0,
+            currentTime: 1000.4,
+            threshold: 0.4
+        )
+        XCTAssertEqual(mode, .group)
+    }
+
+    func testNilHoldStartReturnsGroup() {
+        // nil holdStart (mid-flight detection fallback) → group
+        let mode = WindowManager.determineDragMode(
+            holdStart: nil,
+            currentTime: 1000.0,
+            threshold: 0.4
+        )
+        XCTAssertEqual(mode, .group)
+    }
+
+    func testZeroElapsedReturnsSeparate() {
+        // Elapsed 0s → separate
+        let mode = WindowManager.determineDragMode(
+            holdStart: 1000.0,
+            currentTime: 1000.0,
+            threshold: 0.4
+        )
+        XCTAssertEqual(mode, .separate)
+    }
+}
+```
+
+- [ ] **Step 2: Run test to verify it fails**
+
+```bash
+cd /Users/ad/Projects/nullplayer && swift test --filter WindowManagerDragModeTests 2>&1 | tail -20
+```
+Expected: compile error — `determineDragMode` does not exist yet.
+
+- [ ] **Step 3: Add the static function to WindowManager**
+
+In `WindowManager.swift`, inside the `// MARK: - Window Snapping & Docking` section (around line 2312), add before `windowWillStartDragging`:
+
+```swift
+/// Pure timing function: determines drag mode from hold duration.
+/// - Parameters:
+///   - holdStart: The CACurrentMediaTime() value captured at mouseDown, or nil if unavailable.
+///   - currentTime: The current CACurrentMediaTime() value.
+///   - threshold: The hold duration threshold in seconds.
+/// - Returns: `.separate` if elapsed time is below threshold; `.group` otherwise.
+static func determineDragMode(
+    holdStart: CFTimeInterval?,
+    currentTime: CFTimeInterval,
+    threshold: TimeInterval
+) -> DragMode {
+    guard let start = holdStart else { return .group }
+    return (currentTime - start) < threshold ? .separate : .group
+}
+```
+
+- [ ] **Step 4: Run tests to verify they pass**
+
+```bash
+cd /Users/ad/Projects/nullplayer && swift test --filter WindowManagerDragModeTests 2>&1 | tail -20
+```
+Expected: all 5 tests pass.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add Sources/NullPlayer/App/WindowManager.swift Tests/NullPlayerTests/WindowManagerDragModeTests.swift
+git commit -m "feat: add determineDragMode() static function with unit tests"
+```
+
+---
+
+### Task 3: Update windowWillStartDragging, windowWillMove, windowDidFinishDragging
+
+**Files:**
+- Modify: `Sources/NullPlayer/App/WindowManager.swift`
+
+- [ ] **Step 1: Add postConnectedWindowHighlight helper**
+
+In `WindowManager.swift`, add this private helper near `postLayoutChangeNotification` (around line 2769):
+
+```swift
+/// Post a connectedWindowHighlightDidChange notification.
+/// - Parameter windows: The windows to highlight. Pass an empty set to clear all highlights.
+private func postConnectedWindowHighlight(_ windows: Set<NSWindow>) {
+    NotificationCenter.default.post(
+        name: .connectedWindowHighlightDidChange,
+        object: nil,
+        userInfo: ["highlightedWindows": windows]
+    )
+}
+```
+
+- [ ] **Step 2: Update windowWillStartDragging**
+
+Replace the entire body of `windowWillStartDragging(_:fromTitleBar:)` (lines 2319–2342) with:
+
+```swift
+func windowWillStartDragging(_ window: NSWindow, fromTitleBar: Bool = false) {
+    draggingWindow = window
+    dragStartOrigin = window.frame.origin
+    isTitleBarDrag = fromTitleBar
+    holdStartTime = CACurrentMediaTime()
+    dragMode = .pending
+
+    // Find all windows that are docked to this window
+    dockedWindowsToMove = findDockedWindows(to: window)
+
+    // Store relative offsets from dragging window's origin (prevents drift during fast movement)
+    dockedWindowOffsets.removeAll()
+    dockedWindowOriginalOrigins.removeAll()
+    let dragOrigin = window.frame.origin
+    for dockedWindow in dockedWindowsToMove {
+        let offset = NSPoint(
+            x: dockedWindow.frame.origin.x - dragOrigin.x,
+            y: dockedWindow.frame.origin.y - dragOrigin.y
+        )
+        dockedWindowOffsets[ObjectIdentifier(dockedWindow)] = offset
+        dockedWindowOriginalOrigins[ObjectIdentifier(dockedWindow)] = dockedWindow.frame.origin
+    }
+
+    // Highlight connected peers so user can see which windows would move together
+    if !dockedWindowsToMove.isEmpty {
+        postConnectedWindowHighlight(Set(dockedWindowsToMove))
+        highlightWasPosted = true
+    }
+}
+```
+
+- [ ] **Step 3: Patch the mid-flight fallback in windowWillMove**
+
+In `windowWillMove`, around line 2385, there is a fallback that calls `windowWillStartDragging` when a different window triggers `windowWillMove` mid-flight:
+
+```swift
+// EXISTING — find this:
+if draggingWindow !== window {
+    windowWillStartDragging(window)
+}
+```
+
+This would reset `holdStartTime` to "now", making `elapsed ≈ 0` and incorrectly triggering `.separate` mode. Fix by immediately setting `dragMode = .group` after this fallback call:
+
+```swift
+// REPLACE WITH:
+if draggingWindow !== window {
+    windowWillStartDragging(window)
+    dragMode = .group  // mid-flight detection: hold measurement unavailable, default to group
+}
+```
+
+- [ ] **Step 4: Replace the undock block in windowWillMove**
+
+In `windowWillMove`, find and replace the undock block (lines 2389–2408):
+
+```swift
+// OLD — remove this entire block:
+let isMainWindow = window === mainWindowController?.window
+if !isMainWindow && isTitleBarDrag && !dockedWindowsToMove.isEmpty {
+    let dragDistance = hypot(newOrigin.x - dragStartOrigin.x, newOrigin.y - dragStartOrigin.y)
+    if dragDistance > undockThreshold {
+        isMovingDockedWindows = true
+        for dockedWindow in dockedWindowsToMove {
+            if let origin = dockedWindowOriginalOrigins[ObjectIdentifier(dockedWindow)] {
+                dockedWindow.setFrameOrigin(origin)
+            }
+        }
+        isMovingDockedWindows = false
+        dockedWindowsToMove.removeAll()
+        dockedWindowOffsets.removeAll()
+        dockedWindowOriginalOrigins.removeAll()
+    }
+}
+```
+
+Replace with:
+
+```swift
+// NEW — determine mode on first drag movement
+if dragMode == .pending {
+    let mode = WindowManager.determineDragMode(
+        holdStart: holdStartTime,
+        currentTime: CACurrentMediaTime(),
+        threshold: holdThreshold
+    )
+    dragMode = mode
+    if mode == .separate {
+        // Restore peers to their pre-drag positions before breaking the dock
+        isMovingDockedWindows = true
+        for dockedWindow in dockedWindowsToMove {
+            if let origin = dockedWindowOriginalOrigins[ObjectIdentifier(dockedWindow)] {
+                dockedWindow.setFrameOrigin(origin)
+            }
+        }
+        isMovingDockedWindows = false
+        dockedWindowsToMove.removeAll()
+        dockedWindowOffsets.removeAll()
+        dockedWindowOriginalOrigins.removeAll()
+        if highlightWasPosted {
+            postConnectedWindowHighlight([])
+            highlightWasPosted = false
+        }
+    }
+}
+```
+
+- [ ] **Step 4: Update windowDidFinishDragging**
+
+Replace the body of `windowDidFinishDragging(_:)` (lines 2347–2353) with:
+
+```swift
+func windowDidFinishDragging(_ window: NSWindow) {
+    draggingWindow = nil
+    dockedWindowsToMove.removeAll()
+    dockedWindowOffsets.removeAll()
+    dockedWindowOriginalOrigins.removeAll()
+    holdStartTime = nil
+    dragMode = .pending
+    if highlightWasPosted {
+        postConnectedWindowHighlight([])
+        highlightWasPosted = false
+    }
+    _ = tightenClassicCenterStackIfNeeded()
+    postLayoutChangeNotification()
+    updateDockedChildWindows()
+}
+```
+
+- [ ] **Step 5: Build to confirm no errors**
+
+```bash
+cd /Users/ad/Projects/nullplayer && swift build 2>&1 | head -40
+```
+Expected: clean build (no undockThreshold references remain).
+
+- [ ] **Step 6: Run all tests**
+
+```bash
+cd /Users/ad/Projects/nullplayer && swift test 2>&1 | tail -20
+```
+Expected: all tests pass.
+
+- [ ] **Step 7: Commit**
+
+```bash
+git add Sources/NullPlayer/App/WindowManager.swift
+git commit -m "feat: replace distance-based undock with hold-duration drag mode"
+```
+
+---
+
+### Task 4: Add NSWindow.willCloseNotification observer for mid-drag cleanup
+
+**Files:**
+- Modify: `Sources/NullPlayer/App/WindowManager.swift`
+
+- [ ] **Step 1: Register observer in init()**
+
+In `private init()` (line 360), add after `loadDefaultSkin()`:
+
+```swift
+// Clean up drag state if a window closes mid-drag
+NotificationCenter.default.addObserver(
+    self,
+    selector: #selector(handleWindowWillClose(_:)),
+    name: NSWindow.willCloseNotification,
+    object: nil
+)
+```
+
+- [ ] **Step 2: Add the handler**
+
+Add this method to `WindowManager` in the `// MARK: - Window Snapping & Docking` section:
+
+```swift
+@objc private func handleWindowWillClose(_ notification: Notification) {
+    guard let closingWindow = notification.object as? NSWindow,
+          closingWindow === draggingWindow else { return }
+    windowDidFinishDragging(closingWindow)
+}
+```
+
+- [ ] **Step 3: Build and run tests**
+
+```bash
+cd /Users/ad/Projects/nullplayer && swift build 2>&1 | head -20 && swift test 2>&1 | tail -10
+```
+Expected: clean build, all tests pass.
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add Sources/NullPlayer/App/WindowManager.swift
+git commit -m "feat: clean up hold state when dragged window closes mid-drag"
+```
+
+---
+
+## Chunk 2: View Highlight Rendering
+
+All views follow the same pattern:
+1. Add `private var isHighlighted = false`
+2. Add `addObserver` for `.connectedWindowHighlightDidChange` in the existing setup method
+3. Add `@objc private func connectedWindowHighlightDidChange(_ notification: Notification)` handler
+4. Add the overlay at the end of `draw(_:)`, before the closing brace
+
+The handler is identical for every view:
+
+```swift
+@objc private func connectedWindowHighlightDidChange(_ notification: Notification) {
+    let highlighted = notification.userInfo?["highlightedWindows"] as? Set<NSWindow> ?? []
+    let newValue = highlighted.contains { $0 === window }
+    if isHighlighted != newValue {
+        isHighlighted = newValue
+        needsDisplay = true
+    }
+}
+```
+
+The overlay is identical for every view — add at the very end of `draw(_:)` before the closing `}`:
+
+```swift
+if isHighlighted {
+    NSColor.white.withAlphaComponent(0.15).setFill()
+    bounds.fill()
+}
+```
+
+### Task 5: Add highlight rendering to classic views
+
+**Files:**
+- Modify: `Sources/NullPlayer/Windows/MainWindow/MainWindowView.swift`
+- Modify: `Sources/NullPlayer/Windows/Playlist/PlaylistView.swift`
+- Modify: `Sources/NullPlayer/Windows/Equalizer/EQView.swift`
+- Modify: `Sources/NullPlayer/Windows/Waveform/WaveformView.swift`
+- Modify: `Sources/NullPlayer/Windows/Spectrum/SpectrumView.swift`
+
+#### MainWindowView
+
+- [ ] **Step 1: Add isHighlighted property and observer**
+
+In `MainWindowView.swift`, add the property near the other `private var` flags (around line 1312 near `isDraggingWindow`):
+
+```swift
+private var isHighlighted = false
+```
+
+In `setupView()` (around line 241, after the last `addObserver` call before the closing `}`), add:
+
+```swift
+// Observe connected-window highlight changes during drag
+NotificationCenter.default.addObserver(self, selector: #selector(connectedWindowHighlightDidChange(_:)),
+                                       name: .connectedWindowHighlightDidChange, object: nil)
+```
+
+- [ ] **Step 2: Add handler**
+
+Add the handler method anywhere among the other `@objc` notification handlers in the file:
+
+```swift
+@objc private func connectedWindowHighlightDidChange(_ notification: Notification) {
+    let highlighted = notification.userInfo?["highlightedWindows"] as? Set<NSWindow> ?? []
+    let newValue = highlighted.contains { $0 === window }
+    if isHighlighted != newValue {
+        isHighlighted = newValue
+        needsDisplay = true
+    }
+}
+```
+
+- [ ] **Step 3: Add overlay to draw()**
+
+At the very end of `override func draw(_ dirtyRect: NSRect)`, before the closing `}`, add:
+
+```swift
+if isHighlighted {
+    NSColor.white.withAlphaComponent(0.15).setFill()
+    bounds.fill()
+}
+```
+
+#### PlaylistView
+
+- [ ] **Step 4: Apply same pattern to PlaylistView**
+
+- Add `private var isHighlighted = false` near other state flags
+- In `setupView()` (around line 120, after the last existing `addObserver` call), add:
+  ```swift
+  NotificationCenter.default.addObserver(self, selector: #selector(connectedWindowHighlightDidChange(_:)),
+                                         name: .connectedWindowHighlightDidChange, object: nil)
+  ```
+- Add the handler (identical to above)
+- Add overlay at end of `draw(_:)` (after `context.restoreGState()` at line 388, before closing `}`)
+
+#### EQView
+
+- [ ] **Step 5: Apply same pattern to EQView**
+
+- Add `private var isHighlighted = false` near state flags
+- In `setupView()` (around line 104, after existing observer registration), add:
+  ```swift
+  NotificationCenter.default.addObserver(self, selector: #selector(connectedWindowHighlightDidChange(_:)),
+                                         name: .connectedWindowHighlightDidChange, object: nil)
+  ```
+- Add the handler
+- Add overlay at end of `draw(_:)`
+
+#### WaveformView
+
+- [ ] **Step 6: Apply same pattern to WaveformView**
+
+- Add `private var isHighlighted = false` near the other `private var` flags (around line 5)
+- In `override init(frame frameRect: NSRect)` (line 45), after `setAccessibilityLabel(...)`, add:
+  ```swift
+  NotificationCenter.default.addObserver(self, selector: #selector(connectedWindowHighlightDidChange(_:)),
+                                         name: .connectedWindowHighlightDidChange, object: nil)
+  ```
+  Add the same to `required init?(coder:)` (line 54) after its `setAccessibilityLabel`.
+- In `deinit` (line 63), add `NotificationCenter.default.removeObserver(self)` (WaveformView has no removeObserver currently)
+- Add the handler
+- Add overlay at end of `draw(_:)` (after `drawWaveform(in: context)` at line 104, before closing `}`)
+
+#### SpectrumView
+
+- [ ] **Step 7: Apply same pattern to SpectrumView**
+
+- Add `private var isHighlighted = false`
+- In `setupView()` (around line 72, after existing `addObserver` calls), add:
+  ```swift
+  NotificationCenter.default.addObserver(self, selector: #selector(connectedWindowHighlightDidChange(_:)),
+                                         name: .connectedWindowHighlightDidChange, object: nil)
+  ```
+- Add the handler
+- Add overlay at end of `draw(_:)`
+
+- [ ] **Step 8: Build**
+
+```bash
+cd /Users/ad/Projects/nullplayer && swift build 2>&1 | head -40
+```
+Expected: clean build.
+
+- [ ] **Step 9: Manual test — classic skin**
+
+Launch the app in classic skin mode. Dock 2–3 windows together (drag until they snap). Then:
+- Tap and immediately drag one window → it detaches, no highlight visible (too brief)
+- Hold ~0.5s then drag → peers highlight white, group moves together
+
+- [ ] **Step 10: Commit**
+
+```bash
+git add Sources/NullPlayer/Windows/MainWindow/MainWindowView.swift \
+        Sources/NullPlayer/Windows/Playlist/PlaylistView.swift \
+        Sources/NullPlayer/Windows/Equalizer/EQView.swift \
+        Sources/NullPlayer/Windows/Waveform/WaveformView.swift \
+        Sources/NullPlayer/Windows/Spectrum/SpectrumView.swift
+git commit -m "feat: add drag highlight overlay to classic window views"
+```
+
+---
+
+### Task 6: Add highlight rendering to modern views
+
+**Files:**
+- Modify: `Sources/NullPlayer/Windows/ModernMainWindow/ModernMainWindowView.swift`
+- Modify: `Sources/NullPlayer/Windows/ModernPlaylist/ModernPlaylistView.swift`
+- Modify: `Sources/NullPlayer/Windows/ModernWaveform/ModernWaveformView.swift`
+- Modify: `Sources/NullPlayer/Windows/ModernEQ/ModernEQView.swift`
+- Modify: `Sources/NullPlayer/Windows/ModernSpectrum/ModernSpectrumView.swift`
+
+All five follow the same pattern as Task 5. The setup method names differ:
+
+| View | Setup method | addObserver location |
+|---|---|---|
+| `ModernMainWindowView` | `setupView()` | After last `addObserver` (~line 145) |
+| `ModernPlaylistView` | `commonInit()` or `setupView()` | After last `addObserver` (~line 142) |
+| `ModernWaveformView` | `commonInit()` | After last `addObserver` (~line 103) |
+| `ModernEQView` | `setupView()` or `commonInit()` | After last `addObserver` (~line 174) |
+| `ModernSpectrumView` | `setupView()` | After last `addObserver` (~line 106) |
+
+All have `deinit` with `NotificationCenter.default.removeObserver(self)` — no changes needed there.
+
+- [ ] **Step 1: Apply pattern to ModernMainWindowView**
+
+- Add `private var isHighlighted = false` near other state properties
+- In `setupView()`, after the last `addObserver` call (around line 145), add:
+  ```swift
+  NotificationCenter.default.addObserver(self, selector: #selector(connectedWindowHighlightDidChange(_:)),
+                                         name: .connectedWindowHighlightDidChange, object: nil)
+  ```
+- Add the handler
+- Add overlay at end of `draw(_:)`, before closing `}`
+
+- [ ] **Step 2: Apply pattern to ModernPlaylistView**
+
+Same as above, using `commonInit()` or `setupView()`.
+
+- [ ] **Step 3: Apply pattern to ModernWaveformView**
+
+Same, using `commonInit()`.
+
+- [ ] **Step 4: Apply pattern to ModernEQView**
+
+Same, using appropriate setup method.
+
+- [ ] **Step 5: Apply pattern to ModernSpectrumView**
+
+Same, using `setupView()`.
+
+- [ ] **Step 6: Build**
+
+```bash
+cd /Users/ad/Projects/nullplayer && swift build 2>&1 | head -40
+```
+Expected: clean build.
+
+- [ ] **Step 7: Manual test — modern skin**
+
+Launch in modern skin mode. Dock 2–3 windows. Then:
+- Tap and immediately drag → detaches, no highlight
+- Hold ~0.5s then drag → peers highlight white, group moves together
+- Verify widgets (sliders, buttons) are unaffected — clicking them does not trigger highlight
+
+- [ ] **Step 8: Run all tests**
+
+```bash
+cd /Users/ad/Projects/nullplayer && swift test 2>&1 | tail -20
+```
+Expected: all tests pass.
+
+- [ ] **Step 9: Commit**
+
+```bash
+git add Sources/NullPlayer/Windows/ModernMainWindow/ModernMainWindowView.swift \
+        Sources/NullPlayer/Windows/ModernPlaylist/ModernPlaylistView.swift \
+        Sources/NullPlayer/Windows/ModernWaveform/ModernWaveformView.swift \
+        Sources/NullPlayer/Windows/ModernEQ/ModernEQView.swift \
+        Sources/NullPlayer/Windows/ModernSpectrum/ModernSpectrumView.swift
+git commit -m "feat: add drag highlight overlay to modern window views"
+```

--- a/docs/superpowers/specs/2026-03-15-connected-window-drag-rules-design.md
+++ b/docs/superpowers/specs/2026-03-15-connected-window-drag-rules-design.md
@@ -1,0 +1,128 @@
+# Connected Window Drag Rules — Design Spec
+
+**Date:** 2026-03-15
+**Branch:** window-rules-experimental
+**Status:** Approved
+
+---
+
+## Summary
+
+Replace the current distance-based undock mechanism with a time-based hold model. How long the user holds before dragging determines whether the window moves alone (short hold) or moves with its connected group (long hold). All dockable windows are treated identically — no special cases for the main window.
+
+---
+
+## Behavior Rules
+
+| Interaction | Result |
+|---|---|
+| Short hold + drag (< 400ms) | Dragged window detaches from group; moves alone |
+| Long hold + drag (≥ 400ms) | All connected windows move together as a group |
+| No connected windows | Window always moves alone regardless of hold duration |
+
+When a window detaches via short hold, its former connected peers remain connected to each other — only the dragged window separates.
+
+---
+
+## Hold State Machine
+
+### New state in `WindowManager`
+
+```swift
+private var holdStartTime: CFTimeInterval?
+private let holdThreshold: TimeInterval = 0.4  // 400ms
+private var dragMode: DragMode = .pending
+
+private enum DragMode {
+    case pending   // mouseDown received, drag not yet started
+    case separate  // drag started before threshold — window moves alone
+    case group     // threshold elapsed before drag — connected windows move together
+}
+```
+
+### Event flow
+
+1. **`windowWillStartDragging(_:fromTitleBar:)`**
+   - Sets `holdStartTime = CACurrentMediaTime()`
+   - Sets `dragMode = .pending`
+   - Finds connected windows via existing BFS (`findDockedWindows`)
+   - Posts `connectedWindowHighlightDidChange` with connected peers (if any)
+
+2. **First call to `windowWillMove(_:to:)`**
+   - If `dragMode == .pending`: determine mode based on elapsed time
+     - `elapsed < holdThreshold` → `.separate`: clear `dockedWindowsToMove`; the window drags alone and detaches
+     - `elapsed >= holdThreshold` → `.group`: proceed with existing group-move logic unchanged
+   - Subsequent calls skip mode determination (mode is already set)
+
+3. **`windowDidFinishDragging(_:)`**
+   - Clears `holdStartTime`
+   - Resets `dragMode = .pending`
+   - Posts `connectedWindowHighlightDidChange` with empty set (clears highlight)
+   - Existing cleanup (snapping, child window updates, etc.) unchanged
+
+### Removed
+
+The existing `undockThreshold` (10px distance check) and its associated `isTitleBarDrag` / `isMainWindow` guard are removed. The timing model fully replaces them.
+
+---
+
+## Highlight System
+
+Connected peers are highlighted immediately at `mouseDown` to show the user which windows belong to the group.
+
+### Notification
+
+```swift
+static let connectedWindowHighlightDidChange = Notification.Name("connectedWindowHighlightDidChange")
+// userInfo key: "highlightedWindows" — value: Set<NSWindow>
+// Empty set = clear all highlights
+```
+
+- Posted at `windowWillStartDragging` with the set of connected peers (not the dragging window itself)
+- Posted at `windowDidFinishDragging` and when `.separate` mode is confirmed, with an empty set
+
+### Rendering
+
+Each dockable window view (classic and modern) observes the notification:
+
+- Maintains a local `isHighlighted: Bool` flag
+- Sets `needsDisplay = true` on change
+- In `draw(_:)`: when `isHighlighted`, draws a semi-transparent overlay (e.g. `NSColor.white.withAlphaComponent(0.15)`) over the window content
+
+The dragging window itself is **never** highlighted — only its connected peers are shown, so the user can clearly see what's attached to what they're grabbing.
+
+**No connected windows:** If the dragged window has no connected peers, no notification is posted and no highlight appears.
+
+---
+
+## Interaction Protection
+
+No changes to widget protection. The existing per-view `mouseDown` hit-testing already gates `windowWillStartDragging` — it is only called after confirming the click is not on a button, slider, or visualization area. The hold timer therefore cannot activate through widget interactions.
+
+Widgets that use drag motions (seek slider, volume slider, balance slider) already short-circuit `mouseDragged` via the `draggingSlider` flag before `windowWillMove` is reached. This is unchanged.
+
+---
+
+## Affected Files
+
+| File | Change |
+|---|---|
+| `App/WindowManager.swift` | Add `DragMode` enum, `holdStartTime`, `holdThreshold`, `dragMode` state; update `windowWillStartDragging`, `windowWillMove`, `windowDidFinishDragging`; add `connectedWindowHighlightDidChange` notification; remove `undockThreshold` distance check |
+| `Windows/MainWindow/MainWindowView.swift` | Observe highlight notification, draw overlay |
+| `Windows/Playlist/PlaylistView.swift` | Observe highlight notification, draw overlay |
+| `Windows/Equalizer/EQView.swift` | Observe highlight notification, draw overlay |
+| `Windows/ModernMainWindow/ModernMainWindowView.swift` | Observe highlight notification, draw overlay |
+| `Windows/ModernPlaylist/ModernPlaylistView.swift` | Observe highlight notification, draw overlay |
+| `Windows/ModernWaveform/ModernWaveformView.swift` | Observe highlight notification, draw overlay |
+| `Windows/ModernEQ/ModernEQView.swift` | Observe highlight notification, draw overlay |
+| `Windows/Spectrum/SpectrumWindowController.swift` (or view) | Observe highlight notification, draw overlay |
+| `Windows/ModernSpectrum/ModernSpectrumView.swift` | Observe highlight notification, draw overlay |
+
+---
+
+## Out of Scope
+
+- Haptic feedback on hold threshold crossing
+- Animated highlight transitions
+- Configurable hold threshold in preferences
+- Any changes to snapping, docking detection, or child window tracking

--- a/docs/superpowers/specs/2026-03-15-connected-window-drag-rules-design.md
+++ b/docs/superpowers/specs/2026-03-15-connected-window-drag-rules-design.md
@@ -8,7 +8,13 @@
 
 ## Summary
 
-Replace the current distance-based undock mechanism with a time-based hold model. How long the user holds before dragging determines whether the window moves alone (short hold) or moves with its connected group (long hold). All dockable windows are treated identically — no special cases for the main window.
+Replace the current distance-based undock mechanism with a time-based hold model. How long the user holds before dragging determines whether the window moves alone (short hold) or moves with its connected group (long hold). All dockable windows are treated identically — including the main window.
+
+---
+
+## Drag Architecture Note
+
+All dockable windows set `isMovableByWindowBackground = false`, disabling macOS system-level window dragging. Each window view handles drag events manually via `mouseDown` / `mouseDragged` / `mouseUp` overrides that call directly into `WindowManager`. This means `windowWillStartDragging` is called synchronously from within the view's `mouseDown` — it is not a system drag callback. `holdStartTime` is therefore effectively captured at mouseDown time, making sub-second timing reliable.
 
 ---
 
@@ -20,7 +26,13 @@ Replace the current distance-based undock mechanism with a time-based hold model
 | Long hold + drag (≥ 400ms) | All connected windows move together as a group |
 | No connected windows | Window always moves alone regardless of hold duration |
 
-When a window detaches via short hold, its former connected peers remain connected to each other — only the dragged window separates.
+**Main window:** Treated the same as all other windows. A short-hold drag on the main window detaches it from its group; a long-hold drag moves the group. This is a deliberate behavior change from the current system (which always moved the main window with its group).
+
+**Body-area drags:** The `fromTitleBar` parameter is preserved in `windowWillStartDragging` for reference but is no longer used to gate undock logic. Both title-bar and body-area drags use the same hold-timing model.
+
+**Peer connectivity after detach:** When a window detaches via short hold, former peers remain connected to each other. No explicit graph update is needed — connectivity is position-derived (BFS adjacency check) and peers have not moved during the hold period (no `windowWillMove` calls have occurred). BFS on peers after detach correctly returns the unchanged peer group.
+
+The 400ms threshold aligns with typical macOS long-press conventions and feels responsive without triggering on accidental short clicks.
 
 ---
 
@@ -32,6 +44,7 @@ When a window detaches via short hold, its former connected peers remain connect
 private var holdStartTime: CFTimeInterval?
 private let holdThreshold: TimeInterval = 0.4  // 400ms
 private var dragMode: DragMode = .pending
+private var highlightWasPosted: Bool = false
 
 private enum DragMode {
     case pending   // mouseDown received, drag not yet started
@@ -42,27 +55,35 @@ private enum DragMode {
 
 ### Event flow
 
-1. **`windowWillStartDragging(_:fromTitleBar:)`**
-   - Sets `holdStartTime = CACurrentMediaTime()`
-   - Sets `dragMode = .pending`
+1. **`windowWillStartDragging(_:fromTitleBar:)`** — called from view's `mouseDown`
+   - Sets `holdStartTime = CACurrentMediaTime()`, `dragMode = .pending`
    - Finds connected windows via existing BFS (`findDockedWindows`)
-   - Posts `connectedWindowHighlightDidChange` with connected peers (if any)
+   - If connected peers exist: posts `connectedWindowHighlightDidChange` with peer set; sets `highlightWasPosted = true`
+   - Stores `dockedWindowOriginalOrigins` for peers (same as today — needed for restore on `.separate`)
 
-2. **First call to `windowWillMove(_:to:)`**
-   - If `dragMode == .pending`: determine mode based on elapsed time
-     - `elapsed < holdThreshold` → `.separate`: clear `dockedWindowsToMove`; the window drags alone and detaches
-     - `elapsed >= holdThreshold` → `.group`: proceed with existing group-move logic unchanged
-   - Subsequent calls skip mode determination (mode is already set)
+2. **First call to `windowWillMove(_:to:)`** where `dragMode == .pending`:
+   - Calculates `elapsed = CACurrentMediaTime() - (holdStartTime ?? 0)`
+   - `elapsed < holdThreshold` → `.separate`:
+     - Sets `dragMode = .separate`
+     - Restores all peers to `dockedWindowOriginalOrigins` (same restore logic as existing undock path)
+     - Clears `dockedWindowsToMove`, `dockedWindowOffsets`, `dockedWindowOriginalOrigins`
+     - If `highlightWasPosted`: posts empty `connectedWindowHighlightDidChange`; sets `highlightWasPosted = false`
+   - `elapsed >= holdThreshold` → `.group`:
+     - Sets `dragMode = .group`
+     - Proceeds with existing group-move logic unchanged
+   - Subsequent calls: skip determination (mode already set)
+   - **Fallback — `holdStartTime == nil`** (drag detected without a prior `mouseDown` call, e.g. via the existing `draggingWindow !== window` re-entry path in `windowWillMove`): set `dragMode = .group` and proceed with group-move logic. This preserves existing behavior for the edge case where dragging is detected mid-flight.
 
 3. **`windowDidFinishDragging(_:)`**
-   - Clears `holdStartTime`
-   - Resets `dragMode = .pending`
-   - Posts `connectedWindowHighlightDidChange` with empty set (clears highlight)
-   - Existing cleanup (snapping, child window updates, etc.) unchanged
+   - Clears `holdStartTime = nil`, resets `dragMode = .pending`
+   - If `highlightWasPosted`: posts empty `connectedWindowHighlightDidChange`; sets `highlightWasPosted = false`
+   - Existing cleanup (snapping, child window updates, tighten stack, etc.) unchanged
+
+4. **Window closed mid-drag**: `WindowManager` observes `NSWindow.willCloseNotification` centrally. If the closing window is `draggingWindow`, calls `windowDidFinishDragging` to clean up hold state. No changes to individual window controllers.
 
 ### Removed
 
-The existing `undockThreshold` (10px distance check) and its associated `isTitleBarDrag` / `isMainWindow` guard are removed. The timing model fully replaces them.
+The existing `undockThreshold` (10px distance check) and its `!isMainWindow && isTitleBarDrag && !dockedWindowsToMove.isEmpty` guard in `windowWillMove` are removed. These guarded undock logic only — not widget protection, which operates at the view layer before any `WindowManager` call. The `isTitleBarDrag` property is preserved for possible future use but is no longer read in the undock path.
 
 ---
 
@@ -78,28 +99,35 @@ static let connectedWindowHighlightDidChange = Notification.Name("connectedWindo
 // Empty set = clear all highlights
 ```
 
-- Posted at `windowWillStartDragging` with the set of connected peers (not the dragging window itself)
-- Posted at `windowDidFinishDragging` and when `.separate` mode is confirmed, with an empty set
+- Posted at `windowWillStartDragging` with peer set (only if peers exist)
+- Posted when `.separate` mode is confirmed (empty set, only if `highlightWasPosted`)
+- Posted at `windowDidFinishDragging` (empty set, only if `highlightWasPosted`)
+- Never posted for solo-window drags (no peers = no spurious notifications)
+
+**Brief flash on short-hold:** For short-hold drags, the highlight may appear for up to one event loop before the first `mouseDragged` fires and `.separate` clears it. This is imperceptible in practice.
 
 ### Rendering
 
-Each dockable window view (classic and modern) observes the notification:
+Each dockable window view observes `connectedWindowHighlightDidChange` and checks whether its `window` is in the `highlightedWindows` set.
 
-- Maintains a local `isHighlighted: Bool` flag
-- Sets `needsDisplay = true` on change
-- In `draw(_:)`: when `isHighlighted`, draws a semi-transparent overlay (e.g. `NSColor.white.withAlphaComponent(0.15)`) over the window content
+**Classic views** (`MainWindowView`, `PlaylistView`, `EQView`, `WaveformView`, classic `SpectrumView`):
+- Maintain an `isHighlighted: Bool` flag
+- On change: call `needsDisplay = true`
+- In `draw(_:)`: if `isHighlighted`, fill `bounds` with `NSColor.white.withAlphaComponent(0.15)` **after** the skin render pass (so it overlays the skin)
 
-The dragging window itself is **never** highlighted — only its connected peers are shown, so the user can clearly see what's attached to what they're grabbing.
+**Modern views** (`ModernMainWindowView`, `ModernPlaylistView`, `ModernWaveformView`, `ModernEQView`, `ModernSpectrumView`):
+- Use a `@State` bool or `@ObservedObject` observable driven by the notification
+- Render `Color.white.opacity(0.15)` as a `.overlay` on the root view
 
-**No connected windows:** If the dragged window has no connected peers, no notification is posted and no highlight appears.
+The dragging window is **never** highlighted — only its connected peers.
 
 ---
 
 ## Interaction Protection
 
-No changes to widget protection. The existing per-view `mouseDown` hit-testing already gates `windowWillStartDragging` — it is only called after confirming the click is not on a button, slider, or visualization area. The hold timer therefore cannot activate through widget interactions.
+No changes to widget protection. Per-view `mouseDown` hit-testing gates `windowWillStartDragging` — it is only called after confirming the click is not on a button, slider, or visualization area.
 
-Widgets that use drag motions (seek slider, volume slider, balance slider) already short-circuit `mouseDragged` via the `draggingSlider` flag before `windowWillMove` is reached. This is unchanged.
+Widgets using drag motions (seek slider, volume slider, balance slider) short-circuit `mouseDragged` via the `draggingSlider` flag before `windowWillMove` is reached. Removing `isTitleBarDrag` from the undock check does not affect this — slider and button hit-testing is handled entirely within the view's `mouseDown`, independent of `isTitleBarDrag`.
 
 ---
 
@@ -107,16 +135,17 @@ Widgets that use drag motions (seek slider, volume slider, balance slider) alrea
 
 | File | Change |
 |---|---|
-| `App/WindowManager.swift` | Add `DragMode` enum, `holdStartTime`, `holdThreshold`, `dragMode` state; update `windowWillStartDragging`, `windowWillMove`, `windowDidFinishDragging`; add `connectedWindowHighlightDidChange` notification; remove `undockThreshold` distance check |
-| `Windows/MainWindow/MainWindowView.swift` | Observe highlight notification, draw overlay |
-| `Windows/Playlist/PlaylistView.swift` | Observe highlight notification, draw overlay |
-| `Windows/Equalizer/EQView.swift` | Observe highlight notification, draw overlay |
-| `Windows/ModernMainWindow/ModernMainWindowView.swift` | Observe highlight notification, draw overlay |
-| `Windows/ModernPlaylist/ModernPlaylistView.swift` | Observe highlight notification, draw overlay |
-| `Windows/ModernWaveform/ModernWaveformView.swift` | Observe highlight notification, draw overlay |
-| `Windows/ModernEQ/ModernEQView.swift` | Observe highlight notification, draw overlay |
-| `Windows/Spectrum/SpectrumWindowController.swift` (or view) | Observe highlight notification, draw overlay |
-| `Windows/ModernSpectrum/ModernSpectrumView.swift` | Observe highlight notification, draw overlay |
+| `App/WindowManager.swift` | Add `DragMode` enum, `holdStartTime`, `holdThreshold`, `dragMode`, `highlightWasPosted` state; update `windowWillStartDragging`, `windowWillMove`, `windowDidFinishDragging`; add `connectedWindowHighlightDidChange` notification; add `NSWindow.willCloseNotification` observer for mid-drag cleanup; remove `undockThreshold` and undock distance check |
+| `Windows/MainWindow/MainWindowView.swift` | Observe highlight notification, draw overlay in `draw(_:)` |
+| `Windows/Playlist/PlaylistView.swift` | Observe highlight notification, draw overlay in `draw(_:)` |
+| `Windows/Equalizer/EQView.swift` | Observe highlight notification, draw overlay in `draw(_:)` |
+| `Windows/Waveform/WaveformView.swift` | Observe highlight notification, draw overlay in `draw(_:)` |
+| `Windows/Spectrum/` (classic spectrum view) | Observe highlight notification, draw overlay in `draw(_:)` |
+| `Windows/ModernMainWindow/ModernMainWindowView.swift` | Observe highlight notification, render overlay |
+| `Windows/ModernPlaylist/ModernPlaylistView.swift` | Observe highlight notification, render overlay |
+| `Windows/ModernWaveform/ModernWaveformView.swift` | Observe highlight notification, render overlay |
+| `Windows/ModernEQ/ModernEQView.swift` | Observe highlight notification, render overlay |
+| `Windows/ModernSpectrum/ModernSpectrumView.swift` | Observe highlight notification, render overlay |
 
 ---
 

--- a/skills/ui-guide/SKILL.md
+++ b/skills/ui-guide/SKILL.md
@@ -552,6 +552,25 @@ Complex snapping logic in `WindowManager`:
 - Coordinated minimize: uses `addChildWindow`/`removeChildWindow` in `windowWillMiniaturize`/`windowDidDeminiaturize` to temporarily make docked windows children of the main window so they animate into the dock together. Child relationships are removed on restore.
 - **Center stack collapse**: `slideUpWindowsBelow(closingFrame:)` in `WindowManager` slides docked windows up when a stack window is hidden. Called from `toggleEqualizer/Playlist/Spectrum/Waveform` — capture the frame BEFORE `orderOut`, then call it. Uses BFS over `dockThreshold`-adjacent windows (by vertical gap + horizontal overlap). Must set `isSnappingWindow = true` during moves to prevent the docking feedback loop.
 
+### Hold-Duration Drag Model
+
+Dragging a docked window uses a time-based mode determined at the first `mouseDragged` event:
+
+| Hold duration | Drag mode | Behaviour |
+|---|---|---|
+| < 400 ms (`holdThreshold`) | `.separate` | Dragged window detaches; peers stay connected to each other |
+| ≥ 400 ms | `.group` | All connected windows move together |
+
+Implementation details:
+- `DragMode` enum: `.pending` (not yet decided) / `.separate` / `.group`
+- `holdStartTime` captured at `mouseDown` via `windowWillStartDragging`; mode resolved at first `windowWillMove` call via `determineDragMode(holdStart:currentTime:threshold:)` (pure static, unit-tested)
+- Separate mode: peers are restored to their pre-drag origins before the dock is broken
+- Group mode: connected windows move using stored offsets from drag start to prevent drift; child windows of the dragging window are skipped (AppKit moves them automatically); group top is clamped so no window goes off-screen
+- Mid-drag window close: `NSWindow.willCloseNotification` observer cleans up hold state and clears highlights
+- Mid-flight drag (AppKit-initiated, no prior `mouseDown`): always `.group` mode (override)
+- **Connected window highlight**: at `mouseDown`, all peer windows receive a `white @ 15% opacity` overlay via `connectedWindowHighlightDidChange` notification. Cleared when drag ends or `.separate` mode is resolved. All 10 dockable views (5 classic + 5 modern) observe this notification.
+- `isMovingDockedWindows` flag prevents re-entrant `windowWillMove` calls while peers are being repositioned
+
 ## Related Documentation
 
 - **non-retina-fixes skill** - Fixes for rendering artifacts on 1x displays (blue lines, tile seams, text shimmering)

--- a/skills/user-guide/SKILL.md
+++ b/skills/user-guide/SKILL.md
@@ -43,9 +43,13 @@ Global controls are also available from the macOS top menu bar:
 Windows automatically snap together when dragged near each other:
 - Edge-to-edge snapping
 - Screen edge snapping
-- Group movement (docked windows move together)
 - Group minimize (attached windows minimize together)
 - **Snap to Default** (context menu) resets all windows
+
+**Drag behaviour:**
+- **Quick drag** (release mouse within ~400 ms of clicking): the dragged window detaches from its group and moves alone; other connected windows stay put
+- **Hold then drag** (hold ≥ 400 ms before moving): all connected windows move together as a group
+- Connected peers show a brief highlight overlay at mouseDown to preview which windows will move together
 
 ### Main Window Elements
 

--- a/skills/visualizations/SKILL.md
+++ b/skills/visualizations/SKILL.md
@@ -192,6 +192,7 @@ Place `.milk` files in this folder and use "Reload Presets" from context menu.
 - **Frame Rate**: 60 FPS via CVDisplayLink
 - **Audio Input**: PCM waveform data from AudioEngine
 - **Beat Detection**: Built-in projectM beat sensitivity (adjustable)
+- **Drag suspend**: ProjectM rendering is suspended for the duration of any window drag (`.windowDragDidBegin` / `.windowDragDidEnd` notifications from `WindowManager`). This prevents WindowServer stalls on Apple Silicon caused by simultaneous OpenGL compositing and window repositioning. If adding new window-movement code that runs outside a drag, do not rely on ProjectM being suspended — the suspend is drag-scoped only.
 
 ### Audio Sensitivity (PCM Gain)
 


### PR DESCRIPTION
## Summary

- Replaces the 10px distance-based undock mechanism with a time-based hold model
- Short hold + drag (< 400ms): dragged window separates from its connected group; group stays intact
- Long hold + drag (≥ 400ms): all connected windows move together as a group
- Peer windows are highlighted at mouseDown to preview which windows belong to the group
- Group clamped so no window goes off-screen at top during group drags
- ProjectM rendering suspended during drags to prevent WindowServer stalls

## Changes

- `WindowManager`: new `DragMode` enum (`.pending` / `.separate` / `.group`), `holdStartTime` / `holdThreshold` / `highlightWasPosted` state; `determineDragMode()` pure static function; `connectedWindowHighlightDidChange` notification; `NSWindow.willCloseNotification` observer for mid-drag cleanup; removes `undockThreshold` and distance-based undock check; group top clamping; ProjectM suspend/resume around drag
- All 10 dockable window views (5 classic + 5 modern): observe `connectedWindowHighlightDidChange` and render a `white @ 15% opacity` overlay when highlighted

## Test Plan

- [ ] Unit tests: `swift test --filter WindowManagerDragModeTests` — 5/5 pass
- [ ] Short-hold drag (< 400ms) on a docked window: window detaches, peers remain connected to each other
- [ ] Long-hold drag (≥ 400ms) on a docked window: all connected windows move as a group
- [ ] Solo window (no peers): always moves alone regardless of hold duration
- [ ] Group highlight appears at mouseDown on connected peers, clears on drag start (short) or drag end (group)
- [ ] Main window treated identically to other windows (no special-case behavior)
- [ ] Mid-drag window close: hold state cleaned up, no stale highlights
- [ ] Group drag: no window pushed off top of screen
- [ ] ProjectM active: no WindowServer stall / visual freeze during drag
- [ ] All window types: main, playlist, EQ, spectrum, waveform (classic + modern)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Time-based drag: quick drags move a single window, hold-then-drag moves connected window groups; connected peers show a semi‑transparent highlight preview and drag begin/end notifications.

* **Improvements**
  * Rendering suspended during drags to avoid visual contention; deferred surface updates applied after drag ends.
  * Robust mid-drag handling: window-close and cleanup behavior improved.

* **Documentation**
  * Design/spec and changelog updated for connected-window drag rules.

* **Tests**
  * Unit tests added for drag-mode determination.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->