### PR TITLE
fix: prevent crashes in window toggle functions from force-unwrap

### DIFF
--- a/Sources/NullPlayer/App/WindowManager.swift
+++ b/Sources/NullPlayer/App/WindowManager.swift
@@ -523,9 +523,11 @@ class WindowManager {
     
     func togglePlaylist() {
         if let controller = playlistWindowController, controller.window?.isVisible == true {
-            let closingFrame = controller.window!.frame
+            let closingFrame = controller.window?.frame ?? .zero
             controller.window?.orderOut(nil)
-            slideUpWindowsBelow(closingFrame: closingFrame)
+            if closingFrame != .zero {
+                slideUpWindowsBelow(closingFrame: closingFrame)
+            }
         } else {
             showPlaylist()
         }
@@ -570,9 +572,11 @@ class WindowManager {
     
     func toggleEqualizer() {
         if let controller = equalizerWindowController, controller.window?.isVisible == true {
-            let closingFrame = controller.window!.frame
+            let closingFrame = controller.window?.frame ?? .zero
             controller.window?.orderOut(nil)
-            slideUpWindowsBelow(closingFrame: closingFrame)
+            if closingFrame != .zero {
+                slideUpWindowsBelow(closingFrame: closingFrame)
+            }
         } else {
             showEqualizer()
         }
@@ -1436,11 +1440,13 @@ class WindowManager {
     
     func toggleSpectrum() {
         if let controller = spectrumWindowController, controller.window?.isVisible == true {
-            let closingFrame = controller.window!.frame
+            let closingFrame = controller.window?.frame ?? .zero
             // Stop rendering before hiding to save CPU (orderOut doesn't trigger windowWillClose)
             controller.stopRenderingForHide()
             controller.window?.orderOut(nil)
-            slideUpWindowsBelow(closingFrame: closingFrame)
+            if closingFrame != .zero {
+                slideUpWindowsBelow(closingFrame: closingFrame)
+            }
         } else {
             showSpectrum()
         }
@@ -1506,10 +1512,12 @@ class WindowManager {
 
     func toggleWaveform() {
         if let controller = waveformWindowController, controller.window?.isVisible == true {
-            let closingFrame = controller.window!.frame
+            let closingFrame = controller.window?.frame ?? .zero
             controller.stopLoadingForHide()
             controller.window?.orderOut(nil)
-            slideUpWindowsBelow(closingFrame: closingFrame)
+            if closingFrame != .zero {
+                slideUpWindowsBelow(closingFrame: closingFrame)
+            }
         } else {
             showWaveform()
         }


### PR DESCRIPTION
Closes #163

Fixes 4 potential crash sites in `WindowManager.swift` where `togglePlaylist`, `toggleEqualizer`, `toggleSpectrum`, and `toggleWaveform` all used `controller.window!.frame` to capture the closing frame before hiding the window. If the window is nil during teardown or a reentrancy scenario, the force-unwrap crashes.

## Changes

Replace force-unwrap with safe optional chaining and guard the sliding animation:

```swift
// BEFORE:
let closingFrame = controller.window!.frame
controller.window?.orderOut(nil)
slideUpWindowsBelow(closingFrame: closingFrame)

// AFTER:
let closingFrame = controller.window?.frame ?? .zero
controller.window?.orderOut(nil)
if closingFrame != .zero {
    slideUpWindowsBelow(closingFrame: closingFrame)
}
```

Applied to all 4 sites in `WindowManager.swift`: `togglePlaylist` (line 526), `toggleEqualizer` (line 573), `toggleSpectrum` (line 1439), `toggleWaveform` (line 1509).

## Note

The guard `if closingFrame != .zero` prevents passing a zero rect to `slideUpWindowsBelow` in the (rare) case the window was already gone — this preserves the existing animation behavior when the window is present.