### PR TITLE
perf: cache formatted column values in library browser

### DIFF
--- a/Sources/NullPlayer/Windows/ModernLibraryBrowser/ModernLibraryBrowserView.swift
+++ b/Sources/NullPlayer/Windows/ModernLibraryBrowser/ModernLibraryBrowserView.swift
@@ -244,8 +244,19 @@ class ModernLibraryBrowserView: NSView {
     private var visibleAlbumColumnIds: [String] = ModernBrowserColumn.defaultAlbumColumnIds { didSet { saveVisibleColumns() } }
     private var visibleArtistColumnIds: [String] = ModernBrowserColumn.defaultArtistColumnIds { didSet { saveVisibleColumns() } }
     
-    // Display items
-    private var displayItems: [ModernDisplayItem] = []
+    // Display items (with formatted-value cache invalidation via setter)
+    private var _displayItems: [ModernDisplayItem] = []
+    private var displayItems: [ModernDisplayItem] {
+        get { _displayItems }
+        set {
+            _displayItems = newValue
+            formattedValueCache.removeAll(keepingCapacity: true)
+        }
+    }
+    /// Cache of formatted cell values to avoid re-formatting during scroll.
+    /// Keyed by item.id then column.id. Invalidated when displayItems changes
+    /// and whenever external rating/metadata mutations occur.
+    private var formattedValueCache: [String: [String: String]] = [:]
     
     // Expanded state
     private var expandedArtists: Set<String> = []
@@ -1851,7 +1862,19 @@ class ModernLibraryBrowserView: NSView {
         var x = rect.minX + indent + 4 - horizontalScrollOffset
         for column in columns {
             let width = widthForColumn(column, availableWidth: totalWidth, columns: columns)
-            let value = item.columnValue(for: column)
+            // Performance: cache formatted values to avoid expensive re-formatting
+            // (duration/date/size formatters) on every scroll redraw.
+            let value: String
+            if let cached = formattedValueCache[item.id]?[column.id] {
+                value = cached
+            } else {
+                let formatted = item.columnValue(for: column)
+                if formattedValueCache[item.id] == nil {
+                    formattedValueCache[item.id] = [:]
+                }
+                formattedValueCache[item.id]?[column.id] = formatted
+                value = formatted
+            }
             let isCenteredRadioColumn = (browseMode == .radio && column.id == "genre") ||
                 (isInternetRadioItem(item) && column.id == "rating")
             
@@ -7192,6 +7215,9 @@ class ModernLibraryBrowserView: NSView {
         guard let albumId = sender.representedObject as? String else { return }
         let rating = sender.tag
         MediaLibrary.shared.setAlbumRating(albumId: albumId, rating: rating >= 0 ? rating : nil)
+        // Rating change is external to displayItems; invalidate the formatted cache
+        // so cells recompute rating text on next draw.
+        formattedValueCache.removeAll(keepingCapacity: true)
         needsDisplay = true
     }
 
@@ -7199,6 +7225,7 @@ class ModernLibraryBrowserView: NSView {
         guard let artistId = sender.representedObject as? String else { return }
         let rating = sender.tag
         MediaLibrary.shared.setArtistRating(artistId: artistId, rating: rating >= 0 ? rating : nil)
+        formattedValueCache.removeAll(keepingCapacity: true)
         needsDisplay = true
     }
     


### PR DESCRIPTION
Closes #171

`ModernLibraryBrowserView` previously called `item.columnValue(for:)` in the draw loop for every visible cell on every redraw. That method invokes date/duration/size formatters which are CPU-intensive, causing noticeable stutter when scrolling large lists (thousands of tracks).

## Changes

### 1. Add cache with auto-invalidation on `displayItems` change

```swift
// Before:
private var displayItems: [ModernDisplayItem] = []

// After:
private var _displayItems: [ModernDisplayItem] = []
private var displayItems: [ModernDisplayItem] {
    get { _displayItems }
    set {
        _displayItems = newValue
        formattedValueCache.removeAll(keepingCapacity: true)
    }
}
private var formattedValueCache: [String: [String: String]] = [:]
```

### 2. Use cache in `drawColumnRow`

```swift
let value: String
if let cached = formattedValueCache[item.id]?[column.id] {
    value = cached
} else {
    let formatted = item.columnValue(for: column)
    if formattedValueCache[item.id] == nil {
        formattedValueCache[item.id] = [:]
    }
    formattedValueCache[item.id]?[column.id] = formatted
    value = formatted
}
```

### 3. Invalidate on external rating mutations

Added `formattedValueCache.removeAll(keepingCapacity: true)` to `contextMenuRateLocalAlbum` and `contextMenuRateLocalArtist` — these handlers mutate state *outside* `displayItems` (they update `MediaLibrary` album/artist ratings without reloading the display items), so the setter-based invalidation doesn't catch them.

The other rating handlers (track/subsonic/plex/jellyfin/emby) call `updateCached*Rating` helpers that mutate `displayItems`, which already triggers invalidation automatically via the setter.

## Verification

Build passes. Expected behavior unchanged — only faster scroll redraws.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Performance**
  * Improved scrolling and browsing performance in the library view, particularly when working with large library collections.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->