### PR TITLE
feat: add Sleep Timer

### DIFF
--- a/Sources/NullPlayer/App/ContextMenuBuilder.swift
+++ b/Sources/NullPlayer/App/ContextMenuBuilder.swift
@@ -163,12 +163,77 @@ class ContextMenuBuilder {
 
         menu.addItem(NSMenuItem.separator())
 
+        // Sleep Timer submenu
+        let sleepTimerItem = NSMenuItem(title: "Sleep Timer", action: nil, keyEquivalent: "")
+        sleepTimerItem.submenu = buildSleepTimerMenu()
+        if SleepTimerManager.shared.isActive { sleepTimerItem.state = .on }
+        menu.addItem(sleepTimerItem)
+
+        menu.addItem(NSMenuItem.separator())
+
         let rememberState = NSMenuItem(title: "Remember State On Quit", action: #selector(MenuActions.toggleRememberState), keyEquivalent: "")
         rememberState.target = MenuActions.shared
         rememberState.state = AppStateManager.shared.isEnabled ? .on : .off
         menu.addItem(rememberState)
 
         menu.autoenablesItems = false
+        return menu
+    }
+
+    // MARK: - Sleep Timer Submenu
+
+    static func buildSleepTimerMenu() -> NSMenu {
+        let menu = NSMenu()
+        menu.autoenablesItems = false
+
+        let manager = SleepTimerManager.shared
+
+        if let description = manager.menuDescription {
+            let status = NSMenuItem(title: description, action: nil, keyEquivalent: "")
+            status.isEnabled = false
+            menu.addItem(status)
+
+            let cancel = NSMenuItem(title: "Cancel Sleep Timer", action: #selector(MenuActions.cancelSleepTimer), keyEquivalent: "")
+            cancel.target = MenuActions.shared
+            menu.addItem(cancel)
+
+            menu.addItem(NSMenuItem.separator())
+        }
+
+        for minutes in SleepTimerManager.timedChoicesMinutes {
+            let title: String
+            if minutes >= 60 {
+                let hours = Double(minutes) / 60.0
+                title = hours == floor(hours)
+                    ? "\(Int(hours)) hour\(Int(hours) == 1 ? "" : "s")"
+                    : String(format: "%.1f hours", hours)
+            } else {
+                title = "\(minutes) minutes"
+            }
+            let item = NSMenuItem(title: title, action: #selector(MenuActions.startSleepTimerMinutes(_:)), keyEquivalent: "")
+            item.target = MenuActions.shared
+            item.representedObject = minutes
+            if let state = manager.state,
+               state.mode == .timed,
+               let duration = state.originalDuration,
+               Int(duration / 60) == minutes {
+                item.state = .on
+            }
+            menu.addItem(item)
+        }
+
+        menu.addItem(NSMenuItem.separator())
+
+        let endOfTrack = NSMenuItem(title: "End of Current Track", action: #selector(MenuActions.startSleepTimerEndOfTrack), keyEquivalent: "")
+        endOfTrack.target = MenuActions.shared
+        if manager.state?.mode == .endOfTrack { endOfTrack.state = .on }
+        menu.addItem(endOfTrack)
+
+        let endOfQueue = NSMenuItem(title: "End of Queue", action: #selector(MenuActions.startSleepTimerEndOfQueue), keyEquivalent: "")
+        endOfQueue.target = MenuActions.shared
+        if manager.state?.mode == .endOfQueue { endOfQueue.state = .on }
+        menu.addItem(endOfQueue)
+
         return menu
     }
 
@@ -3486,6 +3551,40 @@ class MenuActions: NSObject {
     
     @objc func toggleBrowserArtworkBackground() {
         WindowManager.shared.showBrowserArtworkBackground.toggle()
+    }
+
+    // MARK: - Sleep Timer
+
+    @objc func startSleepTimerMinutes(_ sender: NSMenuItem) {
+        guard let minutes = sender.representedObject as? Int else { return }
+        if let state = SleepTimerManager.shared.state,
+           state.mode == .timed,
+           let duration = state.originalDuration,
+           Int(duration / 60) == minutes {
+            SleepTimerManager.shared.cancel()
+            return
+        }
+        SleepTimerManager.shared.startTimed(minutes: minutes)
+    }
+
+    @objc func startSleepTimerEndOfTrack() {
+        if SleepTimerManager.shared.state?.mode == .endOfTrack {
+            SleepTimerManager.shared.cancel()
+            return
+        }
+        SleepTimerManager.shared.startEndOfTrack()
+    }
+
+    @objc func startSleepTimerEndOfQueue() {
+        if SleepTimerManager.shared.state?.mode == .endOfQueue {
+            SleepTimerManager.shared.cancel()
+            return
+        }
+        SleepTimerManager.shared.startEndOfQueue()
+    }
+
+    @objc func cancelSleepTimer() {
+        SleepTimerManager.shared.cancel()
     }
 
     // MARK: - Plex Radio History

--- a/Sources/NullPlayer/App/SleepTimerManager.swift
+++ b/Sources/NullPlayer/App/SleepTimerManager.swift
@@ -1,0 +1,245 @@
+import Foundation
+import AppKit
+
+// =============================================================================
+// SLEEP TIMER MANAGER
+// =============================================================================
+// Schedules an automatic pause/stop after a configurable duration.
+//
+// Three modes:
+//   1. Timed:       Pause/stop after N minutes (with optional volume fade-out)
+//   2. EndOfTrack:  Pause/stop when the current track finishes naturally
+//   3. EndOfQueue:  Pause/stop when the last playlist track finishes
+//
+// All public methods must be called from the main thread.
+// State is session-local (not persisted across launches).
+// =============================================================================
+
+final class SleepTimerManager {
+    static let shared = SleepTimerManager()
+
+    // MARK: - Notifications
+
+    static let stateDidChangeNotification = Notification.Name("NullPlayer.SleepTimer.stateDidChange")
+
+    // MARK: - Types
+
+    enum Mode: String { case timed, endOfTrack, endOfQueue }
+    enum Action: String { case pause, stop }
+
+    struct State {
+        let mode: Mode
+        let action: Action
+        let fireDate: Date?
+        let originalDuration: TimeInterval?
+        let fadeOut: Bool
+        let fadeOutSeconds: TimeInterval
+    }
+
+    // MARK: - Public State
+
+    private(set) var state: State?
+    var isActive: Bool { state != nil }
+
+    var remainingSeconds: TimeInterval? {
+        guard let state, let fire = state.fireDate else { return nil }
+        return max(0, fire.timeIntervalSinceNow)
+    }
+
+    // MARK: - Config
+
+    static let timedChoicesMinutes: [Int] = [5, 10, 15, 30, 45, 60, 90, 120]
+    static let defaultFadeOutSeconds: TimeInterval = 10
+
+    // MARK: - Internal
+
+    private var timer: Timer?
+    private var tickTimer: Timer?
+    private var fadeStartVolume: Float?
+    private var lastWrittenVolume: Float?
+    private var isFading: Bool = false
+
+    private init() {
+        // Observe natural track completion (fires BEFORE currentTrack advances).
+        // This lets endOfTrack mode distinguish natural completion from user skip.
+        NotificationCenter.default.addObserver(
+            self,
+            selector: #selector(trackDidFinishNaturally),
+            name: .audioTrackDidFinishNaturally,
+            object: nil
+        )
+        // Observe track changes for endOfQueue mode (nil track = queue ended).
+        NotificationCenter.default.addObserver(
+            self,
+            selector: #selector(trackDidChange),
+            name: .audioTrackDidChange,
+            object: nil
+        )
+    }
+
+    // MARK: - Public API
+
+    func startTimed(minutes: Int, action: Action = .pause, fadeOut: Bool = true) {
+        dispatchPrecondition(condition: .onQueue(.main))
+        cancel()
+        let duration = TimeInterval(max(1, minutes) * 60)
+        let fireDate = Date().addingTimeInterval(duration)
+        state = State(
+            mode: .timed, action: action, fireDate: fireDate,
+            originalDuration: duration, fadeOut: fadeOut,
+            fadeOutSeconds: Self.defaultFadeOutSeconds
+        )
+        fadeStartVolume = nil
+        lastWrittenVolume = nil
+        isFading = false
+        timer = Timer.scheduledTimer(withTimeInterval: duration, repeats: false) { [weak self] _ in
+            self?.fire()
+        }
+        tickTimer = Timer.scheduledTimer(withTimeInterval: 1.0, repeats: true) { [weak self] _ in
+            self?.tick()
+        }
+        notifyChange()
+    }
+
+    func startEndOfTrack(action: Action = .pause) {
+        dispatchPrecondition(condition: .onQueue(.main))
+        cancel()
+        state = State(
+            mode: .endOfTrack, action: action, fireDate: nil,
+            originalDuration: nil, fadeOut: false, fadeOutSeconds: 0
+        )
+        notifyChange()
+    }
+
+    func startEndOfQueue(action: Action = .pause) {
+        dispatchPrecondition(condition: .onQueue(.main))
+        cancel()
+        state = State(
+            mode: .endOfQueue, action: action, fireDate: nil,
+            originalDuration: nil, fadeOut: false, fadeOutSeconds: 0
+        )
+        notifyChange()
+    }
+
+    func cancel() {
+        dispatchPrecondition(condition: .onQueue(.main))
+        timer?.invalidate(); timer = nil
+        tickTimer?.invalidate(); tickTimer = nil
+        if isFading, let startVolume = fadeStartVolume {
+            let currentVolume = WindowManager.shared.audioEngine.volume
+            if let lastWritten = lastWrittenVolume,
+               abs(currentVolume - lastWritten) < 0.01 {
+                WindowManager.shared.audioEngine.volume = startVolume
+            }
+        }
+        fadeStartVolume = nil
+        lastWrittenVolume = nil
+        isFading = false
+        let wasActive = state != nil
+        state = nil
+        if wasActive { notifyChange() }
+    }
+
+    // MARK: - Tick / Fade
+
+    private func tick() {
+        guard let state, let fire = state.fireDate else { return }
+        let remaining = max(0, fire.timeIntervalSinceNow)
+        if state.fadeOut, state.fadeOutSeconds > 0, remaining <= state.fadeOutSeconds, !isFading {
+            beginFade(over: remaining)
+        } else if isFading {
+            if let lastWritten = lastWrittenVolume {
+                let currentVolume = WindowManager.shared.audioEngine.volume
+                if abs(currentVolume - lastWritten) > 0.01 {
+                    isFading = false
+                    fadeStartVolume = nil
+                    lastWrittenVolume = nil
+                    return
+                }
+            }
+            updateFade(remaining: remaining)
+        }
+        notifyChange()
+    }
+
+    private func beginFade(over remaining: TimeInterval) {
+        fadeStartVolume = WindowManager.shared.audioEngine.volume
+        lastWrittenVolume = nil
+        isFading = true
+        updateFade(remaining: remaining)
+    }
+
+    private func updateFade(remaining: TimeInterval) {
+        guard let state, let startVolume = fadeStartVolume else { return }
+        let progress = max(0, min(1, 1.0 - (max(0, remaining) / max(0.001, state.fadeOutSeconds))))
+        let newVolume = max(0, startVolume * Float(1.0 - progress))
+        WindowManager.shared.audioEngine.volume = newVolume
+        lastWrittenVolume = newVolume
+    }
+
+    // MARK: - Firing
+
+    private func fire() {
+        guard let state else { return }
+        applyAction(state.action)
+        if isFading, let startVolume = fadeStartVolume {
+            if let lastWritten = lastWrittenVolume,
+               abs(WindowManager.shared.audioEngine.volume - lastWritten) < 0.01 {
+                WindowManager.shared.audioEngine.volume = startVolume
+            }
+        }
+        timer?.invalidate(); timer = nil
+        tickTimer?.invalidate(); tickTimer = nil
+        self.state = nil
+        fadeStartVolume = nil
+        lastWrittenVolume = nil
+        isFading = false
+        notifyChange()
+    }
+
+    private func applyAction(_ action: Action) {
+        switch action {
+        case .pause: WindowManager.shared.audioEngine.pause()
+        case .stop:  WindowManager.shared.audioEngine.stop()
+        }
+    }
+
+    // MARK: - Track Completion Handlers
+
+    /// Fired when a track finishes playing naturally (BEFORE currentTrack advances).
+    /// This is the correct signal for endOfTrack mode.
+    @objc private func trackDidFinishNaturally(_ note: Notification) {
+        dispatchPrecondition(condition: .onQueue(.main))
+        guard let state, state.mode == .endOfTrack else { return }
+        fire()
+    }
+
+    /// Fired when currentTrack changes (AFTER advancement).
+    /// Used only for endOfQueue mode: fire when currentTrack becomes nil (queue ended).
+    @objc private func trackDidChange(_ note: Notification) {
+        dispatchPrecondition(condition: .onQueue(.main))
+        guard let state, state.mode == .endOfQueue else { return }
+        if WindowManager.shared.audioEngine.currentTrack == nil {
+            fire()
+        }
+    }
+
+    // MARK: - Helpers
+
+    private func notifyChange() {
+        NotificationCenter.default.post(name: Self.stateDidChangeNotification, object: nil)
+    }
+
+    var menuDescription: String? {
+        guard let state else { return nil }
+        switch state.mode {
+        case .timed:
+            guard let remaining = remainingSeconds else { return "Sleep Timer" }
+            let minutes = Int(remaining) / 60
+            let seconds = Int(remaining) % 60
+            return String(format: "Sleep Timer: %d:%02d", minutes, seconds)
+        case .endOfTrack: return "Sleep Timer: End of track"
+        case .endOfQueue: return "Sleep Timer: End of queue"
+        }
+    }
+}

--- a/Sources/NullPlayer/Audio/AudioEngine.swift
+++ b/Sources/NullPlayer/Audio/AudioEngine.swift
@@ -35,7 +35,13 @@ extension Notification.Name {
     /// Posted when BPM detection updates
     /// userInfo contains: "bpm" (Int) - 0 means no confident reading
     static let bpmUpdated = Notification.Name("bpmUpdated")
-    
+
+    /// Posted when a track finishes playing naturally (not skipped by user).
+    /// Fired from `trackDidFinish()` BEFORE `currentTrack` advances to the next track.
+    /// userInfo contains: "track" (Track) - the track that just finished
+    /// Used by SleepTimerManager to distinguish natural completion from manual skip.
+    static let audioTrackDidFinishNaturally = Notification.Name("audioTrackDidFinishNaturally")
+
 }
 
 /// Audio playback state
@@ -3763,7 +3769,17 @@ class AudioEngine {
             NSLog("trackDidFinish: Ignoring during crossfade")
             return
         }
-        
+
+        // Notify observers that the current track finished naturally BEFORE advancing.
+        // This lets SleepTimerManager distinguish natural completion from user skip.
+        if let finishedTrack = currentTrack {
+            NotificationCenter.default.post(
+                name: .audioTrackDidFinishNaturally,
+                object: self,
+                userInfo: ["track": finishedTrack]
+            )
+        }
+
         // Report track finished to Plex (natural end)
         let finishPosition = duration
         PlexPlaybackReporter.shared.trackDidStop(at: finishPosition, finished: true)


### PR DESCRIPTION
## Sleep Timer

Adds a Sleep Timer feature accessible from the **Playback > Sleep Timer** submenu.

### Three modes

- **Timed**: Pause/stop after 5, 10, 15, 30, 45, 60, 90, or 120 minutes. Includes a 10-second linear volume fade-out before firing.
- **End of Current Track**: Pause/stop when the currently playing track finishes naturally. Does **not** fire on manual skip/previous — only on natural completion.
- **End of Queue**: Pause/stop when the last track in the playlist finishes.

### Implementation details

- **`SleepTimerManager.swift`** (245 lines): Singleton manager handling all three modes, fade logic, and state management.
- **New `audioTrackDidFinishNaturally` notification**: Posted from `trackDidFinish()` in `AudioEngine.swift` *before* `currentTrack` advances to the next track. This allows `endOfTrack` mode to distinguish natural completion from user skip — addressing a design concern raised in the previous PR review.
- **Menu integration**: Sleep Timer submenu added to the Playback menu in `ContextMenuBuilder.swift` with status display, cancel option, timed presets, and track-aware options. Toggle behavior: selecting the active preset cancels it.
- **Volume safety**: Fade-out detects external volume changes (user adjusts volume during fade) and aborts. Volume is restored to the original level after the timer fires.
- **Thread safety**: All public methods enforce `dispatchPrecondition(condition: .onQueue(.main))`.
- **Session-local state**: Timer state is not persisted across launches (intentional).

### Files changed (3)

| File | Change |
|------|--------|
| `Sources/NullPlayer/App/SleepTimerManager.swift` | **New** — Sleep timer manager |
| `Sources/NullPlayer/App/ContextMenuBuilder.swift` | Added submenu builder + menu actions |
| `Sources/NullPlayer/Audio/AudioEngine.swift` | Added `audioTrackDidFinishNaturally` notification |

### Stats

3 files changed, 362 insertions(+), 2 deletions(-)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Added Sleep Timer to the Playback menu with three options: timed duration (various minute selections), end of current track, or end of queue
  * Displays current sleep timer status in the menu
  * Toggle an active timer off by selecting the same option again, or cancel anytime from the menu

<!-- end of auto-generated comment: release notes by coderabbit.ai -->