### PR TITLE
fix: defer CVDisplayLink setup until view is in window — fixes GPU panic on external monitor (v0.19.3)

### DIFF
--- a/Sources/NullPlayer/Resources/Info.plist
+++ b/Sources/NullPlayer/Resources/Info.plist
@@ -15,7 +15,7 @@
     <key>CFBundleIconFile</key>
     <string>AppIcon</string>
     <key>CFBundleShortVersionString</key>
-    <string>0.19.2</string>
+    <string>0.19.3</string>
     <key>CFBundleVersion</key>
     <string>3</string>
     <key>LSMinimumSystemVersion</key>

--- a/Sources/NullPlayer/Visualization/SpectrumAnalyzerView.swift
+++ b/Sources/NullPlayer/Visualization/SpectrumAnalyzerView.swift
@@ -1522,7 +1522,14 @@ class SpectrumAnalyzerView: NSView {
         }
         
         self.displayLink = displayLink
-        
+
+        // Pin to the window's actual display to avoid GPU panics on multi-monitor setups.
+        // CVDisplayLinkCreateWithActiveCGDisplays picks an arbitrary active display; on M-series
+        // Macs with an external monitor this can mismatch the Metal device and trigger a kernel panic.
+        if let screenNumber = window?.screen?.deviceDescription[NSDeviceDescriptionKey("NSScreenNumber")] as? CGDirectDisplayID {
+            CVDisplayLinkSetCurrentCGDisplay(displayLink, screenNumber)
+        }
+
         // Create a retained context wrapper with weak view reference
         // This prevents use-after-free crashes when the view is deallocated
         // while the display link callback is still running on a background thread
@@ -1530,10 +1537,10 @@ class SpectrumAnalyzerView: NSView {
         let retainedContext = Unmanaged.passRetained(context)
         self.displayLinkContextRef = retainedContext
         let callbackPointer = retainedContext.toOpaque()
-        
+
         // Set output callback with safe context
         CVDisplayLinkSetOutputCallback(displayLink, displayLinkCallback, callbackPointer)
-        
+
         // Start the display link
         CVDisplayLinkStart(displayLink)
     }
@@ -3520,12 +3527,35 @@ class SpectrumAnalyzerView: NSView {
     
     override func viewDidMoveToWindow() {
         super.viewDidMoveToWindow()
-        if window != nil {
+        if let window = window {
+            // Remove-before-add to avoid duplicate observers if this fires more than once
+            // with a non-nil window (e.g. view re-inserted into hierarchy).
+            NotificationCenter.default.removeObserver(self, name: NSWindow.didChangeScreenNotification, object: nil)
+            NotificationCenter.default.removeObserver(self, name: NSApplication.didChangeScreenParametersNotification, object: nil)
+            NotificationCenter.default.addObserver(self, selector: #selector(handleWindowDidChangeScreen(_:)),
+                name: NSWindow.didChangeScreenNotification, object: window)
+            NotificationCenter.default.addObserver(self, selector: #selector(handleScreenParametersChanged),
+                name: NSApplication.didChangeScreenParametersNotification, object: nil)
             syncMetalLayerScaleAndSize()
             startRendering()
         } else {
+            NotificationCenter.default.removeObserver(self, name: NSWindow.didChangeScreenNotification, object: nil)
+            NotificationCenter.default.removeObserver(self, name: NSApplication.didChangeScreenParametersNotification, object: nil)
             // Window closed - stop the display link to release CPU
             stopRendering()
+        }
+    }
+
+    @objc private func handleWindowDidChangeScreen(_ notification: Notification) {
+        guard notification.object as? NSWindow == window else { return }
+        stopRendering()
+        startRendering()
+    }
+
+    @objc private func handleScreenParametersChanged() {
+        stopRendering()
+        DispatchQueue.main.async { [weak self] in
+            self?.startRendering()
         }
     }
     

--- a/Sources/NullPlayer/Visualization/SpectrumAnalyzerView.swift
+++ b/Sources/NullPlayer/Visualization/SpectrumAnalyzerView.swift
@@ -3548,6 +3548,7 @@ class SpectrumAnalyzerView: NSView {
 
     @objc private func handleWindowDidChangeScreen(_ notification: Notification) {
         guard notification.object as? NSWindow == window else { return }
+        syncMetalLayerScaleAndSize()
         stopRendering()
         startRendering()
     }
@@ -3555,6 +3556,7 @@ class SpectrumAnalyzerView: NSView {
     @objc private func handleScreenParametersChanged() {
         stopRendering()
         DispatchQueue.main.async { [weak self] in
+            self?.syncMetalLayerScaleAndSize()
             self?.startRendering()
         }
     }

--- a/Sources/NullPlayer/Visualization/VisualizationGLView.swift
+++ b/Sources/NullPlayer/Visualization/VisualizationGLView.swift
@@ -159,9 +159,11 @@ class VisualizationGLView: NSOpenGLView {
         openGLContext?.makeCurrentContext()
         setupOpenGL()
         setupEngine()
-        setupDisplayLink()
+        // setupDisplayLink() deferred to viewDidMoveToWindow — the CGL context must be
+        // associated with a real display before CVDisplayLinkSetCurrentCGDisplayFromOpenGLContext
+        // is called, otherwise the GPU driver can panic on M-series Macs with external monitors.
     }
-    
+
     required init?(coder: NSCoder) {
         super.init(coder: coder)
 
@@ -170,17 +172,17 @@ class VisualizationGLView: NSOpenGLView {
            let type = VisualizationType(rawValue: savedType) {
             currentEngineType = type
         }
-        
+
         // Load saved performance mode preference (defaults to low power / 30fps)
         if UserDefaults.standard.object(forKey: "projectMLowPowerMode") != nil {
             isLowPowerMode = UserDefaults.standard.bool(forKey: "projectMLowPowerMode")
         }
-        
+
         // Load saved PCM gain preference (defaults to 1.0 / unity gain)
         if UserDefaults.standard.object(forKey: "projectMPCMGain") != nil {
             pcmGain = UserDefaults.standard.float(forKey: "projectMPCMGain")
         }
-        
+
         // Load saved beat sensitivity preference (defaults to 1.0 / normal)
         if UserDefaults.standard.object(forKey: "projectMBeatSensitivity") != nil {
             normalBeatSensitivity = UserDefaults.standard.float(forKey: "projectMBeatSensitivity")
@@ -188,7 +190,7 @@ class VisualizationGLView: NSOpenGLView {
 
         setupOpenGL()
         setupEngine()
-        setupDisplayLink()
+        // setupDisplayLink() deferred to viewDidMoveToWindow (see above)
     }
 
     deinit {
@@ -325,49 +327,55 @@ class VisualizationGLView: NSOpenGLView {
     // MARK: - Display Link
     
     private func setupDisplayLink() {
-        // Create display link
+        guard displayLink == nil else { return }
+
         CVDisplayLinkCreateWithActiveCGDisplays(&displayLink)
-        
+
         guard let displayLink = displayLink else {
             NSLog("VisualizationGLView: Failed to create CVDisplayLink")
             return
         }
-        
+
         // Create a retained context wrapper with weak view reference
         // This prevents use-after-free crashes when the view is deallocated
         // while the display link callback is still running on a background thread
         let context = VisualizationDisplayLinkContext(view: self)
         let retainedContext = Unmanaged.passRetained(context)
         self.displayLinkContextRef = retainedContext
-        
+
         // Set the callback with safe context
         let callback: CVDisplayLinkOutputCallback = { displayLink, inNow, inOutputTime, flagsIn, flagsOut, context in
             guard let context = context else { return kCVReturnError }
             let wrapper = Unmanaged<VisualizationDisplayLinkContext>.fromOpaque(context).takeUnretainedValue()
-            
+
             // Safely check if view still exists before rendering
             guard let view = wrapper.view else {
                 // View was deallocated - this is expected during shutdown
                 return kCVReturnSuccess
             }
-            
+
             view.renderFrame()
             return kCVReturnSuccess
         }
-        
+
         CVDisplayLinkSetOutputCallback(displayLink, callback, retainedContext.toOpaque())
 
-        // Set the display link to the display of the OpenGL context
-        if let cglContext = openGLContext?.cglContextObj,
-           let cglPixelFormat = pixelFormat?.cglPixelFormatObj {
-            CVDisplayLinkSetCurrentCGDisplayFromOpenGLContext(displayLink, cglContext, cglPixelFormat)
-        }
+        // Pin to the window's actual display now that the view is in a window.
+        updateDisplayLinkForCurrentScreen()
 
         // Suspend rendering during window drags to prevent WindowServer stalls.
         NotificationCenter.default.addObserver(self, selector: #selector(handleWindowDragDidBegin),
                                                name: .windowDragDidBegin, object: nil)
         NotificationCenter.default.addObserver(self, selector: #selector(handleWindowDragDidEnd),
                                                name: .windowDragDidEnd, object: nil)
+    }
+
+    private func updateDisplayLinkForCurrentScreen() {
+        guard let displayLink = displayLink else { return }
+        if let cglContext = openGLContext?.cglContextObj,
+           let cglPixelFormat = pixelFormat?.cglPixelFormatObj {
+            CVDisplayLinkSetCurrentCGDisplayFromOpenGLContext(displayLink, cglContext, cglPixelFormat)
+        }
     }
 
     @objc private func handleWindowDragDidBegin() { isDragSuspended = true }
@@ -604,18 +612,51 @@ class VisualizationGLView: NSOpenGLView {
         super.viewDidMoveToWindow()
 
         if let window = window {
+            // Remove-before-add to avoid duplicate observers if this fires more than once
+            // with a non-nil window (e.g. view re-inserted into hierarchy).
+            NotificationCenter.default.removeObserver(self, name: NSWindow.didChangeOcclusionStateNotification, object: nil)
+            NotificationCenter.default.removeObserver(self, name: NSWindow.didMiniaturizeNotification, object: nil)
+            NotificationCenter.default.removeObserver(self, name: NSWindow.didDeminiaturizeNotification, object: nil)
+            NotificationCenter.default.removeObserver(self, name: NSWindow.didChangeScreenNotification, object: nil)
+            NotificationCenter.default.removeObserver(self, name: NSApplication.didChangeScreenParametersNotification, object: nil)
+
             NotificationCenter.default.addObserver(self, selector: #selector(windowDidChangeOcclusionState(_:)),
                 name: NSWindow.didChangeOcclusionStateNotification, object: window)
             NotificationCenter.default.addObserver(self, selector: #selector(windowDidMiniaturize(_:)),
                 name: NSWindow.didMiniaturizeNotification, object: window)
             NotificationCenter.default.addObserver(self, selector: #selector(windowDidDeminiaturize(_:)),
                 name: NSWindow.didDeminiaturizeNotification, object: window)
+            NotificationCenter.default.addObserver(self, selector: #selector(handleWindowDidChangeScreen(_:)),
+                name: NSWindow.didChangeScreenNotification, object: window)
+            NotificationCenter.default.addObserver(self, selector: #selector(handleScreenParametersChanged),
+                name: NSApplication.didChangeScreenParametersNotification, object: nil)
+
+            if displayLink == nil {
+                setupDisplayLink()
+            } else {
+                updateDisplayLinkForCurrentScreen()
+            }
             startRendering()
         } else {
             NotificationCenter.default.removeObserver(self, name: NSWindow.didChangeOcclusionStateNotification, object: nil)
             NotificationCenter.default.removeObserver(self, name: NSWindow.didMiniaturizeNotification, object: nil)
             NotificationCenter.default.removeObserver(self, name: NSWindow.didDeminiaturizeNotification, object: nil)
+            NotificationCenter.default.removeObserver(self, name: NSWindow.didChangeScreenNotification, object: nil)
+            NotificationCenter.default.removeObserver(self, name: NSApplication.didChangeScreenParametersNotification, object: nil)
             stopRendering()
+        }
+    }
+
+    @objc private func handleWindowDidChangeScreen(_ notification: Notification) {
+        guard notification.object as? NSWindow == window else { return }
+        updateDisplayLinkForCurrentScreen()
+    }
+
+    @objc private func handleScreenParametersChanged() {
+        stopRendering()
+        DispatchQueue.main.async { [weak self] in
+            self?.updateDisplayLinkForCurrentScreen()
+            self?.startRendering()
         }
     }
 

--- a/Sources/NullPlayer/Visualization/VisualizationGLView.swift
+++ b/Sources/NullPlayer/Visualization/VisualizationGLView.swift
@@ -389,8 +389,18 @@ class VisualizationGLView: NSOpenGLView {
     }
     
     // MARK: - Rendering Control
+
+    private func isRenderEligible() -> Bool {
+        guard let window = window else { return false }
+        guard window.isVisible, !window.isMiniaturized else { return false }
+        guard !isHiddenOrHasHiddenAncestor else { return false }
+        // Occlusion state is not always populated yet during initial window attach/show.
+        // Startup callers may legitimately request rendering before AppKit reports .visible.
+        return true
+    }
     
     func startRendering() {
+        guard isRenderEligible() else { return }
         guard let displayLink = displayLink, !isRendering else { return }
         
         // Re-register callback if it was previously cleared by stopRendering()
@@ -653,10 +663,12 @@ class VisualizationGLView: NSOpenGLView {
     }
 
     @objc private func handleScreenParametersChanged() {
+        let shouldResume = isRendering
         stopRendering()
         DispatchQueue.main.async { [weak self] in
-            self?.updateDisplayLinkForCurrentScreen()
-            self?.startRendering()
+            guard let self, shouldResume, self.isRenderEligible() else { return }
+            self.updateDisplayLinkForCurrentScreen()
+            self.startRendering()
         }
     }
 

--- a/Sources/NullPlayer/Visualization/VisualizationGLView.swift
+++ b/Sources/NullPlayer/Visualization/VisualizationGLView.swift
@@ -159,9 +159,9 @@ class VisualizationGLView: NSOpenGLView {
         openGLContext?.makeCurrentContext()
         setupOpenGL()
         setupEngine()
-        // setupDisplayLink() deferred to viewDidMoveToWindow — the CGL context must be
-        // associated with a real display before CVDisplayLinkSetCurrentCGDisplayFromOpenGLContext
-        // is called, otherwise the GPU driver can panic on M-series Macs with external monitors.
+        // setupDisplayLink() deferred to viewDidMoveToWindow — the view must be in a real window
+        // before CVDisplayLinkSetCurrentCGDisplay is called, otherwise the GPU driver can panic
+        // on M-series Macs with external monitors.
     }
 
     required init?(coder: NSCoder) {
@@ -372,9 +372,8 @@ class VisualizationGLView: NSOpenGLView {
 
     private func updateDisplayLinkForCurrentScreen() {
         guard let displayLink = displayLink else { return }
-        if let cglContext = openGLContext?.cglContextObj,
-           let cglPixelFormat = pixelFormat?.cglPixelFormatObj {
-            CVDisplayLinkSetCurrentCGDisplayFromOpenGLContext(displayLink, cglContext, cglPixelFormat)
+        if let screenNumber = window?.screen?.deviceDescription[NSDeviceDescriptionKey("NSScreenNumber")] as? CGDirectDisplayID {
+            CVDisplayLinkSetCurrentCGDisplay(displayLink, screenNumber)
         }
     }
 


### PR DESCRIPTION
## Summary

- **Root cause**: `VisualizationGLView` created its `CVDisplayLink` during `init` — before the view had a window — and immediately called `CVDisplayLinkSetCurrentCGDisplayFromOpenGLContext` with a CGL context that had no display association. On M-series Macs with Sonoma + external monitor, this causes a GPU kernel panic within ~1 second of launch (or ~2 seconds without external monitor). `SpectrumAnalyzerView` (Metal) had a related issue: it called `CVDisplayLinkCreateWithActiveCGDisplays` without pinning the link to the window's actual display.
- Fixes issue #158

## Changes

**`VisualizationGLView.swift`**
- Removed `setupDisplayLink()` from both `init` methods; deferred to `viewDidMoveToWindow` so the CGL context is properly display-associated before use
- Added `guard displayLink == nil` idempotency guard to `setupDisplayLink()`
- Extracted `updateDisplayLinkForCurrentScreen()` helper (calls `CVDisplayLinkSetCurrentCGDisplayFromOpenGLContext`)
- `viewDidMoveToWindow`: calls `setupDisplayLink()` on first entry, `updateDisplayLinkForCurrentScreen()` on re-entry; uses remove-before-add for all observers to prevent duplicates
- Handles `NSWindow.didChangeScreenNotification` (re-pins display) and `NSApplication.didChangeScreenParametersNotification` (stop → re-pin → restart)

**`SpectrumAnalyzerView.swift`**
- Pins the new `CVDisplayLink` to the window's actual `CGDirectDisplayID` via `CVDisplayLinkSetCurrentCGDisplay` immediately after creation
- `viewDidMoveToWindow`: adds `didChangeScreenNotification` and `didChangeScreenParametersNotification` observers with remove-before-add
- `handleWindowDidChangeScreen`: stop + restart (creates a fresh pinned link since `stopRendering()` nils the link)
- `handleScreenParametersChanged`: async restart to let display topology stabilize

## Test plan

- [ ] Launch with external monitor connected — confirm no system crash
- [ ] Launch without external monitor — confirm app stays open
- [ ] Launch normally, then plug in external monitor — confirm visualization resumes without crash
- [ ] Move spectrum/visualization window to external monitor — confirm rendering continues
- [ ] Unplug external monitor while visualization is running — confirm graceful recovery

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved display rendering stability when moving windows between screens
  * Enhanced detection and handling of screen configuration changes
  * Better synchronization of rendering with active display parameters

<!-- end of auto-generated comment: release notes by coderabbit.ai -->