### PR TITLE
Add marquee album art and improve CLI launch UX

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -20,6 +20,15 @@
 - **Audio system limiter docs corrected** — documentation now reflects the current audio chain after removal of the old limiter path.
 - **Timer skill docs updated** — the timer-related skill documentation now matches the current modern timer capabilities and configuration options.
 
+## 0.19.3
+
+### Bug Fixes
+
+- **External monitor display-link crash fixed** — ProjectM and the spectrum visualizer no longer create or re-pin `CVDisplayLink` objects before their views are associated with a real display. This fixes a GPU kernel panic/crash path seen on Apple Silicon Macs with external monitors connected at launch or when the display topology changed.
+- **ProjectM startup restored** — the display-link safety guard introduced for the monitor crash no longer blocks ProjectM from starting up normally.
+- **Safer display re-pinning** — OpenGL display-link updates now use the window screen's direct display ID instead of the older CGL-context rebind path, avoiding another unsafe re-association window during screen changes.
+- **Spectrum display-change resync fixed** — the spectrum layer now resynchronizes when displays change so visualization rendering stays aligned after moving windows between monitors or changing monitor configuration.
+
 ## 0.19.2
 
 ### New Features

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,25 @@
 # Changelog
 
+## 0.20.0
+
+### New Features
+
+- **Modern marquee album art** — the modern main window marquee can now show album artwork alongside scrolling track metadata, making the modern transport feel more like a compact now-playing display instead of text-only chrome.
+- **Installable `nullplayer` launcher** — the bundled CLI is now easier to run from Terminal without digging through `NullPlayer.app/Contents/MacOS`. Releases now include a `nullplayer` launcher, an installer script, and a double-click `.command` helper for installing the launcher into `/usr/local/bin`.
+- **Automation-first CLI positioning** — the README and CLI skill docs now present the headless CLI as a first-class feature for automation pipelines, multi-source playback, and routing to local outputs, Sonos, Chromecast, and UPnP/DLNA devices.
+- **Modern timer number system options** — the modern UI timer now supports additional number system options for its time display styling.
+
+### Improvements
+
+- **Modern transport spacing adjusted** — transport layout spacing in the modern main window has been tightened for a cleaner balance around the marquee and playback controls.
+- **CLI launch path clarified** — built-in CLI help and public docs now use the `nullplayer --cli ...` command as the primary entrypoint while still documenting the underlying bundled executable path for fallback use.
+- **Volume control documentation expanded** — the README now calls out `--volume <0-100>` and the live keyboard volume controls explicitly, including the fact that the same control path is used when casting is active.
+
+### Documentation
+
+- **Audio system limiter docs corrected** — documentation now reflects the current audio chain after removal of the old limiter path.
+- **Timer skill docs updated** — the timer-related skill documentation now matches the current modern timer capabilities and configuration options.
+
 ## 0.19.2
 
 ### New Features

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # NullPlayer
 
-## A throwback open-source music player for macOS written in Swift, supporting Plex, Sonos, Navidrome, Jellyfin, Emby, Chromecast, ProjectM, local media, internet radio and more.
+## A throwback open-source music player for macOS written in Swift, with a first-class headless CLI for automation, multi-source playback, and casting across Sonos, Chromecast, UPnP/DLNA, local media servers, and internet radio.
 
 ## This is a 100% clean room hobby project is not affiliated with Winamp, Nullsoft, Sonos, Plex, Radionomy Group or anyone else.
 
@@ -17,6 +17,8 @@
 
 ## Features
 
+- First-class headless CLI for terminal workflows and automation pipelines
+- Scriptable media control across multiple sources and playback targets
 - Library browser window for Plex, Jellyfin, Emby, Navidrome/Subsonic, and local library files
 - Plex Media Server integration with PIN-based authentication
 - Jellyfin media server integration with music and video streaming, scrobbling, and library browsing
@@ -46,13 +48,32 @@
 - Cast local files, Jellyfin/Emby/Navidrome/Subsonic streams, and internet radio to Sonos
 - macOS Now Playing integration (Control Center, Touch Bar, AirPods controls)
 - [Discord Music Presence](https://github.com/ungive/discord-music-presence) support
-- Headless CLI mode for terminal-based browsing and playback (no GUI, no Dock icon)
+- Headless CLI mode for querying libraries, starting playback, and routing to local outputs or cast devices (no GUI, no Dock icon)
 
 ## Installation
 
 Download the latest DMG from [Releases](https://github.com/ad-repo/nullplayer/releases).
 
 Follow [r/NullPlayer](https://www.reddit.com/r/NullPlayer/) for release notifications. Report bugs on [GitHub Issues](https://github.com/ad-repo/nullplayer/issues) or the subreddit.
+
+### Optional command-line launcher
+
+If you want to use NullPlayer as a scriptable command in terminal workflows or automation pipelines without digging into `NullPlayer.app/Contents/MacOS`, the DMG includes:
+
+- `nullplayer` — launcher wrapper
+- `Install NullPlayer CLI.command` — one-click installer for `/usr/local/bin/nullplayer`
+
+Install flow:
+
+```bash
+open "/Volumes/NullPlayer/Install NullPlayer CLI.command"
+nullplayer --cli --help
+```
+
+The launcher looks for:
+
+- `/Applications/NullPlayer.app`
+- `~/Applications/NullPlayer.app`
 
 
 ### Fixing "App is damaged" or "macOS cannot verify that this app is free from malware" Error
@@ -128,38 +149,93 @@ Backups are stored in `~/Library/Application Support/NullPlayer/Backups/`.
 
 ## CLI Mode
 
-NullPlayer includes a headless CLI mode for browsing and playing music entirely from the terminal — no GUI, no Dock icon.
+NullPlayer includes a first-class headless CLI mode for browsing, querying, playing, and routing media entirely from the terminal. It is designed to work as a scriptable command in automation pipelines: resolve media from multiple sources, pick a local output or cast target, then hand off playback without opening the GUI.
+
+This is not just a hidden debug flag. `nullplayer` is a supported command surface for:
+
+- querying and searching local, Plex, Subsonic/Navidrome, Jellyfin, Emby, and radio sources
+- starting playback from those sources with a stable command-line interface
+- routing playback to local outputs or casting to Sonos, Chromecast, and UPnP/DLNA devices
+- emitting machine-friendly query output with `--json`
 
 ```bash
-NullPlayer --cli [OPTIONS]
+nullplayer --cli [OPTIONS]
+```
+
+### Multi-source media control
+
+`nullplayer` can act as a scriptable media control command for automation pipelines, connecting multiple media sources to multiple playback targets.
+
+Supported media sources include:
+
+- local library
+- Plex
+- Subsonic / Navidrome
+- Jellyfin
+- Emby
+- internet radio
+
+Supported playback targets include:
+
+- local audio output devices
+- Sonos
+- Chromecast
+- UPnP / DLNA
+
+Typical automation shape:
+
+```bash
+nullplayer --cli --source plex --playlist "Morning Rotation" --cast "Living Room" --cast-type sonos
+nullplayer --cli --source local --artist "Boards of Canada" --output "MacBook Pro Speakers"
+nullplayer --cli --station "KEXP" --source radio --cast "Kitchen Speaker" --cast-type chromecast
 ```
 
 ### Query commands (print results and exit)
 
 ```bash
-NullPlayer --cli --list-sources                          # show configured sources
-NullPlayer --cli --list-artists --source plex            # list artists
-NullPlayer --cli --list-albums  --source local           # list albums
-NullPlayer --cli --list-tracks  --source subsonic        # list tracks
-NullPlayer --cli --list-genres  --source local           # list genres
-NullPlayer --cli --list-playlists --source jellyfin      # list playlists
-NullPlayer --cli --list-stations                         # list internet radio stations
-NullPlayer --cli --list-eq                               # list EQ presets
-NullPlayer --cli --list-outputs                          # list audio output devices
-NullPlayer --cli --search "radiohead" --source local     # search library
-NullPlayer --cli --list-artists --source plex --json     # JSON output
+nullplayer --cli --list-sources                          # show configured sources
+nullplayer --cli --list-artists --source plex            # list artists
+nullplayer --cli --list-albums  --source local           # list albums
+nullplayer --cli --list-tracks  --source subsonic        # list tracks
+nullplayer --cli --list-genres  --source local           # list genres
+nullplayer --cli --list-playlists --source jellyfin      # list playlists
+nullplayer --cli --list-stations                         # list internet radio stations
+nullplayer --cli --list-eq                               # list EQ presets
+nullplayer --cli --list-outputs                          # list audio output devices
+nullplayer --cli --list-devices                          # list cast devices
+nullplayer --cli --search "radiohead" --source local     # search library
+nullplayer --cli --list-artists --source plex --json     # JSON output
 ```
 
 ### Playback
 
 ```bash
-NullPlayer --cli --source local --artist "Pink Floyd"
-NullPlayer --cli --source plex --album "OK Computer" --shuffle
-NullPlayer --cli --source local --genre "Jazz" --repeat-all
-NullPlayer --cli --station "KEXP" --source radio
-NullPlayer --cli --source local --radio artist --artist "Björk"
-NullPlayer --cli --source local --volume 80 --eq "Rock"
+nullplayer --cli --source local --artist "Pink Floyd"
+nullplayer --cli --source plex --album "OK Computer" --shuffle
+nullplayer --cli --source local --genre "Jazz" --repeat-all
+nullplayer --cli --station "KEXP" --source radio
+nullplayer --cli --source local --radio artist --artist "Björk"
+nullplayer --cli --source local --volume 80 --eq "Rock"
+nullplayer --cli --source jellyfin --playlist "Late Night" --cast "Bedroom" --cast-type sonos
+nullplayer --cli --source local --album "Selected Ambient Works 85-92" --cast "Office TV" --cast-type dlna
 ```
+
+### Volume control
+
+Set the initial playback volume at launch:
+
+```bash
+nullplayer --cli --source local --artist "Björk" --volume 80
+nullplayer --cli --source plex --playlist "Focus" --cast "Living Room" --cast-type sonos --volume 35
+```
+
+During playback:
+
+- `↑` increases volume by 5%
+- `↓` decreases volume by 5%
+- `m` toggles mute
+
+When casting is active, the same CLI volume control path is used for the cast target as well.
 
 ### Keyboard controls (during playback)
 
@@ -175,7 +251,7 @@ NullPlayer --cli --source local --volume 80 --eq "Rock"
 | `m` | Toggle mute |
 | `i` | Show track info |
 
-See `--help` for the full flag reference.
+See `nullplayer --cli --help` for the full flag reference. If you have not installed the launcher yet, the underlying app binary is still available at `NullPlayer.app/Contents/MacOS/NullPlayer`.
 
 ## Development
 
@@ -214,6 +290,3 @@ This project is open source and uses the following licensed components:
 
 - **KSPlayer** (GPL-3.0) - Video playback with FFmpeg backend
 - **libprojectM** (LGPL-2.1) - ProjectM visualizations
-
-
-

--- a/Sources/NullPlayer/App/ContextMenuBuilder.swift
+++ b/Sources/NullPlayer/App/ContextMenuBuilder.swift
@@ -486,16 +486,7 @@ class ContextMenuBuilder {
         let wm = WindowManager.shared
         let engine = wm.audioEngine
         
-        // Time display mode
-        let timeElapsed = NSMenuItem(title: "Time elapsed", action: #selector(MenuActions.setTimeElapsed), keyEquivalent: "")
-        timeElapsed.target = MenuActions.shared
-        timeElapsed.state = wm.timeDisplayMode == .elapsed ? .on : .off
-        optionsMenu.addItem(timeElapsed)
-        
-        let timeRemaining = NSMenuItem(title: "Time remaining", action: #selector(MenuActions.setTimeRemaining), keyEquivalent: "")
-        timeRemaining.target = MenuActions.shared
-        timeRemaining.state = wm.timeDisplayMode == .remaining ? .on : .off
-        optionsMenu.addItem(timeRemaining)
+        optionsMenu.addItem(buildTimerMenuItem())
         
         optionsMenu.addItem(NSMenuItem.separator())
         
@@ -797,6 +788,62 @@ class ContextMenuBuilder {
         optionsMenu.addItem(artworkBgItem)
 
         return optionsMenu
+    }
+
+    private static func buildTimerMenuItem() -> NSMenuItem {
+        let item = NSMenuItem(title: "Timer", action: nil, keyEquivalent: "")
+        item.submenu = buildTimerMenu()
+        return item
+    }
+
+    private static func buildTimerMenu() -> NSMenu {
+        let menu = NSMenu()
+        menu.autoenablesItems = false
+
+        let wm = WindowManager.shared
+
+        let elapsedItem = NSMenuItem(title: "Elapsed", action: #selector(MenuActions.setTimeElapsed), keyEquivalent: "")
+        elapsedItem.target = MenuActions.shared
+        elapsedItem.state = wm.timeDisplayMode == .elapsed ? .on : .off
+        menu.addItem(elapsedItem)
+
+        let remainingItem = NSMenuItem(title: "Remaining", action: #selector(MenuActions.setTimeRemaining), keyEquivalent: "")
+        remainingItem.target = MenuActions.shared
+        remainingItem.state = wm.timeDisplayMode == .remaining ? .on : .off
+        menu.addItem(remainingItem)
+
+        menu.addItem(NSMenuItem.separator())
+
+        let numberSystemItem = NSMenuItem(title: "Number System", action: nil, keyEquivalent: "")
+        numberSystemItem.submenu = buildTimeDisplayNumberSystemMenu()
+        numberSystemItem.isEnabled = wm.isRunningModernUI
+        menu.addItem(numberSystemItem)
+
+        return menu
+    }
+
+    private static func buildTimeDisplayNumberSystemMenu() -> NSMenu {
+        let menu = NSMenu()
+        menu.autoenablesItems = false
+
+        let selected = WindowManager.shared.timeDisplayNumberSystem
+        let defaultItem = NSMenuItem(title: "Default (Decimal)", action: #selector(MenuActions.setTimeDisplayNumberSystem(_:)), keyEquivalent: "")
+        defaultItem.target = MenuActions.shared
+        defaultItem.representedObject = TimeDisplayNumberSystem.decimal.rawValue
+        defaultItem.state = selected == .decimal ? .on : .off
+        menu.addItem(defaultItem)
+        menu.addItem(NSMenuItem.separator())
+
+        for system in TimeDisplayNumberSystem.allCases {
+            guard system != .decimal else { continue }
+            let item = NSMenuItem(title: system.displayName, action: #selector(MenuActions.setTimeDisplayNumberSystem(_:)), keyEquivalent: "")
+            item.target = MenuActions.shared
+            item.representedObject = system.rawValue
+            item.state = selected == system ? .on : .off
+            menu.addItem(item)
+        }
+
+        return menu
     }
     
     // MARK: - Main Window Visualization Submenu
@@ -3447,6 +3494,13 @@ class MenuActions: NSObject {
     
     @objc func setTimeRemaining() {
         WindowManager.shared.timeDisplayMode = .remaining
+    }
+
+    @objc func setTimeDisplayNumberSystem(_ sender: NSMenuItem) {
+        guard WindowManager.shared.isRunningModernUI else { return }
+        guard let rawValue = sender.representedObject as? String,
+              let system = TimeDisplayNumberSystem(rawValue: rawValue) else { return }
+        WindowManager.shared.timeDisplayNumberSystem = system
     }
     
     @objc func toggleRepeat() {

--- a/Sources/NullPlayer/App/NowPlayingManager.swift
+++ b/Sources/NullPlayer/App/NowPlayingManager.swift
@@ -9,7 +9,8 @@ class NowPlayingManager {
     // MARK: - Singleton
     
     static let shared = NowPlayingManager()
-    
+    static let artworkDidLoadNotification = Notification.Name("NowPlayingArtworkDidLoad")
+
     // MARK: - Properties
     
     /// Current artwork being displayed (cached to avoid reloading)
@@ -160,7 +161,13 @@ class NowPlayingManager {
         // Clear now playing
         MPNowPlayingInfoCenter.default().nowPlayingInfo = nil
         MPNowPlayingInfoCenter.default().playbackState = .stopped
-        
+
+        NotificationCenter.default.post(
+            name: NowPlayingManager.artworkDidLoadNotification,
+            object: nil,
+            userInfo: ["image": NSNull(), "trackId": NSNull()]
+        )
+
         NSLog("NowPlayingManager: Cleared now playing info")
     }
     
@@ -271,7 +278,8 @@ class NowPlayingManager {
         // Cancel previous load
         artworkLoadTask?.cancel()
         currentTrackId = track.id
-        
+        let expectedTrackId = track.id
+
         artworkLoadTask = Task { [weak self] in
             guard let self = self else { return }
             
@@ -302,6 +310,11 @@ class NowPlayingManager {
                 if let imageTag = track.artworkThumb {
                     image = await self.loadJellyfinArtwork(itemId: track.jellyfinId!, imageTag: imageTag)
                 }
+            } else if track.embyId != nil {
+                // Emby track - load cover art
+                if let imageTag = track.artworkThumb {
+                    image = await self.loadEmbyArtwork(itemId: track.embyId!, imageTag: imageTag)
+                }
             }
             
             // Check if cancelled
@@ -312,6 +325,8 @@ class NowPlayingManager {
             
             // Update Now Playing with artwork on main thread
             await MainActor.run {
+                // Guard against a track change that occurred while artwork was loading
+                guard self.currentTrackId == expectedTrackId else { return }
                 self.currentArtwork = loadedImage
                 self.applyArtworkToNowPlaying(loadedImage)
             }
@@ -333,8 +348,14 @@ class NowPlayingManager {
         }
         
         MPNowPlayingInfoCenter.default().nowPlayingInfo = nowPlayingInfo
+
+        NotificationCenter.default.post(
+            name: NowPlayingManager.artworkDidLoadNotification,
+            object: nil,
+            userInfo: ["image": image as Any, "trackId": currentTrackId as Any]
+        )
     }
-    
+
     // MARK: - Artwork Loading Helpers
     
     /// Load embedded artwork from local audio file
@@ -456,8 +477,20 @@ class NowPlayingManager {
         }
     }
     
+    private func loadEmbyArtwork(itemId: String, imageTag: String) async -> NSImage? {
+        guard let artworkURL = EmbyManager.shared.imageURL(itemId: itemId, imageTag: imageTag, size: 400) else { return nil }
+        do {
+            let (data, response) = try await URLSession.shared.data(from: artworkURL)
+            guard let httpResponse = response as? HTTPURLResponse, httpResponse.statusCode == 200 else { return nil }
+            return NSImage(data: data)
+        } catch {
+            NSLog("NowPlayingManager: Failed to load Emby artwork: %@", error.localizedDescription)
+            return nil
+        }
+    }
+
     // MARK: - Periodic Time Update
-    
+
     /// Call this periodically (e.g., every second) to keep elapsed time in sync
     /// Optional: Hook into existing time update timer in AudioEngine if more precision needed
     func periodicTimeUpdate() {

--- a/Sources/NullPlayer/App/TimeDisplayFormatter.swift
+++ b/Sources/NullPlayer/App/TimeDisplayFormatter.swift
@@ -1,0 +1,89 @@
+import Foundation
+
+struct TimeDisplayFormatter {
+    static func string(
+        currentTime: TimeInterval,
+        duration: TimeInterval,
+        mode: TimeDisplayMode,
+        numberSystem: TimeDisplayNumberSystem
+    ) -> String {
+        let displayTime: TimeInterval
+        let showMinus: Bool
+
+        if mode == .remaining && duration > 0 {
+            displayTime = duration - currentTime
+            showMinus = true
+        } else {
+            displayTime = currentTime
+            showMinus = false
+        }
+
+        let totalSeconds = Int(abs(displayTime))
+        let minutes = totalSeconds / 60
+        let seconds = totalSeconds % 60
+        return string(minutes: minutes, seconds: seconds, isNegative: showMinus, numberSystem: numberSystem)
+    }
+
+    static func string(
+        minutes: Int,
+        seconds: Int,
+        isNegative: Bool,
+        numberSystem: TimeDisplayNumberSystem
+    ) -> String {
+        let prefix = isNegative ? "-" : ""
+
+        switch numberSystem {
+        case .decimal:
+            return prefix + mapDecimalNumber(minutes, digits: "0123456789") + ":" + mapDecimalNumber(seconds, digits: "0123456789", minimumDigits: 2)
+        case .arabicIndic:
+            return prefix + mapDecimalNumber(minutes, digits: "٠١٢٣٤٥٦٧٨٩") + ":" + mapDecimalNumber(seconds, digits: "٠١٢٣٤٥٦٧٨٩", minimumDigits: 2)
+        case .extendedArabicIndic:
+            return prefix + mapDecimalNumber(minutes, digits: "۰۱۲۳۴۵۶۷۸۹") + ":" + mapDecimalNumber(seconds, digits: "۰۱۲۳۴۵۶۷۸۹", minimumDigits: 2)
+        case .devanagari:
+            return prefix + mapDecimalNumber(minutes, digits: "०१२३४५६७८९") + ":" + mapDecimalNumber(seconds, digits: "०१२३४५६७८९", minimumDigits: 2)
+        case .bengali:
+            return prefix + mapDecimalNumber(minutes, digits: "০১২৩৪৫৬৭৮৯") + ":" + mapDecimalNumber(seconds, digits: "০১২৩৪৫৬৭৮৯", minimumDigits: 2)
+        case .thai:
+            return prefix + mapDecimalNumber(minutes, digits: "๐๑๒๓๔๕๖๗๘๙") + ":" + mapDecimalNumber(seconds, digits: "๐๑๒๓๔๕๖๗๘๙", minimumDigits: 2)
+        case .fullwidth:
+            return prefix + mapDecimalNumber(minutes, digits: "０１２３４５６７８９") + ":" + mapDecimalNumber(seconds, digits: "０１２３４５６７８９", minimumDigits: 2)
+        case .octal:
+            return prefix + convert(minutes, base: 8, symbols: Array("01234567")) + ":" + convert(seconds, base: 8, symbols: Array("01234567"), minimumDigits: 2)
+        case .hexadecimal:
+            return prefix + convert(minutes, base: 16, symbols: Array("0123456789ABCDEF")) + ":" + convert(seconds, base: 16, symbols: Array("0123456789ABCDEF"), minimumDigits: 2)
+        }
+    }
+
+    private static func mapDecimalNumber(_ value: Int, digits: String, minimumDigits: Int = 1) -> String {
+        let westernDigits = Array("0123456789")
+        let replacementDigits = Array(digits).map(String.init)
+        let padded = String(format: "%0\(minimumDigits)d", max(0, value))
+
+        return padded.map { char in
+            if let index = westernDigits.firstIndex(of: char) {
+                return replacementDigits[index]
+            }
+            return String(char)
+        }.joined()
+    }
+
+    private static func convert(_ value: Int, base: Int, symbols: [Character], minimumDigits: Int = 1) -> String {
+        precondition(base >= 2)
+        precondition(symbols.count >= base)
+
+        var number = max(0, value)
+        var digits: [String] = []
+
+        repeat {
+            digits.append(String(symbols[number % base]))
+            number /= base
+        } while number > 0
+
+        while digits.count < minimumDigits {
+            digits.append(String(symbols[0]))
+        }
+
+        return digits.reversed().joined()
+    }
+
+}

--- a/Sources/NullPlayer/App/WindowManager.swift
+++ b/Sources/NullPlayer/App/WindowManager.swift
@@ -4,6 +4,7 @@ import AppKit
 
 extension Notification.Name {
     static let timeDisplayModeDidChange = Notification.Name("timeDisplayModeDidChange")
+    static let timeDisplaySettingsDidChange = Notification.Name("timeDisplaySettingsDidChange")
     static let doubleSizeDidChange = Notification.Name("doubleSizeDidChange")
     static let windowLayoutDidChange = Notification.Name("windowLayoutDidChange")
     static let connectedWindowHighlightDidChange = Notification.Name("connectedWindowHighlightDidChange")
@@ -16,6 +17,43 @@ extension Notification.Name {
 enum TimeDisplayMode: String {
     case elapsed
     case remaining
+}
+
+enum TimeDisplayNumberSystem: String, CaseIterable {
+    case decimal
+    case arabicIndic
+    case extendedArabicIndic
+    case devanagari
+    case bengali
+    case thai
+    case fullwidth
+    case octal
+    case hexadecimal
+
+    static let modernDefault: TimeDisplayNumberSystem = .decimal
+
+    var displayName: String {
+        switch self {
+        case .decimal:
+            return "Decimal"
+        case .arabicIndic:
+            return "Arabic-Indic"
+        case .extendedArabicIndic:
+            return "Extended Arabic-Indic"
+        case .devanagari:
+            return "Devanagari"
+        case .bengali:
+            return "Bengali"
+        case .thai:
+            return "Thai"
+        case .fullwidth:
+            return "Fullwidth"
+        case .octal:
+            return "Octal"
+        case .hexadecimal:
+            return "Hexadecimal"
+        }
+    }
 }
 
 /// Determines how a window drag affects its connected group.
@@ -67,6 +105,21 @@ class WindowManager {
         didSet {
             UserDefaults.standard.set(timeDisplayMode.rawValue, forKey: "timeDisplayMode")
             NotificationCenter.default.post(name: .timeDisplayModeDidChange, object: nil)
+            NotificationCenter.default.post(name: .timeDisplaySettingsDidChange, object: nil)
+        }
+    }
+
+    private var storedTimeDisplayNumberSystem: TimeDisplayNumberSystem = .modernDefault
+
+    /// Numeral system for the modern time display. Falls back to decimal outside modern UI mode.
+    var timeDisplayNumberSystem: TimeDisplayNumberSystem {
+        get { isRunningModernUI ? storedTimeDisplayNumberSystem : .modernDefault }
+        set {
+            guard isRunningModernUI else { return }
+            guard storedTimeDisplayNumberSystem != newValue else { return }
+            storedTimeDisplayNumberSystem = newValue
+            UserDefaults.standard.set(newValue.rawValue, forKey: "timeDisplayNumberSystem")
+            NotificationCenter.default.post(name: .timeDisplaySettingsDidChange, object: nil)
         }
     }
     
@@ -424,6 +477,7 @@ class WindowManager {
     private func registerPreferenceDefaults() {
         UserDefaults.standard.register(defaults: [
             "timeDisplayMode": TimeDisplayMode.elapsed.rawValue,
+            "timeDisplayNumberSystem": TimeDisplayNumberSystem.modernDefault.rawValue,
             "isAlwaysOnTop": false,
             "isWindowLayoutLocked": false,
             "hideTitleBars": true,
@@ -437,6 +491,10 @@ class WindowManager {
         if let mode = UserDefaults.standard.string(forKey: "timeDisplayMode"),
            let displayMode = TimeDisplayMode(rawValue: mode) {
             timeDisplayMode = displayMode
+        }
+        if let rawValue = UserDefaults.standard.string(forKey: "timeDisplayNumberSystem"),
+           let numberSystem = TimeDisplayNumberSystem(rawValue: rawValue) {
+            storedTimeDisplayNumberSystem = numberSystem
         }
         // Note: isDoubleSize always starts false - windows are created at 1x size
         // and we apply double size after they're created if needed

--- a/Sources/NullPlayer/Audio/AudioEngine.swift
+++ b/Sources/NullPlayer/Audio/AudioEngine.swift
@@ -974,7 +974,7 @@ class AudioEngine {
         playerNode.volume = 1.0
         crossfadePlayerNode.volume = 0  // Still starts silent for crossfade
         
-        // Apply initial volume to mainMixerNode (after EQ/limiter, before output)
+        // Apply initial volume to mainMixerNode (after EQ, before output)
         engine.mainMixerNode.outputVolume = volume
         
         // EQ is disabled (bypassed) by default - user must enable it

--- a/Sources/NullPlayer/CLI/CLIDisplay.swift
+++ b/Sources/NullPlayer/CLI/CLIDisplay.swift
@@ -132,7 +132,7 @@ class CLIDisplay {
         NullPlayer CLI Mode
 
         USAGE:
-            NullPlayer --cli [OPTIONS]
+            nullplayer --cli [OPTIONS]
 
         QUERY COMMANDS (print and exit):
             --list-sources              List configured sources
@@ -196,7 +196,7 @@ class CLIDisplay {
         let version = Bundle.main.infoDictionary?["CFBundleShortVersionString"] as? String
             ?? Bundle(for: CLIDisplay.self).infoDictionary?["CFBundleShortVersionString"] as? String
             ?? "unknown"
-        print("NullPlayer \(version)")
+        print("nullplayer -> NullPlayer \(version)")
     }
 
     // MARK: - ASCII Art

--- a/Sources/NullPlayer/ModernSkin/ModernMarqueeLayer.swift
+++ b/Sources/NullPlayer/ModernSkin/ModernMarqueeLayer.swift
@@ -46,9 +46,16 @@ class ModernMarqueeLayer: CALayer {
     /// Whether scrolling is active
     private(set) var isScrolling = false
     
+    var artworkImage: NSImage? {
+        get { _artworkImage }
+        set { scheduleArtwork(newValue) }
+    }
+
     // MARK: - Private State
-    
+
+    private var _artworkImage: NSImage?
     private var scrollOffset: CGFloat = 0
+    private var artScrollOffset: CGFloat = 0
     private var textWidth: CGFloat = 0
     private var scrollTimer: Timer?
     private var isPaused = false
@@ -127,14 +134,20 @@ class ModernMarqueeLayer: CALayer {
         let attrStr = NSAttributedString(string: text, attributes: attrs)
         textWidth = attrStr.size().width
         
-        let needsScroll = textWidth > bounds.width
         let pad: CGFloat = glowEnabled ? 8.0 : 2.0
-        
+
+        // Art geometry
+        let artSize: CGFloat = _artworkImage != nil ? bounds.height : 0
+        let artGap: CGFloat = _artworkImage != nil ? 8.0 : 0
+        artScrollOffset = artSize + artGap
+
+        let needsScroll = (artScrollOffset + textWidth) > bounds.width
+        let loopWidth = artScrollOffset + textWidth + scrollGap
+
         // Calculate total content width
         let contentWidth: CGFloat
         if needsScroll {
-            // Two copies of text + gap + padding on both sides
-            contentWidth = (textWidth + scrollGap) * 2 + pad * 2
+            contentWidth = loopWidth * 2 + pad * 2
         } else {
             contentWidth = bounds.width + pad * 2
         }
@@ -164,8 +177,13 @@ class ModernMarqueeLayer: CALayer {
         let textSize = attrStr.size()
         let y = (bounds.height - textSize.height) / 2
         
+        func drawArt(atX x: CGFloat) {
+            guard let img = _artworkImage else { return }
+            img.draw(in: NSRect(x: x, y: 0, width: artSize, height: artSize),
+                     from: .zero, operation: .sourceOver, fraction: 1.0)
+        }
+
         if needsScroll {
-            // Draw text twice for seamless looping
             let drawText = { (x: CGFloat) in
                 if self.glowEnabled {
                     self.drawWithGlow(attrStr, at: NSPoint(x: x, y: y), ctx: ctx)
@@ -173,14 +191,16 @@ class ModernMarqueeLayer: CALayer {
                     attrStr.draw(at: NSPoint(x: x, y: y))
                 }
             }
-            drawText(pad)
-            drawText(pad + textWidth + scrollGap)
+            drawArt(atX: pad)
+            drawText(pad + artScrollOffset)
+            drawArt(atX: pad + loopWidth)
+            drawText(pad + loopWidth + artScrollOffset)
         } else {
-            // Static text
+            drawArt(atX: pad)
             if glowEnabled {
-                drawWithGlow(attrStr, at: NSPoint(x: pad, y: y), ctx: ctx)
+                drawWithGlow(attrStr, at: NSPoint(x: pad + artScrollOffset, y: y), ctx: ctx)
             } else {
-                attrStr.draw(at: NSPoint(x: pad, y: y))
+                attrStr.draw(at: NSPoint(x: pad + artScrollOffset, y: y))
             }
         }
         
@@ -213,7 +233,7 @@ class ModernMarqueeLayer: CALayer {
 
         let timer = Timer.scheduledTimer(withTimeInterval: 1.0 / 30.0, repeats: true) { [weak self] _ in
             guard let self = self, !self.isPaused else { return }
-            let loopWidth = self.textWidth + self.scrollGap
+            let loopWidth = self.artScrollOffset + self.textWidth + self.scrollGap
             guard loopWidth > 0 else { return }
             self.scrollOffset += self.scrollSpeed / 30.0
             self.scrollOffset = self.scrollOffset.truncatingRemainder(dividingBy: loopWidth)
@@ -228,6 +248,28 @@ class ModernMarqueeLayer: CALayer {
         isScrolling = false
         scrollTimer?.invalidate()
         scrollTimer = nil
+    }
+
+    private func scheduleArtwork(_ image: NSImage?) {
+        if image == nil {
+            // Clear immediately — never linger with stale art
+            _artworkImage = nil
+            needsTextRender = true
+            renderAndLayout()
+        } else if isScrolling {
+            // Re-render now but compensate scrollOffset so visible text stays put.
+            // The art lands behind the current position and scrolls in from the right naturally.
+            let previousArtScrollOffset = artScrollOffset
+            _artworkImage = image
+            needsTextRender = true
+            renderAndLayout()
+            scrollOffset += artScrollOffset - previousArtScrollOffset
+            applyScrollPosition()
+        } else {
+            _artworkImage = image
+            needsTextRender = true
+            renderAndLayout()
+        }
     }
     
     /// Apply the current scroll offset to the content layer position (main thread only)

--- a/Sources/NullPlayer/ModernSkin/ModernMarqueeLayer.swift
+++ b/Sources/NullPlayer/ModernSkin/ModernMarqueeLayer.swift
@@ -259,6 +259,11 @@ class ModernMarqueeLayer: CALayer {
         } else if isScrolling {
             // Re-render now but compensate scrollOffset so visible text stays put.
             // The art lands behind the current position and scrolls in from the right naturally.
+            //
+            // Invariant: callers always set artworkImage = nil synchronously before starting a
+            // new load (see ModernMainWindowView.updateTrackInfo), so previousArtScrollOffset
+            // is 0 here. The compensation equals the full artScrollOffset of the new image,
+            // shifting the text back to its current screen position after the loop widens.
             let previousArtScrollOffset = artScrollOffset
             _artworkImage = image
             needsTextRender = true

--- a/Sources/NullPlayer/ModernSkin/ModernSkin.swift
+++ b/Sources/NullPlayer/ModernSkin/ModernSkin.swift
@@ -299,6 +299,13 @@ class ModernSkin {
     
     /// Playlist track list text font (default base size 8)
     func playlistFont() -> NSFont { scaledFont(size: config.fonts.playlistSize ?? 8) }
+
+    /// Time display font (default base size 20)
+    func timeDisplayFont() -> NSFont {
+        let size = config.fonts.timeSize ?? ModernSkinFont.defaultTimeSize
+        return timeFont?.withSize(size * ModernSkinElements.scaleFactor)
+            ?? NSFont.monospacedSystemFont(ofSize: size * ModernSkinElements.scaleFactor, weight: .regular)
+    }
     
     // MARK: - Title Character Sprites
     

--- a/Sources/NullPlayer/ModernSkin/ModernSkinElements.swift
+++ b/Sources/NullPlayer/ModernSkin/ModernSkinElements.swift
@@ -141,14 +141,12 @@ enum ModernSkinElements {
                                  states: ["normal", "pressed", "disabled"])
     static let btnNext = Element("btn_next", NSRect(x: 118, y: 3, width: 28, height: 24),
                                  states: ["normal", "pressed", "disabled"])
-    static let btnEject = Element("btn_eject", NSRect(x: 146, y: 3, width: 28, height: 24),
-                                  states: ["normal", "pressed"])
     
-    // MARK: - Volume Slider (bottom-right, replaces old shuffle/repeat/cast buttons)
+    // MARK: - Volume Slider (bottom-right, expanded to fill the former open-file control space)
     
-    static let volumeTrack = Element("volume_track", NSRect(x: 182, y: 12, width: 87, height: 3))
-    static let volumeFill = Element("volume_fill", NSRect(x: 182, y: 12, width: 0, height: 3))
-    static let volumeThumb = Element("volume_thumb", NSRect(x: 182, y: 10, width: 6, height: 6),
+    static let volumeTrack = Element("volume_track", NSRect(x: 157, y: 12, width: 107, height: 3))
+    static let volumeFill = Element("volume_fill", NSRect(x: 157, y: 12, width: 0, height: 3))
+    static let volumeThumb = Element("volume_thumb", NSRect(x: 157, y: 10, width: 6, height: 6),
                                      states: ["normal", "pressed"])
     
     // MARK: - Playlist Window
@@ -337,7 +335,7 @@ enum ModernSkinElements {
         spectrumArea,
         btn2x, btnEQ, btnPlaylist, btnLibrary, btnProjectM, btnSpectrum,
         seekTrack, seekFill, seekThumb,
-        btnPrev, btnPlay, btnPause, btnStop, btnNext, btnEject,
+        btnPrev, btnPlay, btnPause, btnStop, btnNext,
         volumeTrack, volumeFill, volumeThumb,
         playlistTitleBar, playlistBtnClose, playlistBtnShade,
         eqTitleBar, eqBtnClose, eqBtnShade,

--- a/Sources/NullPlayer/ModernSkin/ModernSkinRenderer.swift
+++ b/Sources/NullPlayer/ModernSkin/ModernSkinRenderer.swift
@@ -620,31 +620,66 @@ class ModernSkinRenderer {
     /// Draw a time digit (0-9, minus, colon) as 7-segment LED display
     func drawTimeDigit(_ character: String, in rect: NSRect, context: CGContext) {
         let scaledR = scaledRect(rect)
-        
-        // Map character to image name
-        let imageName: String
-        switch character {
-        case "0"..."9":
-            imageName = "time_digit_\(character)"
-        case "-":
-            imageName = "time_minus"
-        case ":":
-            imageName = "time_colon"
-        default:
-            return
-        }
-        
+
         // Time digits are text-like content: keep them independent from parent window/content alpha.
         context.saveGState()
         context.setAlpha(skin.textOpacityMultiplier)
-        if let img = skin.image(for: imageName) {
+
+        if let imageName = timeDigitImageName(for: character),
+           let img = skin.image(for: imageName) {
             // Use pixel art rendering for crisp scaling of small digit sprites
             drawPixelArtImage(img, in: scaledR, context: context)
-        } else {
-            // Programmatic 7-segment LED rendering
+        } else if uses7SegmentFallback(for: character) {
             draw7SegmentChar(character, in: scaledR, context: context)
+        } else {
+            drawTimeTextCharacter(character, in: scaledR, context: context)
         }
         context.restoreGState()
+    }
+
+    private func timeDigitImageName(for character: String) -> String? {
+        switch character {
+        case "0"..."9":
+            return "time_digit_\(character)"
+        case "-":
+            return "time_minus"
+        case ":":
+            return "time_colon"
+        default:
+            return nil
+        }
+    }
+
+    private func uses7SegmentFallback(for character: String) -> Bool {
+        switch character {
+        case "0"..."9", "-", ":":
+            return true
+        default:
+            return false
+        }
+    }
+
+    private func drawTimeTextCharacter(_ character: String, in rect: NSRect, context: CGContext) {
+        let font = skin.timeDisplayFont()
+        let color = skin.applyTextOpacity(to: skin.timeColor)
+        let attributes: [NSAttributedString.Key: Any] = [
+            .font: font,
+            .foregroundColor: color
+        ]
+        let attributed = NSAttributedString(string: character, attributes: attributes)
+        let size = attributed.size()
+        let origin = NSPoint(
+            x: rect.midX - size.width / 2,
+            y: rect.midY - size.height / 2
+        )
+
+        if skin.config.glow.enabled {
+            drawTextWithGlow(attributed, at: origin, glowColor: color, context: context)
+        } else {
+            drawTextUnattenuated(in: context) {
+                attributed.draw(at: origin)
+            }
+        }
     }
     
     /// Draw a character as a 7-segment LED display

--- a/Sources/NullPlayer/Resources/Info.plist
+++ b/Sources/NullPlayer/Resources/Info.plist
@@ -15,9 +15,9 @@
     <key>CFBundleIconFile</key>
     <string>AppIcon</string>
     <key>CFBundleShortVersionString</key>
-    <string>0.19.2</string>
+    <string>0.20.0</string>
     <key>CFBundleVersion</key>
-    <string>3</string>
+    <string>1</string>
     <key>LSMinimumSystemVersion</key>
     <string>14.0</string>
     <key>NSHighResolutionCapable</key>

--- a/Sources/NullPlayer/Windows/ModernMainWindow/ModernMainWindowView.swift
+++ b/Sources/NullPlayer/Windows/ModernMainWindow/ModernMainWindowView.swift
@@ -1,4 +1,5 @@
 import AppKit
+import AVFoundation
 import QuartzCore
 
 /// The main window view for the modern skin system.
@@ -28,6 +29,9 @@ class ModernMainWindowView: NSView {
     
     /// Current track info
     private var currentTrack: Track?
+    private var currentArtworkImage: NSImage?
+    private var artworkLoadTask: Task<Void, Never>?
+    private static let artworkCache = NSCache<NSString, NSImage>()
     
     /// Video title override
     private var videoTitle: String?
@@ -148,7 +152,6 @@ class ModernMainWindowView: NSView {
                                                 name: .visClassicProfileCommand, object: nil)
         NotificationCenter.default.addObserver(self, selector: #selector(connectedWindowHighlightDidChange(_:)),
                                                 name: .connectedWindowHighlightDidChange, object: nil)
-
         // Set accessibility
         setAccessibilityIdentifier("ModernMainWindowView")
         setAccessibilityRole(.group)
@@ -818,8 +821,11 @@ class ModernMainWindowView: NSView {
     }
     
     func updateTrackInfo(_ track: Track?) {
+        currentArtworkImage = nil
+        marqueeLayer.artworkImage = nil
         self.currentTrack = track
         self.videoTitle = nil
+        loadArtwork(for: track)
         self.currentBPM = nil  // Reset BPM for new track
         self.bpmMultiplierState = 2  // Reset multiplier for new track (default to 0.5x)
         refreshMarqueeText()
@@ -888,6 +894,7 @@ class ModernMainWindowView: NSView {
         renderer = ModernSkinRenderer(skin: skin)
         setupGridBackground(skin: skin)
         marqueeLayer.configure(with: skin)
+        marqueeLayer.artworkImage = currentArtworkImage
         updateMarqueeOpacity()
         updateSpectrumOverlayOpacity()
         refreshMarqueeText()
@@ -1013,6 +1020,103 @@ class ModernMainWindowView: NSView {
             edgeOcclusionSegments = newSegments
             needsDisplay = true
         }
+    }
+
+    private func loadArtwork(for track: Track?) {
+        artworkLoadTask?.cancel()
+        artworkLoadTask = nil
+
+        guard let track = track else { return }
+        let expectedId = track.id
+
+        artworkLoadTask = Task { [weak self] in
+            guard let self = self else { return }
+
+            var image: NSImage?
+
+            if let plexRatingKey = track.plexRatingKey {
+                let key = NSString(string: "marquee_plex:\(plexRatingKey)")
+                if let cached = Self.artworkCache.object(forKey: key) {
+                    image = cached
+                } else if let thumbPath = track.artworkThumb,
+                          let url = PlexManager.shared.artworkURL(thumb: thumbPath, size: 400) {
+                    if let (data, resp) = try? await URLSession.shared.data(from: url),
+                       (resp as? HTTPURLResponse)?.statusCode == 200,
+                       let img = NSImage(data: data) {
+                        Self.artworkCache.setObject(img, forKey: key)
+                        image = img
+                    }
+                }
+            } else if let subsonicId = track.subsonicId {
+                let key = NSString(string: "marquee_subsonic:\(subsonicId)")
+                if let cached = Self.artworkCache.object(forKey: key) {
+                    image = cached
+                } else if let url = SubsonicManager.shared.coverArtURL(coverArtId: subsonicId, size: 400) {
+                    if let (data, resp) = try? await URLSession.shared.data(from: url),
+                       (resp as? HTTPURLResponse)?.statusCode == 200,
+                       let img = NSImage(data: data) {
+                        Self.artworkCache.setObject(img, forKey: key)
+                        image = img
+                    }
+                }
+            } else if let jellyfinId = track.jellyfinId {
+                let key = NSString(string: "marquee_jellyfin:\(jellyfinId)")
+                if let cached = Self.artworkCache.object(forKey: key) {
+                    image = cached
+                } else if let url = JellyfinManager.shared.imageURL(itemId: jellyfinId, imageTag: nil, size: 400) {
+                    if let (data, resp) = try? await URLSession.shared.data(from: url),
+                       (resp as? HTTPURLResponse)?.statusCode == 200,
+                       let img = NSImage(data: data) {
+                        Self.artworkCache.setObject(img, forKey: key)
+                        image = img
+                    }
+                }
+            } else if let embyId = track.embyId {
+                let key = NSString(string: "marquee_emby:\(embyId)")
+                if let cached = Self.artworkCache.object(forKey: key) {
+                    image = cached
+                } else if let url = EmbyManager.shared.imageURL(itemId: embyId, imageTag: track.artworkThumb, size: 400) {
+                    if let (data, resp) = try? await URLSession.shared.data(from: url),
+                       (resp as? HTTPURLResponse)?.statusCode == 200,
+                       let img = NSImage(data: data) {
+                        Self.artworkCache.setObject(img, forKey: key)
+                        image = img
+                    }
+                }
+            } else if track.url.isFileURL {
+                let key = NSString(string: "marquee_local:\(track.url.path)")
+                if let cached = Self.artworkCache.object(forKey: key) {
+                    image = cached
+                } else {
+                    image = await self.loadLocalArtwork(url: track.url)
+                    if let img = image { Self.artworkCache.setObject(img, forKey: key) }
+                }
+            }
+
+            guard !Task.isCancelled else { return }
+
+            await MainActor.run {
+                guard self.currentTrack?.id == expectedId else { return }
+                self.currentArtworkImage = image
+                self.marqueeLayer.artworkImage = image
+            }
+        }
+    }
+
+    private func loadLocalArtwork(url: URL) async -> NSImage? {
+        let asset = AVURLAsset(url: url)
+        do {
+            for format in [try await asset.load(.metadata),
+                           try await asset.loadMetadata(for: .id3Metadata),
+                           try await asset.loadMetadata(for: .iTunesMetadata)] {
+                for item in format {
+                    if item.commonKey == .commonKeyArtwork,
+                       let data = try? await item.load(.dataValue),
+                       let img = NSImage(data: data) { return img }
+                }
+            }
+        } catch {}
+        return nil
     }
 
     @objc private func radioMetadataDidChange() {

--- a/Sources/NullPlayer/Windows/ModernMainWindow/ModernMainWindowView.swift
+++ b/Sources/NullPlayer/Windows/ModernMainWindow/ModernMainWindowView.swift
@@ -1099,6 +1099,7 @@ class ModernMainWindowView: NSView {
     }
 
     private func loadLocalArtwork(url: URL) async -> NSImage? {
+        guard !Task.isCancelled else { return nil }
         let asset = AVURLAsset(url: url)
         do {
             for format in [try await asset.load(.metadata),

--- a/Sources/NullPlayer/Windows/ModernMainWindow/ModernMainWindowView.swift
+++ b/Sources/NullPlayer/Windows/ModernMainWindow/ModernMainWindowView.swift
@@ -506,7 +506,7 @@ class ModernMainWindowView: NSView {
                 }
 
                 // 8. Transport buttons
-                let transportRegion = scaledRect(NSRect(x: 6, y: 3, width: 168, height: 24))
+                let transportRegion = scaledRect(NSRect(x: 6, y: 3, width: 140, height: 24))
                 if dirtyRect.intersects(transportRegion) {
                     drawTransportButtons(context: context)
                 }
@@ -516,7 +516,7 @@ class ModernMainWindowView: NSView {
                 if dirtyRect.intersects(volumeScaled) {
                     // `window.areaOpacity.volumeArea` controls panel + slider content.
                     renderer.drawInsetPanel(
-                        in: NSRect(x: 177, y: 6, width: 92, height: 17),
+                        in: NSRect(x: 152, y: 6, width: 117, height: 17),
                         backgroundOpacity: volumeOpacity.background,
                         borderOpacity: volumeOpacity.border,
                         context: context
@@ -748,7 +748,6 @@ class ModernMainWindowView: NSView {
             (ModernSkinElements.btnPause, "btn_pause"),
             (ModernSkinElements.btnStop, "btn_stop"),
             (ModernSkinElements.btnNext, "btn_next"),
-            (ModernSkinElements.btnEject, "btn_eject"),
         ]
         
         for (element, id) in buttons {
@@ -1366,8 +1365,8 @@ class ModernMainWindowView: NSView {
             rect = scaledRect(effectiveMarqueePanelRect)
         case "spectrum_area":
             rect = scaledRect(ModernSkinElements.spectrumArea.defaultRect)
-        case "btn_prev", "btn_play", "btn_pause", "btn_stop", "btn_next", "btn_eject":
-            rect = scaledRect(NSRect(x: 6, y: 3, width: 168, height: 24))
+        case "btn_prev", "btn_play", "btn_pause", "btn_stop", "btn_next":
+            rect = scaledRect(NSRect(x: 6, y: 3, width: 140, height: 24))
         case "btn_close", "btn_minimize", "btn_shade":
             rect = scaledRect(ModernSkinElements.titleBar.defaultRect)
         case let id where id.hasPrefix("btn_"):
@@ -1414,7 +1413,6 @@ class ModernMainWindowView: NSView {
             ("btn_pause", ModernSkinElements.btnPause.defaultRect),
             ("btn_stop", ModernSkinElements.btnStop.defaultRect),
             ("btn_next", ModernSkinElements.btnNext.defaultRect),
-            ("btn_eject", ModernSkinElements.btnEject.defaultRect),
             // Toggle button row (10 buttons aligned with marquee panel x:93–267)
         ])
         do {
@@ -1645,9 +1643,6 @@ class ModernMainWindowView: NSView {
                 audioEngine.next()
             }
             
-        case "btn_eject":
-            openFileDialog()
-            
         case "btn_sk":
             showModernSkinsMenu()
             
@@ -1709,25 +1704,6 @@ class ModernMainWindowView: NSView {
         let btnRect = scaledRect(NSRect(x: 163, y: 42, width: 18, height: 14))
         let menuPoint = NSPoint(x: btnRect.minX, y: btnRect.maxY)
         menu.popUp(positioning: nil, at: menuPoint, in: self)
-    }
-    
-    // MARK: - File Dialog
-    
-    private func openFileDialog() {
-        let panel = NSOpenPanel()
-        panel.allowsMultipleSelection = true
-        panel.canChooseDirectories = true
-        panel.allowedContentTypes = [.audio, .mp3, .mpeg4Audio, .wav, .aiff]
-        
-        panel.begin { [weak self] response in
-            guard response == .OK else { return }
-            LocalFileDiscovery.discoverMediaURLsAsync(from: panel.urls, includeVideo: false) { urls in
-                guard !urls.isEmpty else { return }
-                WindowManager.shared.audioEngine.loadFiles(urls)
-                WindowManager.shared.audioEngine.play()
-            }
-            _ = self
-        }
     }
     
     // MARK: - Keyboard Events

--- a/Sources/NullPlayer/Windows/ModernMainWindow/ModernMainWindowView.swift
+++ b/Sources/NullPlayer/Windows/ModernMainWindow/ModernMainWindowView.swift
@@ -75,6 +75,9 @@ class ModernMainWindowView: NSView {
     
     /// Timer for distinguishing single vs double click on vis area
     private var visClickTimer: Timer?
+
+    /// Timer for distinguishing single vs double click on the time display.
+    private var timeDisplayClickTimer: Timer?
     
     /// Throttle timestamp for CPU-rendered mini spectrum updates (20Hz)
     private var lastMiniSpectrumUpdate: CFAbsoluteTime = 0
@@ -145,6 +148,10 @@ class ModernMainWindowView: NSView {
         NotificationCenter.default.addObserver(self, selector: #selector(playbackOptionsDidChange),
                                                 name: .audioPlaybackOptionsChanged, object: nil)
 
+        // Observe time display settings so timer menu changes redraw the clock immediately.
+        NotificationCenter.default.addObserver(self, selector: #selector(timeDisplaySettingsDidChange),
+                                                name: .timeDisplaySettingsDidChange, object: nil)
+
         // Observe main window vis mode changes from context menu
         NotificationCenter.default.addObserver(self, selector: #selector(mainVisSettingsChanged),
                                                 name: NSNotification.Name("MainWindowVisChanged"), object: nil)
@@ -163,6 +170,7 @@ class ModernMainWindowView: NSView {
     
     deinit {
         visClickTimer?.invalidate()
+        timeDisplayClickTimer?.invalidate()
         NotificationCenter.default.removeObserver(self)
     }
     
@@ -240,6 +248,11 @@ class ModernMainWindowView: NSView {
 
     @objc private func playbackOptionsDidChange() {
         needsDisplay = true
+    }
+
+    @objc private func timeDisplaySettingsDidChange() {
+        let timeRect = scaledRect(effectiveTimeDisplayRect).insetBy(dx: -2, dy: -2)
+        setNeedsDisplay(timeRect)
     }
 
     private func updateCornerMask() {
@@ -606,35 +619,18 @@ class ModernMainWindowView: NSView {
         let digitWidth = ModernSkinElements.timeDigitSize.width
         let colonWidth = ModernSkinElements.timeColonSize.width
         let digitHeight = ModernSkinElements.timeDigitSize.height
-        
-        let displayTime: TimeInterval
-        let showMinus: Bool
-        
-        let mode = WindowManager.shared.timeDisplayMode
-        if mode == .remaining && duration > 0 {
-            displayTime = duration - currentTime
-            showMinus = true
-        } else {
-            displayTime = currentTime
-            showMinus = false
-        }
-        
-        let totalSeconds = Int(abs(displayTime))
-        let minutes = totalSeconds / 60
-        let seconds = totalSeconds % 60
-        
-        // Build character sequence: [-]M:SS
-        var chars: [String] = []
-        if showMinus { chars.append("-") }
-        chars.append("\(minutes)")
-        chars.append(":")
-        chars.append(String(format: "%02d", seconds))
-        
+
+        let displayString = TimeDisplayFormatter.string(
+            currentTime: currentTime,
+            duration: duration,
+            mode: WindowManager.shared.timeDisplayMode,
+            numberSystem: WindowManager.shared.timeDisplayNumberSystem
+        )
+
         // Calculate total width to center within time display area
-        let allChars = chars.joined()
         var totalWidth: CGFloat = 0
         let digitGap: CGFloat = 1
-        for char in allChars {
+        for char in displayString {
             totalWidth += (String(char) == ":" ? colonWidth : digitWidth) + digitGap
         }
         totalWidth -= digitGap
@@ -643,7 +639,7 @@ class ModernMainWindowView: NSView {
         var x = timeDisplayRect.minX + (timeDisplayRect.width - totalWidth) / 2
         let y = timeDisplayRect.minY + (timeDisplayRect.height - digitHeight) / 2
         
-        for char in allChars {
+        for char in displayString {
             let charStr = String(char)
             let charWidth = charStr == ":" ? colonWidth : digitWidth
             let rect = NSRect(x: x, y: y, width: charWidth, height: digitHeight)
@@ -1478,9 +1474,18 @@ class ModernMainWindowView: NSView {
                 isDraggingVolume = true
                 updateVolumePosition(from: point)
             } else if element == "time_display" {
-                // Toggle time display mode
-                let mode = WindowManager.shared.timeDisplayMode
-                WindowManager.shared.timeDisplayMode = (mode == .elapsed) ? .remaining : .elapsed
+                if event.clickCount == 2 {
+                    timeDisplayClickTimer?.invalidate()
+                    timeDisplayClickTimer = nil
+                    cycleTimeDisplayNumberSystem()
+                } else {
+                    timeDisplayClickTimer?.invalidate()
+                    timeDisplayClickTimer = Timer.scheduledTimer(withTimeInterval: NSEvent.doubleClickInterval, repeats: false) { [weak self] _ in
+                        self?.timeDisplayClickTimer = nil
+                        let mode = WindowManager.shared.timeDisplayMode
+                        WindowManager.shared.timeDisplayMode = (mode == .elapsed) ? .remaining : .elapsed
+                    }
+                }
             } else if element == "info_bpm" {
                 if event.clickCount == 2 {
                     // Cycle: normal → 2x → 0.5x → normal
@@ -1519,6 +1524,18 @@ class ModernMainWindowView: NSView {
                 }
             }
         }
+    }
+
+    private func cycleTimeDisplayNumberSystem() {
+        let systems = TimeDisplayNumberSystem.allCases
+        let current = WindowManager.shared.timeDisplayNumberSystem
+        guard let currentIndex = systems.firstIndex(of: current) else {
+            WindowManager.shared.timeDisplayNumberSystem = .modernDefault
+            return
+        }
+
+        let nextIndex = systems.index(after: currentIndex)
+        WindowManager.shared.timeDisplayNumberSystem = nextIndex == systems.endIndex ? systems[systems.startIndex] : systems[nextIndex]
     }
     
     override func mouseDragged(with event: NSEvent) {

--- a/Tests/NullPlayerAppTests/TimeDisplayFormatterTests.swift
+++ b/Tests/NullPlayerAppTests/TimeDisplayFormatterTests.swift
@@ -1,0 +1,64 @@
+import XCTest
+@testable import NullPlayer
+
+final class TimeDisplayFormatterTests: XCTestCase {
+    func testDecimalFormattingMatchesCurrentBehavior() {
+        XCTAssertEqual(
+            TimeDisplayFormatter.string(minutes: 4, seconds: 32, isNegative: false, numberSystem: .decimal),
+            "4:32"
+        )
+        XCTAssertEqual(
+            TimeDisplayFormatter.string(minutes: 4, seconds: 32, isNegative: true, numberSystem: .decimal),
+            "-4:32"
+        )
+    }
+
+    func testAlternateDecimalScriptsMapDigits() {
+        XCTAssertEqual(
+            TimeDisplayFormatter.string(minutes: 4, seconds: 32, isNegative: false, numberSystem: .arabicIndic),
+            "٤:٣٢"
+        )
+        XCTAssertEqual(
+            TimeDisplayFormatter.string(minutes: 4, seconds: 32, isNegative: false, numberSystem: .extendedArabicIndic),
+            "۴:۳۲"
+        )
+        XCTAssertEqual(
+            TimeDisplayFormatter.string(minutes: 4, seconds: 32, isNegative: false, numberSystem: .devanagari),
+            "४:३२"
+        )
+        XCTAssertEqual(
+            TimeDisplayFormatter.string(minutes: 4, seconds: 32, isNegative: false, numberSystem: .bengali),
+            "৪:৩২"
+        )
+        XCTAssertEqual(
+            TimeDisplayFormatter.string(minutes: 4, seconds: 32, isNegative: false, numberSystem: .thai),
+            "๔:๓๒"
+        )
+        XCTAssertEqual(
+            TimeDisplayFormatter.string(minutes: 4, seconds: 32, isNegative: false, numberSystem: .fullwidth),
+            "４:３２"
+        )
+    }
+
+    func testRadixFormattingSupportsDiscussedModes() {
+        XCTAssertEqual(
+            TimeDisplayFormatter.string(minutes: 4, seconds: 32, isNegative: false, numberSystem: .octal),
+            "4:40"
+        )
+        XCTAssertEqual(
+            TimeDisplayFormatter.string(minutes: 4, seconds: 32, isNegative: false, numberSystem: .hexadecimal),
+            "4:20"
+        )
+    }
+
+    func testRemainingModeOnlyShowsMinusWhenDurationExists() {
+        XCTAssertEqual(
+            TimeDisplayFormatter.string(currentTime: 32, duration: 0, mode: .remaining, numberSystem: .decimal),
+            "0:32"
+        )
+        XCTAssertEqual(
+            TimeDisplayFormatter.string(currentTime: 32, duration: 300, mode: .remaining, numberSystem: .decimal),
+            "-4:28"
+        )
+    }
+}

--- a/scripts/Install NullPlayer CLI.command
+++ b/scripts/Install NullPlayer CLI.command
@@ -1,0 +1,9 @@
+#!/bin/bash
+
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
+"$SCRIPT_DIR/install_cli_launcher.sh"
+
+echo
+read -r -p "Press Return to close this window..." _

--- a/scripts/build_dmg.sh
+++ b/scripts/build_dmg.sh
@@ -301,6 +301,15 @@ mkdir -p "$STAGING_DIR"
 # Copy app to staging
 cp -R "$APP_BUNDLE" "$STAGING_DIR/"
 
+# Copy CLI launcher and install helper
+cp "$REPO_ROOT/scripts/nullplayer" "$STAGING_DIR/"
+cp "$REPO_ROOT/scripts/install_cli_launcher.sh" "$STAGING_DIR/"
+cp "$REPO_ROOT/scripts/Install NullPlayer CLI.command" "$STAGING_DIR/"
+chmod 755 \
+    "$STAGING_DIR/nullplayer" \
+    "$STAGING_DIR/install_cli_launcher.sh" \
+    "$STAGING_DIR/Install NullPlayer CLI.command"
+
 # Create Applications symlink for drag-and-drop install
 ln -s /Applications "$STAGING_DIR/Applications"
 

--- a/scripts/install_cli_launcher.sh
+++ b/scripts/install_cli_launcher.sh
@@ -1,0 +1,54 @@
+#!/bin/bash
+
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+LAUNCHER_SOURCE="$SCRIPT_DIR/nullplayer"
+APP_CANDIDATES=(
+    "/Applications/NullPlayer.app"
+    "$HOME/Applications/NullPlayer.app"
+)
+
+find_installed_app() {
+    local app_path
+    for app_path in "${APP_CANDIDATES[@]}"; do
+        if [[ -x "$app_path/Contents/MacOS/NullPlayer" ]]; then
+            printf '%s\n' "$app_path"
+            return 0
+        fi
+    done
+    return 1
+}
+
+if [[ ! -f "$LAUNCHER_SOURCE" ]]; then
+    echo "Launcher template not found at $LAUNCHER_SOURCE" >&2
+    exit 1
+fi
+
+if ! app_path="$(find_installed_app)"; then
+    cat >&2 <<'EOF'
+NullPlayer.app was not found.
+
+Install it first in one of these locations:
+  /Applications/NullPlayer.app
+  ~/Applications/NullPlayer.app
+EOF
+    exit 1
+fi
+
+target_dir="/usr/local/bin"
+mkdir_cmd=(mkdir -p "$target_dir")
+install_cmd=(install -m 755 "$LAUNCHER_SOURCE" "$target_dir/nullplayer")
+
+if [[ -w "$target_dir" ]] || { [[ ! -e "$target_dir" ]] && [[ -w "/usr/local" ]]; }; then
+    "${mkdir_cmd[@]}"
+    "${install_cmd[@]}"
+else
+    echo "Installing to $target_dir requires administrator privileges."
+    sudo "${mkdir_cmd[@]}"
+    sudo "${install_cmd[@]}"
+fi
+
+echo "Installed nullplayer to $target_dir/nullplayer"
+echo "Using app bundle: $app_path"
+echo "Run: nullplayer --cli --help"

--- a/scripts/nullplayer
+++ b/scripts/nullplayer
@@ -1,0 +1,26 @@
+#!/bin/bash
+
+set -euo pipefail
+
+APP_CANDIDATES=(
+    "/Applications/NullPlayer.app"
+    "$HOME/Applications/NullPlayer.app"
+)
+
+for app_path in "${APP_CANDIDATES[@]}"; do
+    binary_path="$app_path/Contents/MacOS/NullPlayer"
+    if [[ -x "$binary_path" ]]; then
+        exec "$binary_path" "$@"
+    fi
+done
+
+cat >&2 <<'EOF'
+NullPlayer.app was not found in a supported location.
+
+Expected one of:
+  /Applications/NullPlayer.app
+  ~/Applications/NullPlayer.app
+
+Install NullPlayer.app first, then run this command again.
+EOF
+exit 1

--- a/skills/audio-system/SKILL.md
+++ b/skills/audio-system/SKILL.md
@@ -39,7 +39,7 @@ Both pipelines support the active EQ layout for the current UI mode and real-tim
 │  └──────────────┘         │         │              │              │ │
 │                           │         │              ▼              │ │
 │  ┌──────────────┐         │         │  ┌───────────────────────┐  │ │
-│  │crossfadeNode │─────────┼──► mixerNode ─► eqNode ─► limiter   │ │
+│  │crossfadeNode │─────────┼──► mixerNode ─► eqNode ────────────┐ │ │
 │  │ (for Sweet   │         │         │  │ AVAudioUnitEQ         │  │ │
 │  │  Fades)      │         │         │  └───────────┬───────────┘  │ │
 │  └──────────────┘         │         │              │              │ │
@@ -57,12 +57,6 @@ Both pipelines support the active EQ layout for the current UI mode and real-tim
 │                    ┌──────────────┐                                 │
 │                    │ eqNode       │                                 │
 │                    │ (mode EQ)    │                                 │
-│                    └──────┬───────┘                                 │
-│                           │                                         │
-│                           ▼                                         │
-│                    ┌──────────────┐                                 │
-│                    │ limiterNode  │                                 │
-│                    │ (Anti-clip)  │                                 │
 │                    └──────┬───────┘                                 │
 │                           │                                         │
 │                           ▼                                         │
@@ -88,7 +82,6 @@ Main audio controller managing:
 - Shuffle cycle management for non-repeating playback order
 - Track loading (routes to appropriate pipeline)
 - EQ settings (synced to both pipelines)
-- Anti-clipping limiter for EQ protection
 - Gapless playback (optional, local files only)
 - Volume normalization (optional, local files only)
 - Sweet Fades crossfade (both pipelines)
@@ -103,7 +96,6 @@ private let playerNode = AVAudioPlayerNode()
 private let crossfadePlayerNode = AVAudioPlayerNode()
 private let activeEQConfiguration: EQConfiguration
 private let eqNode: AVAudioUnitEQ
-private let limiterNode = AVAudioUnitDynamicsProcessor()
 private var streamingPlayer: StreamingAudioPlayer?
 private var crossfadeStreamingPlayer: StreamingAudioPlayer?
 var gaplessPlaybackEnabled: Bool
@@ -191,7 +183,6 @@ Frequencies: `31.5, 45, 63, 90, 125, 180, 250, 355, 500, 710, 1000, 1400, 2000, 
 - Per-band gain: **-12 dB to +12 dB**
 - Preamp (global gain): **-12 dB to +12 dB**
 - **Disabled by default** to preserve original audio quality
-- Transparent limiter (threshold: -1 dB) prevents clipping
 - Saved EQ arrays are remapped between 10-band and 21-band layouts when restoring across classic/modern mode switches
 
 ### Modern EQ UI Controls

--- a/skills/audio-system/audio-pipelines.md
+++ b/skills/audio-system/audio-pipelines.md
@@ -52,7 +52,7 @@ When enabled via **Playback Options → Sweet Fades (Crossfade)**, tracks smooth
 ```
 playerNode ─────────────────┐
 (outgoing, fading out)      │
-                            ├─► mixerNode ─► eqNode ─► limiter ─► output
+                            ├─► mixerNode ─► eqNode ─► mainMixerNode ─► output
 crossfadePlayerNode ────────┘
 (incoming, fading in)
 ```

--- a/skills/cli/SKILL.md
+++ b/skills/cli/SKILL.md
@@ -5,15 +5,72 @@ description: Headless CLI mode for NullPlayer. Use when working on CLI features,
 
 # NullPlayer CLI Mode
 
-NullPlayer supports a `--cli` flag that launches a headless mode for browsing, searching, and playing music from all configured sources via the terminal. The process stays alive during playback with interactive keyboard controls. Query commands (`--list-*`, `--search`) print results and exit immediately.
+NullPlayer supports a `--cli` flag that launches a headless mode for browsing, searching, playing, and routing media from all configured sources via the terminal. Treat this as a first-class command surface, not a debug-only mode. The process stays alive during playback with interactive keyboard controls. Query commands (`--list-*`, `--search`) print results and exit immediately.
+
+## Positioning
+
+The right mental model is:
+
+- `nullplayer` is a scriptable media control command
+- it connects multiple media sources to multiple playback targets
+- it works well inside shell scripts, launchers, shortcuts, and automation pipelines
+
+Be explicit about both sides of the pipeline:
+
+- Sources in: local library, Plex, Subsonic/Navidrome, Jellyfin, Emby, internet radio
+- Targets out: local audio outputs, Sonos, Chromecast, UPnP/DLNA
+
+Do not describe it as a daemon, background control server, or remote-control protocol unless that is separately implemented. It is a command you invoke to query, resolve, start playback, and optionally cast.
 
 ## Launching
 
 ```bash
-NullPlayer --cli [OPTIONS]
+nullplayer --cli [OPTIONS]
 ```
 
 `--cli` and `--ui-testing` are mutually exclusive. In CLI mode the app runs with `.accessory` activation policy — no Dock icon, no menu bar.
+
+If the launcher is not installed, the underlying executable is still:
+
+```bash
+NullPlayer.app/Contents/MacOS/NullPlayer --cli [OPTIONS]
+```
+
+## Automation Use Cases
+
+This CLI is strong when you need one command to:
+
+- query available sources, libraries, outputs, and cast devices
+- resolve media from different backends with one consistent UX
+- start playback on the Mac itself or send it to a network playback target
+- emit machine-friendly query output via `--json`
+
+Typical examples:
+
+```bash
+# Query sources and devices for downstream scripting
+nullplayer --cli --list-sources --json
+nullplayer --cli --list-devices --json
+nullplayer --cli --list-outputs --json
+
+# Start playback from different backends with one command shape
+nullplayer --cli --source local --artist "Aphex Twin"
+nullplayer --cli --source plex --playlist "Dinner"
+nullplayer --cli --source jellyfin --album "Moon Safari"
+
+# Use NullPlayer as a media-routing command
+nullplayer --cli --source radio --station "KEXP" --cast "Living Room" --cast-type sonos
+nullplayer --cli --source local --album "Kid A" --cast "Office TV" --cast-type dlna
+nullplayer --cli --source subsonic --artist "Massive Attack" --cast "Kitchen Speaker" --cast-type chromecast
+```
+
+When documenting or selling the feature, good phrasing is:
+
+- "scriptable media control command"
+- "headless playback and casting command"
+- "automation-friendly CLI for multi-source media routing"
+
+Avoid vague phrasing like "CLI browser" when the real value is orchestration across sources and outputs.
 
 ---
 
@@ -100,10 +157,50 @@ NullPlayer --cli [OPTIONS]
 | `--region <name>` | string | Radio region (with `--folder region`) |
 | `--volume <0-100>` | int | Initial volume (divided by 100 for `AudioEngine.volume`) |
 | `--cast <device>` | string | Cast to named device (case-insensitive match) |
-| `--cast-type <type>` | string | `sonos`, `chromecast`, `dlna` |
+| `--cast-type <type>` | string | `sonos`, `chromecast`, `dlna` (UPnP/DLNA target filter) |
 | `--sonos-rooms <rooms>` | string | Comma-separated Sonos room names for multi-room |
 | `--eq <preset>` | string | EQ preset name (case-insensitive; from `EQPreset.allPresets`) |
 | `--output <device>` | string | Audio output device name (case-insensitive) |
+
+## Multi-Source / Multi-Output Framing
+
+When explaining this subsystem, always make the two-sided model clear:
+
+1. Source selection
+2. Playback routing
+
+Source selection is handled by `--source`, library filters, search filters, playlists, radio modes, and station selection.
+
+Playback routing is handled by:
+
+- default local playback if no routing flag is supplied
+- `--output <device>` for local audio device selection
+- `--cast <device>` with optional `--cast-type` for network playback targets
+- `--sonos-rooms <rooms>` when targeting grouped Sonos playback
+
+That is why "media control command" is more accurate than "terminal player". The command is not limited to local playback; it also chooses where playback goes.
+
+## Query vs Control Behavior
+
+There are two main command shapes:
+
+- Query commands: print results and exit
+- Playback commands: resolve media, start playback, then remain attached for interactive control
+
+This distinction matters for automation guidance:
+
+- Use query commands plus `--json` when NullPlayer is feeding another step in the pipeline
+- Use playback commands when NullPlayer is the execution step that actually starts playback or casting
+
+Good examples:
+
+```bash
+# Query step
+nullplayer --cli --list-playlists --source plex --json
+
+# Execution step
+nullplayer --cli --source plex --playlist "Focus" --cast "Bedroom" --cast-type sonos
+```
 
 ---
 

--- a/skills/modern-skin-guide/SKILL.md
+++ b/skills/modern-skin-guide/SKILL.md
@@ -194,6 +194,15 @@ Images go in the `images/` subdirectory:
 - `btn_play_pressed.png` -- Play button, pressed state
 - `time_digit_5.png` -- Digit "5" for time display
 
+### Time Display Rendering
+
+The modern main-window timer supports two rendering paths:
+
+- Sprite-based rendering for the default 7-segment set: `time_digit_0` through `time_digit_9`, `time_colon`, and `time_minus`
+- Font-based fallback rendering for alternate timer number systems when matching sprites are not present
+
+This means skins can keep the existing LED-style decimal timer sprites, while alternate numeral systems and radix modes still render using the configured time font.
+
 The engine automatically checks for `@2x` variants on Retina displays.
 
 ## Creating a Minimal Skin

--- a/skills/modern-skin-guide/SKILL.md
+++ b/skills/modern-skin-guide/SKILL.md
@@ -171,7 +171,7 @@ Some UI sections have dedicated `elements` color keys that override the palette:
 | Element key | Controls | Fallback chain |
 |-------------|----------|----------------|
 | `play_controls` | All transport button icon colors | `palette.primary` |
-| `btn_prev` … `btn_eject` | Individual transport button (overrides `play_controls`) | `play_controls` → `palette.primary` |
+| `btn_prev` … `btn_next` | Individual transport button (overrides `play_controls`) | `play_controls` → `palette.primary` |
 | `seek_fill` | Seek bar fill + thumb | `palette.primary` |
 | `volume_fill` | Volume bar fill + thumb | `seek_fill.color` → `palette.primary` |
 | `playlist_text` | Normal (non-current, non-selected) track text in playlist | `palette.textDim` |

--- a/skills/modern-skin-guide/advanced-features.md
+++ b/skills/modern-skin-guide/advanced-features.md
@@ -437,6 +437,72 @@ Side windows scale their width by `sizeMultiplier` and match the vertical stack 
 
 A skin with `"window": { "scale": 1.5 }` sets `baseScaleFactor` to 1.5. In Large UI mode, effective `scaleFactor` becomes 2.25 (1.5 x 1.5).
 
+## Marquee Album Art
+
+The modern main window marquee (`ModernMarqueeLayer`) shows a square album art thumbnail prepended to the scrolling title/artist text. Art and text scroll as a single unit in one seamless loop.
+
+### Layout
+
+- Art square size = `bounds.height` of the marquee layer (fills the full layer height)
+- Art gap = 8 pt between the art square and the text
+- `artScrollOffset = artSize + artGap` (0 when no art)
+- Loop content: `[pad | art | gap | text | scrollGap | pad | art | gap | text | scrollGap]`
+- `loopWidth = artScrollOffset + textWidth + scrollGap`
+
+When no art is present, `artScrollOffset = 0` and the layout is identical to the pre-art behaviour.
+
+### Graceful Entry
+
+Art never pops into a mid-scroll position. When a new image arrives while the marquee is scrolling:
+
+1. The bitmap is re-rendered immediately with the art in the new layout
+2. `scrollOffset` is bumped by `artScrollOffset` so the currently visible text stays at the same screen position
+3. The art sits to the right of the current visible window and scrolls in naturally as the loop progresses
+
+Clearing art (`artworkImage = nil`) is always immediate — stale art never lingers across track changes.
+
+### `artworkImage` property
+
+```swift
+// ModernMarqueeLayer
+var artworkImage: NSImage?   // backed by _artworkImage via scheduleArtwork(_:)
+```
+
+- Setting to `nil`: clears immediately, re-renders
+- Setting to an image while scrolling: compensates `scrollOffset`, re-renders with art entering from right
+- Setting to an image while static: renders immediately
+
+### Artwork Loading in ModernMainWindowView
+
+`ModernMainWindowView` loads artwork itself — it does **not** depend on `NowPlayingManager` or any other window being open.
+
+Loading is triggered from `updateTrackInfo(_ track:)` via a private `loadArtwork(for:)` method:
+
+| Source | Key used | Notes |
+|--------|----------|-------|
+| Plex | `plexRatingKey` | Requires `artworkThumb` for URL |
+| Subsonic | `subsonicId` (as cover art ID) | Does not require `artworkThumb` |
+| Jellyfin | `jellyfinId`, `imageTag: nil` | Server picks image; does not require `artworkThumb` |
+| Emby | `embyId`, `artworkThumb` as imageTag | Falls back gracefully if `artworkThumb` is nil |
+| Local | `track.url` | Extracts from ID3/iTunes/common metadata via `AVURLAsset` |
+
+**Critical**: Subsonic and Jellyfin do not require `artworkThumb` to be set — the loaders fall back to server-side defaults. Using `artworkThumb` as a required guard (as `NowPlayingManager` does) silently skips tracks where the field is absent.
+
+### Caching
+
+`ModernMainWindowView` maintains a private `static let artworkCache = NSCache<NSString, NSImage>()` keyed by source + ID (e.g. `"marquee_plex:{ratingKey}"`). Subsequent plays of the same track are served from cache with no network request.
+
+### Race Condition Prevention
+
+`loadArtwork(for:)` captures `expectedId = track.id` before the async task. The `MainActor.run` block guards `currentTrack?.id == expectedId` before applying the image. Fast track changes (user clicking Next repeatedly) cannot cause stale art from a cancelled/slow load to appear on the new track.
+
+### Key Files
+
+| File | Role |
+|------|------|
+| `ModernSkin/ModernMarqueeLayer.swift` | `artworkImage` property, `scheduleArtwork`, scroll compensation |
+| `Windows/ModernMainWindow/ModernMainWindowView.swift` | `loadArtwork(for:)`, `artworkLoadTask`, `artworkCache`, `skinDidChange` re-apply |
+
 ## Adding a Modern Sub-Window (Developer Guide)
 
 This section documents the repeatable pattern for creating modern-skinned versions of sub-windows.

--- a/skills/modern-skin-guide/element-reference.md
+++ b/skills/modern-skin-guide/element-reference.md
@@ -23,10 +23,12 @@ Complete reference of all skinnable elements with IDs, default positions, and st
 
 | Element ID | Default Rect | Description |
 |-----------|-------------|-------------|
-| `time_display` | 14,64,76,26 | Time display area |
-| `time_digit_0` through `time_digit_9` | 12x20 each | 7-segment LED digits |
+| `time_display` | 14,64,76,26 | Time display area; single-click toggles elapsed/remaining, double-click cycles number systems |
+| `time_digit_0` through `time_digit_9` | 12x20 each | 7-segment LED digits for the default decimal timer |
 | `time_colon` | 5x20 | Colon separator |
 | `time_minus` | 12x20 | Minus sign (remaining time) |
+
+If a timer character has no matching sprite, the modern renderer falls back to drawing it with the configured time font. This is how alternate numeral systems render without requiring a full sprite sheet per script.
 
 ## Info Panel
 

--- a/skills/modern-skin-guide/element-reference.md
+++ b/skills/modern-skin-guide/element-reference.md
@@ -74,14 +74,13 @@ Complete reference of all skinnable elements with IDs, default positions, and st
 | `btn_pause` | 62,3,28,24 | normal, pressed, disabled | Pause |
 | `btn_stop` | 90,3,28,24 | normal, pressed, disabled | Stop |
 | `btn_next` | 118,3,28,24 | normal, pressed, disabled | Next track |
-| `btn_eject` | 146,3,28,24 | normal, pressed | Open file |
 
 **Color:** Use `play_controls` in `elements` to set one color for all transport button icons. Per-button entries (e.g. `btn_play`) take precedence over `play_controls`. Both fall back to `palette.primary`.
 
 ```json
 "elements": {
     "play_controls": { "color": "#00ffcc" },
-    "btn_eject":     { "color": "#ff00aa" }
+    "btn_play":      { "color": "#ff00aa" }
 }
 ```
 
@@ -110,8 +109,8 @@ These buttons appear between the seek bar and transport row, toggling window vis
 
 | Element ID | Default Rect | States | Description |
 |-----------|-------------|--------|-------------|
-| `volume_track` | 182,12,87,3 | normal | Volume bar track |
-| `volume_fill` | 182,12,*,3 | normal | Filled portion |
+| `volume_track` | 157,12,107,3 | normal | Volume bar track |
+| `volume_fill` | 157,12,*,3 | normal | Filled portion |
 | `volume_thumb` | *,10,6,6 | normal, pressed | Volume thumb |
 
 **Color:** Set `volume_fill.color` in `elements` to control the fill and thumb color independently from the seek bar. Falls back to `seek_fill.color`, then `palette.primary`.

--- a/skills/user-guide/SKILL.md
+++ b/skills/user-guide/SKILL.md
@@ -59,13 +59,22 @@ Windows automatically snap together when dragged near each other:
 
 | Element | Description |
 |---------|-------------|
-| **Time Display** | Elapsed/remaining time (click to toggle) |
+| **Time Display** | Single-click toggles elapsed/remaining; double-click cycles timer number systems in modern UI |
 | **Track Marquee** | Scrolling song title/artist, with album art thumbnail when available |
 | **Bitrate** | Track bitrate in kbps |
 | **Sample Rate** | Audio sample rate in kHz |
 | **Stereo Indicator** | Shows mono/stereo status |
 | **Cast Indicator** | Shows when casting to external device |
 | **Spectrum Analyzer** | Real-time frequency visualization |
+
+### Playback Menu: Timer
+
+`Playback > Timer` unifies main-window timer options:
+
+- `Elapsed` / `Remaining` choose the time basis
+- `Number System` is modern-only
+- `Default (Decimal)` restores the current default behavior
+- Additional modern timer number systems include Arabic-Indic, Extended Arabic-Indic, Devanagari, Bengali, Thai, Fullwidth, Octal, and Hexadecimal
 
 ### Sliders
 

--- a/skills/user-guide/SKILL.md
+++ b/skills/user-guide/SKILL.md
@@ -75,7 +75,7 @@ Windows automatically snap together when dragged near each other:
 
 ### Transport Buttons
 
-Previous, Play, Pause, Stop, Next, Eject (open file dialog)
+Previous, Play, Pause, Stop, Next
 
 ### Toggle Buttons
 

--- a/skills/user-guide/SKILL.md
+++ b/skills/user-guide/SKILL.md
@@ -60,7 +60,7 @@ Windows automatically snap together when dragged near each other:
 | Element | Description |
 |---------|-------------|
 | **Time Display** | Elapsed/remaining time (click to toggle) |
-| **Track Marquee** | Scrolling song title/artist |
+| **Track Marquee** | Scrolling song title/artist, with album art thumbnail when available |
 | **Bitrate** | Track bitrate in kbps |
 | **Sample Rate** | Audio sample rate in kHz |
 | **Stereo Indicator** | Shows mono/stereo status |


### PR DESCRIPTION
Summary:
- add modern marquee album art and timer/display updates
- add an installable nullplayer launcher and package it in the DMG
- expand README, CLI skill docs, and changelog for the CLI automation/casting workflow

Testing:
- swift build

Note:
- working tree still has an unrelated deleted .claude/worktrees/agent-ada3c188 file that is not part of this PR

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes v0.20.0

* **New Features**
  * Added album artwork display in the modern main-window marquee
  * Added modern timer number system options (Arabic-Indic, Thai, Fullwidth, Octal, Hexadecimal, and more)
  * Added installable `nullplayer` CLI launcher with one-click installer to `/usr/local/bin`

* **Improvements**
  * Enhanced time display interaction: single-click toggles elapsed/remaining; double-click cycles number systems
  * Tighter modern transport UI layout
  * Improved album artwork loading with caching and race-condition handling
  * Expanded volume control documentation with keyboard shortcuts

* **Documentation**
  * Enhanced CLI documentation as the primary automation entry point
  * Expanded volume and timer configuration guides
  * Updated modern skin reference with marquee and number system details

<!-- end of auto-generated comment: release notes by coderabbit.ai -->