### PR TITLE
fix: restore radio metadata display when replayed without RadioManager

### DIFF
--- a/Sources/NullPlayer/Audio/AudioEngine.swift
+++ b/Sources/NullPlayer/Audio/AudioEngine.swift
@@ -3088,10 +3088,14 @@ class AudioEngine {
         currentTrack = track
         _currentTime = 0
         lastReportedTime = 0
-        
+
+        // Re-activate RadioManager if the URL belongs to a known station but radio isn't active.
+        // This handles playlist replay and state-restore paths that bypass RadioManager.play(station:).
+        RadioManager.shared.reactivateIfNeeded(for: track.url)
+
         // Increment generation
         playbackGeneration += 1
-        
+
         // Start playback through the streaming player (routes through AVAudioEngine with EQ)
         streamingPlayer?.play(url: track.url)
         

--- a/Sources/NullPlayer/Radio/RadioManager.swift
+++ b/Sources/NullPlayer/Radio/RadioManager.swift
@@ -1599,6 +1599,20 @@ class RadioManager {
         return false
     }
 
+    /// Re-activate radio for a stream URL that is already playing (e.g. playlist replay or state restore).
+    /// Used when the audio engine starts playing a radio URL without going through `play(station:)`,
+    /// leaving `isActive = false` and causing ICY metadata to be silently dropped.
+    /// No-op if radio is already active or the URL does not match a known station.
+    func reactivateIfNeeded(for url: URL) {
+        guard currentStation == nil else { return }
+        guard let station = stations.first(where: { $0.url == url }) else { return }
+        NSLog("RadioManager: Re-activating for station '%@' (played without RadioManager)", station.name)
+        manualStopRequested = false
+        currentStation = station
+        connectionState = .connecting
+        // connectionState will update to .connected once streamDidConnect() fires
+    }
+
     /// Stop radio playback
     func stop() {
         manualStopRequested = true


### PR DESCRIPTION
## Summary

- Radio played via playlist double-click, play button after stop, or state restore bypassed `RadioManager.play(station:)`, leaving `isActive = false`
- This caused ICY stream metadata to be silently dropped and the classic main window marquee to show stale track info instead of live station metadata
- Add `RadioManager.reactivateIfNeeded(for:)` — called from `loadStreamingTrack` — which looks up the stream URL in the known stations list and re-activates RadioManager if found while inactive

## Test plan

- [ ] Play a radio station from the browser, stop it, press play again — marquee should show station name then update to ICY stream title
- [ ] Double-click a radio track in the playlist — ICY metadata should appear in marquee
- [ ] Normal path (play from browser) still works — `reactivateIfNeeded` is a no-op when `currentStation` is already set

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Enhanced radio connectivity handling to automatically restore active station state when resuming playback of streaming content associated with known stations, ensuring proper connection management during playlist and state recovery scenarios.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->