### PR TITLE
chore: modernize deprecated AVAsset APIs in WaveformCacheService

### DIFF
--- a/Sources/NullPlayer/Waveform/WaveformCacheService.swift
+++ b/Sources/NullPlayer/Waveform/WaveformCacheService.swift
@@ -298,15 +298,26 @@ actor WaveformCacheService {
         }
 
         let asset = AVURLAsset(url: descriptor.sourceURL)
-        try await loadAssetValues(for: asset, keys: ["tracks"])
 
-        guard let audioTrack = asset.tracks(withMediaType: .audio).first else {
+        // Modern async API (macOS 13+): replaces synchronous
+        // tracks(withMediaType:) + loadValuesAsynchronously.
+        let audioTracks: [AVAssetTrack]
+        do {
+            audioTracks = try await asset.loadTracks(withMediaType: .audio)
+        } catch {
+            throw NSError(domain: "WaveformCacheService", code: 1, userInfo: [
+                NSLocalizedDescriptionKey: "Failed to load audio tracks: \(error.localizedDescription)",
+                NSUnderlyingErrorKey: error
+            ])
+        }
+
+        guard let audioTrack = audioTracks.first else {
             throw NSError(domain: "WaveformCacheService", code: 1, userInfo: [
                 NSLocalizedDescriptionKey: "No audio track available for waveform prerender"
             ])
         }
 
-        let sampleRate = Self.sampleRate(for: audioTrack) ?? 44_100
+        let sampleRate = (await Self.sampleRate(for: audioTrack)) ?? 44_100
         let totalFrames = max(Int64(round(duration * sampleRate)), 1)
         var accumulator = WaveformBucketAccumulator(totalFrames: totalFrames)
         var frameIndex: Int64 = 0
@@ -431,26 +442,6 @@ actor WaveformCacheService {
             allowsSeeking: true,
             isStreaming: true
         )
-    }
-
-    private func loadAssetValues(for asset: AVAsset, keys: [String]) async throws {
-        try await withCheckedThrowingContinuation { (continuation: CheckedContinuation<Void, Error>) in
-            asset.loadValuesAsynchronously(forKeys: keys) {
-                for key in keys {
-                    var error: NSError?
-                    let status = asset.statusOfValue(forKey: key, error: &error)
-                    if status == .failed || status == .cancelled {
-                        continuation.resume(throwing: error ?? NSError(
-                            domain: "WaveformCacheService",
-                            code: 1,
-                            userInfo: [NSLocalizedDescriptionKey: "Failed to load AVAsset key: \(key)"]
-                        ))
-                        return
-                    }
-                }
-                continuation.resume()
-            }
-        }
     }
 
     private func fileMetadata(for url: URL) throws -> (canonicalPath: String, fileSize: Int64, modificationDate: Date) {
@@ -587,9 +578,16 @@ actor WaveformCacheService {
         return amplitude
     }
 
-    private static func sampleRate(for track: AVAssetTrack) -> Double? {
-        for formatDescription in track.formatDescriptions {
-            let description = formatDescription as! CMFormatDescription
+    private static func sampleRate(for track: AVAssetTrack) async -> Double? {
+        // Modern async API (macOS 13+): replaces synchronous formatDescriptions accessor.
+        let descriptions: [CMFormatDescription]
+        do {
+            descriptions = try await track.load(.formatDescriptions)
+        } catch {
+            NSLog("WaveformCacheService: failed to load formatDescriptions: %@", error.localizedDescription)
+            return nil
+        }
+        for description in descriptions {
             guard let asbdPointer = CMAudioFormatDescriptionGetStreamBasicDescription(description) else {
                 continue
             }


### PR DESCRIPTION
Closes #170

Replaces three deprecated-in-macOS-13 synchronous AVAsset APIs with their modern async equivalents. The containing functions were already `async`, so this is a localized change with no call-site cascading.

## Changes

| Before | After |
|--------|-------|
| `asset.tracks(withMediaType: .audio)` | `asset.loadTracks(withMediaType: .audio)` |
| `track.formatDescriptions` | `track.load(.formatDescriptions)` |
| `loadAssetValues` helper (used `statusOfValue`) | Removed — no longer needed |

## Error handling improvements

- Track-load failure now preserves the underlying error via `NSUnderlyingErrorKey` so diagnostics aren't lost when the outer `generateServiceSnapshot` logs the failure
- `formatDescriptions` load failure is now explicitly logged (`NSLog`) instead of silently returning nil. If the load legitimately fails, downstream code falls back to the hardcoded 44.1 kHz default — at least now there's a log trail.

## Note

`Track.swift` and `MediaLibrary.swift` also use deprecated AVAsset APIs but require converting their synchronous initializers/helpers to async, which cascades through the library scanner hot path. That is a larger, separate effort and is not in scope for this PR.

## Verification

```
Build complete! (WaveformCacheService: 0 deprecated warnings)
```