### PR TITLE
fix: waveform prerender extension and corrupt stream loop

### DIFF
--- a/Sources/NullPlayer/Audio/AudioEngine.swift
+++ b/Sources/NullPlayer/Audio/AudioEngine.swift
@@ -4697,7 +4697,8 @@ extension AudioEngine: StreamingAudioPlayerDelegate {
 
             Task { [weak self] in
                 guard let self else { return }
-                if let refreshedTrack = await StreamingTrackResolver.resolve(failingTrack) {
+                if let refreshedTrack = await StreamingTrackResolver.resolve(failingTrack),
+                   refreshedTrack.url.path != failingTrack.url.path {
                     await MainActor.run {
                         guard retryIndex >= 0 && retryIndex < self.playlist.count else { return }
                         // Ensure we're still looking at the same logical service track.
@@ -4708,6 +4709,8 @@ extension AudioEngine: StreamingAudioPlayerDelegate {
                         }
                     }
                 } else {
+                    // Resolve returned nil or the same file path — token refresh won't help
+                    // (file is corrupt or permanently unavailable). Advance to next track.
                     await MainActor.run {
                         self.handleStreamingErrorFallback(error, errorDescription: errorDescription)
                     }
@@ -4722,9 +4725,14 @@ extension AudioEngine: StreamingAudioPlayerDelegate {
     private func handleStreamingErrorFallback(_ error: AudioPlayerError, errorDescription: String) {
         let isPacketTableError = errorDescription.contains("packet table")
             || errorDescription.contains("streamParseBytesFailure")
+        let isCodecError = errorDescription.contains("codecError")
 
-        if isPacketTableError {
-            NSLog("AudioEngine: M4A parsing error - file may not be optimized for streaming")
+        if isPacketTableError || isCodecError {
+            if isPacketTableError {
+                NSLog("AudioEngine: M4A parsing error - file may not be optimized for streaming")
+            } else {
+                NSLog("AudioEngine: Codec error - file is corrupt or unplayable, advancing")
+            }
 
             // Show error in marquee briefly, then advance to next track
             if let track = currentTrack {

--- a/Sources/NullPlayer/Audio/AudioEngine.swift
+++ b/Sources/NullPlayer/Audio/AudioEngine.swift
@@ -4665,8 +4665,17 @@ extension AudioEngine: StreamingAudioPlayerDelegate {
         // Handle streaming errors gracefully
         // The error callback fires BEFORE the state changes to .error
         // so we handle recovery here
+
+        // AudioStreaming fires this delegate method multiple times for a single error.
+        // If a refresh is already in-flight for this track, suppress duplicate callbacks.
+        if let identity = currentTrack?.streamingServiceIdentity,
+           staleStreamingRefreshRetriedServiceIdentity == identity {
+            NSLog("AudioEngine: Ignoring duplicate streaming error - %@", String(describing: error))
+            return
+        }
+
         NSLog("AudioEngine: Streaming error - %@", String(describing: error))
-        
+
         // Check if this is a radio stream - let RadioManager handle reconnection
         if RadioManager.shared.isActive {
             NSLog("AudioEngine: Radio stream error - delegating to RadioManager for reconnect")

--- a/Sources/NullPlayer/Waveform/WaveformCacheService.swift
+++ b/Sources/NullPlayer/Waveform/WaveformCacheService.swift
@@ -398,9 +398,12 @@ actor WaveformCacheService {
             ])
         }
 
+        // Use the source URL's path extension (strips query string) rather than
+        // the temp download path, which has no extension and would resolve to ".bin"
+        let sourceExt = descriptor.sourceURL.pathExtension
         let localURL = FileManager.default.temporaryDirectory
             .appendingPathComponent("waveform-prerender-\(UUID().uuidString)")
-            .appendingPathExtension(tempDownloadURL.pathExtension.isEmpty ? "bin" : tempDownloadURL.pathExtension)
+            .appendingPathExtension(sourceExt.isEmpty ? "bin" : sourceExt)
 
         try? FileManager.default.removeItem(at: localURL)
         try FileManager.default.moveItem(at: tempDownloadURL, to: localURL)


### PR DESCRIPTION
## Summary

- **Waveform never rendered for Plex FLAC tracks** — `generateServiceSnapshotViaDownload` was naming the temp file with `.bin` because `tempDownloadURL.pathExtension` is always empty (URLSession temp paths have no extension). Fixed by using `descriptor.sourceURL.pathExtension` instead, which correctly returns `flac` from the Plex URL (Swift's `URL.pathExtension` strips query strings).

- **Corrupt streaming tracks caused an infinite play loop** — when a `codecError` occurred, the URL refresh resolved the same file path (same corrupt file, just a fresh token) and called `loadTrack` again, restarting the unplayable track indefinitely. Fixed with two changes:
  - Refresh task now compares `refreshedTrack.url.path` vs `failingTrack.url.path`; if same, falls through to the error handler instead of reloading
  - `handleStreamingErrorFallback` now treats `codecError` like packet table errors — posts an error notification and advances to the next track

- **Duplicate `codecError` callbacks** from the AudioStreaming library are now suppressed after the first one is handled (dedup guard at top of `streamingPlayerDidEncounterError`).

## Test plan

- [ ] Play Plex FLAC tracks — waveform should render (no more "Remote asset-reader prerender failed / Operation Stopped" in logs)
- [ ] Confirm a corrupt/undecodable streaming track auto-advances instead of looping
- [ ] Confirm normal track transitions and crossfades are unaffected

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Bug Fixes
* Enhanced streaming error handling to prevent duplicate error callbacks during playback recovery attempts.
* Improved streaming URL refresh logic to detect when refreshes are ineffective and advance playback accordingly.
* Added support for detecting and handling codec-related playback errors with clearer notifications.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->