### PR TITLE
fix: audio distortion, play history data loss, token redaction (0.19.1)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,11 @@
 # Changelog
 
+## 0.19.1
+
+### Security
+
+- **Redact auth tokens from logs** — Subsonic credentials (`u`, `t`, `s`) and Plex tokens (`X-Plex-Token`) are now stripped from all NSLog output. A shared `URL.redacted` extension covers streaming playback, gapless queue, cast, and recovery log sites.
+
 ## 0.19.0
 
 ### Play History (modern UI)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,11 @@
 
 ## 0.19.1
 
+### Bug Fixes
+
+- **Audio distortion after long idle fixed** — removed the `AUDynamicsProcessor` limiter from the audio chain. The node caused intermittent heavy distortion after macOS put the audio hardware into a power-saving state: `AVAudioEngineConfigurationChange` would fire, reconnect the node, and reset it to Apple's aggressive defaults (threshold −20 dB, 2:1 expansion) with no way to recover without restarting the app. Signal chain is now `playerNode → mixerNode → eqNode → output`.
+- **Play/radio history no longer lost on quit** — history writes and play-event inserts now complete synchronously before the process exits. Cast track completions also now record play events (previously missing). The MediaLibrary WAL is checkpointed and closed on `applicationWillTerminate` to flush any pending writes before shutdown.
+
 ### Security
 
 - **Redact auth tokens from logs** — Subsonic credentials (`u`, `t`, `s`) and Plex tokens (`X-Plex-Token`) are now stripped from all NSLog output. A shared `URL.redacted` extension covers streaming playback, gapless queue, cast, and recovery log sites.

--- a/Sources/NullPlayer/App/AppDelegate.swift
+++ b/Sources/NullPlayer/App/AppDelegate.swift
@@ -154,6 +154,10 @@ class AppDelegate: NSObject, NSApplicationDelegate {
         
         // Save window positions (always saved, used by snapToDefault)
         windowManager.saveWindowPositions()
+
+        // Flush WAL to disk before exit so history survives hard shutdown / reboot
+        MediaLibraryStore.shared.checkpoint()
+        MediaLibraryStore.shared.close()
     }
     
     func applicationShouldTerminateAfterLastWindowClosed(_ sender: NSApplication) -> Bool {

--- a/Sources/NullPlayer/Audio/AudioEngine.swift
+++ b/Sources/NullPlayer/Audio/AudioEngine.swift
@@ -121,19 +121,6 @@ class AudioEngine {
     /// Equalizer
     private let eqNode: AVAudioUnitEQ
     
-    /// Limiter for anti-clipping protection when EQ boosts are applied
-    /// Uses Apple's built-in AUDynamicsProcessor Audio Unit
-    private let limiterNode: AVAudioUnitEffect = {
-        let componentDescription = AudioComponentDescription(
-            componentType: kAudioUnitType_Effect,
-            componentSubType: kAudioUnitSubType_DynamicsProcessor,
-            componentManufacturer: kAudioUnitManufacturer_Apple,
-            componentFlags: 0,
-            componentFlagsMask: 0
-        )
-        return AVAudioUnitEffect(audioComponentDescription: componentDescription)
-    }()
-    
     /// Mixer node to combine player nodes (class property for graph rebuilding)
     private let mixerNode = AVAudioMixerNode()
     
@@ -965,27 +952,22 @@ class AudioEngine {
         engine.attach(playerNode)
         engine.attach(crossfadePlayerNode)  // For Sweet Fades crossfade
         engine.attach(eqNode)
-        engine.attach(limiterNode)
         engine.attach(mixerNode)  // Class property for graph rebuilding
         
         // Get the standard format from the mixer
         let mixerFormat = engine.mainMixerNode.outputFormat(forBus: 0)
         
         // Signal flow: playerNode ─┐
-        //                          ├─► mixerNode ─► eqNode ─► limiter ─► output
+        //                          ├─► mixerNode ─► eqNode ─► output
         //  crossfadePlayerNode ────┘
         
         // Connect both players to the mixer
         engine.connect(playerNode, to: mixerNode, format: mixerFormat)
         engine.connect(crossfadePlayerNode, to: mixerNode, format: mixerFormat)
         
-        // Connect mixer to EQ to limiter to output
+        // Connect mixer to EQ to output
         engine.connect(mixerNode, to: eqNode, format: mixerFormat)
-        engine.connect(eqNode, to: limiterNode, format: mixerFormat)
-        engine.connect(limiterNode, to: engine.mainMixerNode, format: mixerFormat)
-        
-        // Configure limiter for transparent anti-clipping
-        configureLimiter()
+        engine.connect(eqNode, to: engine.mainMixerNode, format: mixerFormat)
         
         // Player nodes stay at unity gain (1.0) - volume applied at mainMixerNode
         // This ensures the spectrum tap captures volume-independent audio
@@ -1003,40 +985,6 @@ class AudioEngine {
         
         // Prepare engine
         engine.prepare()
-    }
-    
-    /// Configure the limiter Audio Unit for transparent anti-clipping protection
-    private func configureLimiter() {
-        let audioUnit = limiterNode.audioUnit
-        
-        // AUDynamicsProcessor parameters (from AudioUnitParameters.h):
-        // kDynamicsProcessorParam_Threshold = 0 (dB, -40 to 20)
-        // kDynamicsProcessorParam_HeadRoom = 1 (dB, 0.1 to 40)
-        // kDynamicsProcessorParam_ExpansionRatio = 2 (1 to 50)
-        // kDynamicsProcessorParam_AttackTime = 4 (seconds, 0.0001 to 0.2)
-        // kDynamicsProcessorParam_ReleaseTime = 5 (seconds, 0.01 to 3)
-        // kDynamicsProcessorParam_MasterGain = 6 (dB, -40 to 40)
-        // kDynamicsProcessorParam_CompressionAmount = 1000 (read-only, dB)
-        
-        // Set threshold close to 0 dB to catch peaks before clipping
-        AudioUnitSetParameter(audioUnit, 0, kAudioUnitScope_Global, 0, -1.0, 0)
-        
-        // Set headroom (how much above threshold before limiting kicks in hard)
-        AudioUnitSetParameter(audioUnit, 1, kAudioUnitScope_Global, 0, 1.0, 0)
-        
-        // Expansion ratio = 1 (no expansion, only compression/limiting)
-        AudioUnitSetParameter(audioUnit, 2, kAudioUnitScope_Global, 0, 1.0, 0)
-        
-        // Fast attack time (1ms) for transparent limiting
-        AudioUnitSetParameter(audioUnit, 4, kAudioUnitScope_Global, 0, 0.001, 0)
-        
-        // Medium release time (50ms)
-        AudioUnitSetParameter(audioUnit, 5, kAudioUnitScope_Global, 0, 0.05, 0)
-        
-        // No makeup gain
-        AudioUnitSetParameter(audioUnit, 6, kAudioUnitScope_Global, 0, 0.0, 0)
-        
-        NSLog("AudioEngine: Limiter configured for anti-clipping protection")
     }
     
     /// Load audio quality preferences from UserDefaults
@@ -1076,9 +1024,8 @@ class AudioEngine {
         engine.connect(playerNode, to: mixerNode, format: mixerFormat)
         engine.connect(crossfadePlayerNode, to: mixerNode, format: mixerFormat)
         engine.connect(mixerNode, to: eqNode, format: mixerFormat)
-        engine.connect(eqNode, to: limiterNode, format: mixerFormat)
-        engine.connect(limiterNode, to: engine.mainMixerNode, format: mixerFormat)
-        
+        engine.connect(eqNode, to: engine.mainMixerNode, format: mixerFormat)
+
         // Re-schedule current audio if we were playing local files
         if wasPlaying && !isStreamingPlayback, let file = audioFile {
             do {

--- a/Sources/NullPlayer/Audio/AudioEngine.swift
+++ b/Sources/NullPlayer/Audio/AudioEngine.swift
@@ -3673,7 +3673,7 @@ class AudioEngine {
     
     private func loadStreamingTrack(_ track: Track) {
         NSLog("loadStreamingTrack: %@ - %@", track.artist ?? "Unknown", track.title)
-        NSLog("  URL: %@", track.url.absoluteString)
+        NSLog("  URL: %@", track.url.redacted)
         
         // Stop local playback and REMOVE spectrum tap (streaming player has its own)
         playerNode.stop()

--- a/Sources/NullPlayer/Audio/AudioEngine.swift
+++ b/Sources/NullPlayer/Audio/AudioEngine.swift
@@ -2564,14 +2564,34 @@ class AudioEngine {
 
         // Record to radio history (track actually finished playing via cast)
         if let finishedTrack = currentTrack {
-            Task.detached(priority: .utility) { [track = finishedTrack] in
-                switch track.playHistorySource {
-                case .plex:      PlexRadioHistory.shared.recordTrackPlayed(track)
-                case .subsonic:  SubsonicRadioHistory.shared.recordTrackPlayed(track)
-                case .jellyfin:  JellyfinRadioHistory.shared.recordTrackPlayed(track)
-                case .emby:      EmbyRadioHistory.shared.recordTrackPlayed(track)
-                case .local, .radio:
-                    LocalRadioHistory.shared.recordTrackPlayed(track)
+            switch finishedTrack.playHistorySource {
+            case .plex:      PlexRadioHistory.shared.recordTrackPlayed(finishedTrack)
+            case .subsonic:  SubsonicRadioHistory.shared.recordTrackPlayed(finishedTrack)
+            case .jellyfin:  JellyfinRadioHistory.shared.recordTrackPlayed(finishedTrack)
+            case .emby:      EmbyRadioHistory.shared.recordTrackPlayed(finishedTrack)
+            case .local, .radio:
+                LocalRadioHistory.shared.recordTrackPlayed(finishedTrack)
+            }
+        }
+
+        // Play event (analytics) — inline to survive quit
+        if let finishedTrack = currentTrack {
+            let trackId = finishedTrack.playHistoryTrackIdentifier
+            let eventId = MediaLibraryStore.shared.insertPlayEvent(
+                trackId: trackId,
+                trackURL: finishedTrack.url.isFileURL ? finishedTrack.url.absoluteString : nil,
+                title: finishedTrack.title,
+                artist: finishedTrack.artist,
+                album: finishedTrack.album,
+                genre: finishedTrack.genre,
+                playedAt: Date(),
+                durationListened: finishedTrack.duration ?? 0,
+                source: finishedTrack.playHistorySource.rawValue,
+                skipped: false)
+            if let eventId, finishedTrack.genre == nil || finishedTrack.genre?.isEmpty == true {
+                Task.detached(priority: .utility) { [track = finishedTrack] in
+                    await GenreDiscoveryService.shared.enrichPlayEvent(
+                        id: eventId, title: track.title, artist: track.artist, album: track.album)
                 }
             }
         }
@@ -3812,36 +3832,32 @@ class AudioEngine {
 
         // Record to radio history (track actually finished playing)
         if let finishedTrack = currentTrack {
-            Task.detached(priority: .utility) { [track = finishedTrack] in
-                switch track.playHistorySource {
-                case .plex:      PlexRadioHistory.shared.recordTrackPlayed(track)
-                case .subsonic:  SubsonicRadioHistory.shared.recordTrackPlayed(track)
-                case .jellyfin:  JellyfinRadioHistory.shared.recordTrackPlayed(track)
-                case .emby:      EmbyRadioHistory.shared.recordTrackPlayed(track)
-                case .local, .radio:
-                    LocalRadioHistory.shared.recordTrackPlayed(track)
-                }
+            switch finishedTrack.playHistorySource {
+            case .plex:      PlexRadioHistory.shared.recordTrackPlayed(finishedTrack)
+            case .subsonic:  SubsonicRadioHistory.shared.recordTrackPlayed(finishedTrack)
+            case .jellyfin:  JellyfinRadioHistory.shared.recordTrackPlayed(finishedTrack)
+            case .emby:      EmbyRadioHistory.shared.recordTrackPlayed(finishedTrack)
+            case .local, .radio:
+                LocalRadioHistory.shared.recordTrackPlayed(finishedTrack)
             }
         }
 
         // Record play event to analytics
         if let finishedTrack = currentTrack {
-            Task.detached(priority: .utility) { [track = finishedTrack] in
-                let trackId: String?
-                trackId = track.playHistoryTrackIdentifier
-
-                if let eventId = MediaLibraryStore.shared.insertPlayEvent(
-                    trackId: trackId,
-                    trackURL: track.url.isFileURL ? track.url.absoluteString : nil,
-                    title: track.title,
-                    artist: track.artist,
-                    album: track.album,
-                    genre: track.genre,
-                    playedAt: Date(),
-                    durationListened: track.duration ?? 0,
-                    source: track.playHistorySource.rawValue,
-                    skipped: false),
-                   track.genre == nil || track.genre?.isEmpty == true {
+            let trackId = finishedTrack.playHistoryTrackIdentifier
+            let eventId = MediaLibraryStore.shared.insertPlayEvent(
+                trackId: trackId,
+                trackURL: finishedTrack.url.isFileURL ? finishedTrack.url.absoluteString : nil,
+                title: finishedTrack.title,
+                artist: finishedTrack.artist,
+                album: finishedTrack.album,
+                genre: finishedTrack.genre,
+                playedAt: Date(),
+                durationListened: finishedTrack.duration ?? 0,
+                source: finishedTrack.playHistorySource.rawValue,
+                skipped: false)
+            if let eventId, finishedTrack.genre == nil || finishedTrack.genre?.isEmpty == true {
+                Task.detached(priority: .utility) { [track = finishedTrack] in
                     await GenreDiscoveryService.shared.enrichPlayEvent(
                         id: eventId, title: track.title, artist: track.artist, album: track.album)
                 }
@@ -4379,36 +4395,32 @@ class AudioEngine {
         
         // Record outgoing track to radio history (track finished via crossfade)
         if let outgoingTrack = currentTrack {
-            Task.detached(priority: .utility) { [track = outgoingTrack] in
-                switch track.playHistorySource {
-                case .plex:      PlexRadioHistory.shared.recordTrackPlayed(track)
-                case .subsonic:  SubsonicRadioHistory.shared.recordTrackPlayed(track)
-                case .jellyfin:  JellyfinRadioHistory.shared.recordTrackPlayed(track)
-                case .emby:      EmbyRadioHistory.shared.recordTrackPlayed(track)
-                case .local, .radio:
-                    LocalRadioHistory.shared.recordTrackPlayed(track)
-                }
+            switch outgoingTrack.playHistorySource {
+            case .plex:      PlexRadioHistory.shared.recordTrackPlayed(outgoingTrack)
+            case .subsonic:  SubsonicRadioHistory.shared.recordTrackPlayed(outgoingTrack)
+            case .jellyfin:  JellyfinRadioHistory.shared.recordTrackPlayed(outgoingTrack)
+            case .emby:      EmbyRadioHistory.shared.recordTrackPlayed(outgoingTrack)
+            case .local, .radio:
+                LocalRadioHistory.shared.recordTrackPlayed(outgoingTrack)
             }
         }
 
         // Record play event to analytics (track finished via crossfade)
         if let outgoingTrack = currentTrack {
-            Task.detached(priority: .utility) { [track = outgoingTrack] in
-                let trackId: String?
-                trackId = track.playHistoryTrackIdentifier
-
-                if let eventId = MediaLibraryStore.shared.insertPlayEvent(
-                    trackId: trackId,
-                    trackURL: track.url.isFileURL ? track.url.absoluteString : nil,
-                    title: track.title,
-                    artist: track.artist,
-                    album: track.album,
-                    genre: track.genre,
-                    playedAt: Date(),
-                    durationListened: track.duration ?? 0,
-                    source: track.playHistorySource.rawValue,
-                    skipped: false),
-                   track.genre == nil || track.genre?.isEmpty == true {
+            let trackId = outgoingTrack.playHistoryTrackIdentifier
+            let eventId = MediaLibraryStore.shared.insertPlayEvent(
+                trackId: trackId,
+                trackURL: outgoingTrack.url.isFileURL ? outgoingTrack.url.absoluteString : nil,
+                title: outgoingTrack.title,
+                artist: outgoingTrack.artist,
+                album: outgoingTrack.album,
+                genre: outgoingTrack.genre,
+                playedAt: Date(),
+                durationListened: outgoingTrack.duration ?? 0,
+                source: outgoingTrack.playHistorySource.rawValue,
+                skipped: false)
+            if let eventId, outgoingTrack.genre == nil || outgoingTrack.genre?.isEmpty == true {
+                Task.detached(priority: .utility) { [track = outgoingTrack] in
                     await GenreDiscoveryService.shared.enrichPlayEvent(
                         id: eventId, title: track.title, artist: track.artist, album: track.album)
                 }
@@ -4494,36 +4506,32 @@ class AudioEngine {
         
         // Record outgoing track to radio history (track finished via streaming crossfade)
         if let outgoingTrack = currentTrack {
-            Task.detached(priority: .utility) { [track = outgoingTrack] in
-                switch track.playHistorySource {
-                case .plex:      PlexRadioHistory.shared.recordTrackPlayed(track)
-                case .subsonic:  SubsonicRadioHistory.shared.recordTrackPlayed(track)
-                case .jellyfin:  JellyfinRadioHistory.shared.recordTrackPlayed(track)
-                case .emby:      EmbyRadioHistory.shared.recordTrackPlayed(track)
-                case .local, .radio:
-                    LocalRadioHistory.shared.recordTrackPlayed(track)
-                }
+            switch outgoingTrack.playHistorySource {
+            case .plex:      PlexRadioHistory.shared.recordTrackPlayed(outgoingTrack)
+            case .subsonic:  SubsonicRadioHistory.shared.recordTrackPlayed(outgoingTrack)
+            case .jellyfin:  JellyfinRadioHistory.shared.recordTrackPlayed(outgoingTrack)
+            case .emby:      EmbyRadioHistory.shared.recordTrackPlayed(outgoingTrack)
+            case .local, .radio:
+                LocalRadioHistory.shared.recordTrackPlayed(outgoingTrack)
             }
         }
 
         // Record play event to analytics (track finished via streaming crossfade)
         if let outgoingTrack = currentTrack {
-            Task.detached(priority: .utility) { [track = outgoingTrack] in
-                let trackId: String?
-                trackId = track.playHistoryTrackIdentifier
-
-                if let eventId = MediaLibraryStore.shared.insertPlayEvent(
-                    trackId: trackId,
-                    trackURL: track.url.isFileURL ? track.url.absoluteString : nil,
-                    title: track.title,
-                    artist: track.artist,
-                    album: track.album,
-                    genre: track.genre,
-                    playedAt: Date(),
-                    durationListened: track.duration ?? 0,
-                    source: track.playHistorySource.rawValue,
-                    skipped: false),
-                   track.genre == nil || track.genre?.isEmpty == true {
+            let trackId = outgoingTrack.playHistoryTrackIdentifier
+            let eventId = MediaLibraryStore.shared.insertPlayEvent(
+                trackId: trackId,
+                trackURL: outgoingTrack.url.isFileURL ? outgoingTrack.url.absoluteString : nil,
+                title: outgoingTrack.title,
+                artist: outgoingTrack.artist,
+                album: outgoingTrack.album,
+                genre: outgoingTrack.genre,
+                playedAt: Date(),
+                durationListened: outgoingTrack.duration ?? 0,
+                source: outgoingTrack.playHistorySource.rawValue,
+                skipped: false)
+            if let eventId, outgoingTrack.genre == nil || outgoingTrack.genre?.isEmpty == true {
+                Task.detached(priority: .utility) { [track = outgoingTrack] in
                     await GenreDiscoveryService.shared.enrichPlayEvent(
                         id: eventId, title: track.title, artist: track.artist, album: track.album)
                 }

--- a/Sources/NullPlayer/Audio/StreamingAudioPlayer.swift
+++ b/Sources/NullPlayer/Audio/StreamingAudioPlayer.swift
@@ -269,7 +269,7 @@ class StreamingAudioPlayer {
     
     /// Play audio from a URL (local or remote)
     func play(url: URL) {
-        NSLog("StreamingAudioPlayer: Playing URL: %@", url.absoluteString)
+        NSLog("StreamingAudioPlayer: Playing URL: %@", url.redacted)
         hasReportedFormat = false  // Reset for new track
         _hasQueuedTrack = false     // Clear any previous queue state
         bpmDetector.reset()         // Reset BPM for new track
@@ -320,7 +320,7 @@ class StreamingAudioPlayer {
     /// Queue a URL for gapless playback after current track
     /// Uses AudioStreaming's built-in queue API
     func queue(url: URL) {
-        NSLog("StreamingAudioPlayer: Queueing URL for gapless: %@", url.absoluteString)
+        NSLog("StreamingAudioPlayer: Queueing URL for gapless: %@", url.redacted)
         player.queue(url: url)
         _hasQueuedTrack = true
     }
@@ -340,7 +340,7 @@ class StreamingAudioPlayer {
     
     /// Attempt to recover from error state by reloading the current URL
     func attemptRecovery(with url: URL) {
-        NSLog("StreamingAudioPlayer: Attempting recovery with URL: %@", url.absoluteString)
+        NSLog("StreamingAudioPlayer: Attempting recovery with URL: %@", url.redacted)
         stop()
         play(url: url)
     }

--- a/Sources/NullPlayer/Casting/CastManager.swift
+++ b/Sources/NullPlayer/Casting/CastManager.swift
@@ -142,7 +142,7 @@ class CastManager {
         if let pollResult = await upnpManager.pollSonosPlaybackState() {
             savedPosition = pollResult.position
         }
-        NSLog("CastManager: Saved state - URL: %@, position: %.1f", savedURL.absoluteString, savedPosition)
+        NSLog("CastManager: Saved state - URL: %@, position: %.1f", savedURL.redacted, savedPosition)
         
         // 2. Stop polling and topology refresh to prevent interference during swap
         stopSonosPolling()
@@ -709,7 +709,7 @@ class CastManager {
     
     /// Cast a specific track to a device
     func castTrack(_ track: Track, to device: CastDevice, startPosition: TimeInterval = 0) async throws {
-        NSLog("CastManager: castTrack called for '%@' - track.url: %@", track.title, track.url.absoluteString)
+        NSLog("CastManager: castTrack called for '%@' - track.url: %@", track.title, track.url.redacted)
         NSLog("CastManager: track.subsonicId=%@, track.jellyfinId=%@, track.embyId=%@, track.plexRatingKey=%@",
               track.subsonicId ?? "nil", track.jellyfinId ?? "nil", track.embyId ?? "nil", track.plexRatingKey ?? "nil")
 
@@ -728,7 +728,7 @@ class CastManager {
                 let result = try await prepareProxyURL(for: track, device: device)
                 castURL = result.url
                 effectiveContentType = result.contentType
-                NSLog("CastManager: Using proxy for Subsonic/Jellyfin/Emby->Sonos: %@", castURL.absoluteString)
+                NSLog("CastManager: Using proxy for Subsonic/Jellyfin/Emby->Sonos: %@", castURL.redacted)
             } else {
                 // For Plex/remote URLs, ensure token is included
                 if let tokenizedURL = PlexManager.shared.getCastableStreamURL(for: track.url) {
@@ -791,7 +791,7 @@ class CastManager {
             contentType: contentType
         )
         
-        NSLog("CastManager: castTrack URL: %@, contentType: %@", finalCastURL.absoluteString, contentType)
+        NSLog("CastManager: castTrack URL: %@, contentType: %@", finalCastURL.redacted, contentType)
         
         try await cast(to: device, url: finalCastURL, metadata: metadata, startPosition: startPosition)
     }
@@ -884,7 +884,7 @@ class CastManager {
                     let result = try await prepareProxyURL(for: track, device: session.device)
                     castURL = result.url
                     effectiveContentType = result.contentType
-                    NSLog("CastManager: castNewTrack using proxy for Subsonic/Jellyfin/Emby->Sonos: %@", castURL.absoluteString)
+                    NSLog("CastManager: castNewTrack using proxy for Subsonic/Jellyfin/Emby->Sonos: %@", castURL.redacted)
                 } catch {
                     await clearLoadingState()
                     throw error
@@ -1891,11 +1891,7 @@ class CastManager {
     
     /// Redact sensitive tokens from URL for safe logging
     private func redactedURL(_ url: URL) -> String {
-        guard var components = URLComponents(url: url, resolvingAgainstBaseURL: false) else {
-            return "<invalid URL>"
-        }
-        components.queryItems?.removeAll { $0.name == "X-Plex-Token" }
-        return components.url?.absoluteString ?? "<redacted>"
+        url.redacted
     }
     
     /// Replace localhost/127.0.0.1 with the Mac's actual network IP for casting

--- a/Sources/NullPlayer/Casting/CastProtocol.swift
+++ b/Sources/NullPlayer/Casting/CastProtocol.swift
@@ -342,7 +342,7 @@ class CastSessionController {
             return
         }
         
-        NSLog("CastSessionController: Loading media: %@", url.absoluteString)
+        NSLog("CastSessionController: Loading media: %@", url.redacted)
         
         let rid = nextRequestId()
         var media: [String: Any] = [

--- a/Sources/NullPlayer/Casting/ChromecastManager.swift
+++ b/Sources/NullPlayer/Casting/ChromecastManager.swift
@@ -358,7 +358,7 @@ class ChromecastManager: CastSessionControllerDelegate {
             throw CastError.sessionNotActive
         }
         
-        NSLog("ChromecastManager: Casting %@ to %@", url.absoluteString, session.device.name)
+        NSLog("ChromecastManager: Casting %@ to %@", url.redacted, session.device.name)
         
         // Launch the Default Media Receiver app
         try await withCheckedThrowingContinuation { (continuation: CheckedContinuation<Void, Error>) in

--- a/Sources/NullPlayer/Plex/PlexServerClient.swift
+++ b/Sources/NullPlayer/Plex/PlexServerClient.swift
@@ -1155,16 +1155,7 @@ class PlexServerClient {
     // MARK: - Extended Radio API (Non-Sonic and Sonic Versions)
 
     private func redactedURL(_ url: URL?) -> String {
-        guard let url,
-              var components = URLComponents(url: url, resolvingAgainstBaseURL: false) else {
-            return url?.absoluteString ?? "unknown"
-        }
-        components.queryItems = components.queryItems?.map {
-            $0.name == "X-Plex-Token"
-                ? URLQueryItem(name: $0.name, value: "<redacted>")
-                : $0
-        }
-        return components.url?.absoluteString ?? url.absoluteString
+        url?.redacted ?? "unknown"
     }
 
     func makeLibraryRadioRequest(libraryID: String, limit: Int) -> URLRequest? {

--- a/Sources/NullPlayer/Resources/Info.plist
+++ b/Sources/NullPlayer/Resources/Info.plist
@@ -15,7 +15,7 @@
     <key>CFBundleIconFile</key>
     <string>AppIcon</string>
     <key>CFBundleShortVersionString</key>
-    <string>0.19.0</string>
+    <string>0.19.1</string>
     <key>CFBundleVersion</key>
     <string>2</string>
     <key>LSMinimumSystemVersion</key>

--- a/Sources/NullPlayer/Utilities/URL+Redacted.swift
+++ b/Sources/NullPlayer/Utilities/URL+Redacted.swift
@@ -1,0 +1,20 @@
+import Foundation
+
+extension URL {
+    /// Returns the URL string with known auth query parameters replaced by "<redacted>".
+    /// Covers:
+    ///   - Subsonic: u (username), t (token), s (salt)
+    ///   - Plex: X-Plex-Token
+    var redacted: String {
+        guard var components = URLComponents(url: self, resolvingAgainstBaseURL: false) else {
+            return "<invalid URL>"
+        }
+        let sensitiveParams: Set<String> = ["u", "t", "s", "X-Plex-Token"]
+        components.queryItems = components.queryItems?.map {
+            sensitiveParams.contains($0.name)
+                ? URLQueryItem(name: $0.name, value: "<redacted>")
+                : $0
+        }
+        return components.url?.absoluteString ?? absoluteString
+    }
+}


### PR DESCRIPTION
## Summary

- **Audio distortion after long idle** — removes the `AUDynamicsProcessor` limiter from the audio chain. After macOS put the audio hardware into power-saving state, `AVAudioEngineConfigurationChange` would reconnect the node and reset it to Apple's aggressive defaults (threshold −20 dB, 2:1 expansion), causing heavy distortion until app restart. Signal chain is now `playerNode → mixerNode → eqNode → output`.
- **Play/radio history lost on quit** — history writes and play-event inserts now complete synchronously before exit; cast completions now record play events (previously missing); MediaLibrary WAL is checkpointed on `applicationWillTerminate`.
- **Auth token redaction** — Subsonic and Plex tokens stripped from all NSLog output via a shared `URL.redacted` extension.

## Test plan

- [ ] Play audio for an extended session, leave app idle for 30+ minutes (or trigger a device change), resume — confirm no distortion
- [ ] Play several tracks through to completion, quit the app, relaunch — confirm play history and radio history are preserved
- [ ] Check Console logs during playback — confirm no raw auth tokens appear in NSLog output

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed play history persistence to complete synchronously before app exit, ensuring all play events are recorded.
  * Added database checkpointing on app termination to guarantee pending writes are flushed.

* **Security**
  * Logs now redact sensitive credentials (Subsonic login information and Plex tokens) to prevent accidental exposure.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->