### PR TITLE
chore: centralize all UserDefaults keys with type-safe constants

### DIFF
--- a/Sources/NullPlayer/App/AppStateManager.swift
+++ b/Sources/NullPlayer/App/AppStateManager.swift
@@ -519,7 +519,7 @@ class AppStateManager {
             
             // EQ settings
             eqEnabled: engine.isEQEnabled(),
-            eqAutoEnabled: UserDefaults.standard.bool(forKey: "EQAutoEnabled"),
+            eqAutoEnabled: UserDefaults.standard.bool(forKey: .eqAutoEnabled),
             eqPreamp: engine.getPreamp(),
             eqBands: (0..<engine.eqConfiguration.bandCount).map { engine.getEQBand($0) },
             
@@ -543,8 +543,8 @@ class AppStateManager {
             
             // v2 fields
             isDoubleSize: wm.isDoubleSize,
-            modernSkinName: UserDefaults.standard.string(forKey: "modernSkinName"),
-            selectedOutputDeviceUID: UserDefaults.standard.string(forKey: "selectedOutputDeviceUID"),
+            modernSkinName: UserDefaults.standard.string(forKey: .modernSkinName),
+            selectedOutputDeviceUID: UserDefaults.standard.string(forKey: .selectedOutputDeviceUID),
             browserBrowseMode: browserBrowseMode,
             savedInModernMode: wm.isRunningModernUI
         )
@@ -668,7 +668,7 @@ class AppStateManager {
         
         // Restore EQ settings
         engine.setEQEnabled(state.eqEnabled)
-        UserDefaults.standard.set(state.eqAutoEnabled, forKey: "EQAutoEnabled")
+        UserDefaults.standard.set(state.eqAutoEnabled, forKey: .eqAutoEnabled)
         engine.setPreamp(state.eqPreamp)
         let restoredBands = remappedEQBands(state.eqBands, for: engine.eqConfiguration)
         for (index, gain) in restoredBands.enumerated() {
@@ -692,14 +692,14 @@ class AppStateManager {
         
         // Restore modern skin name (if saved and modern UI is active)
         if runningModernMode, let modernSkin = state.modernSkinName {
-            UserDefaults.standard.set(modernSkin, forKey: "modernSkinName")
+            UserDefaults.standard.set(modernSkin, forKey: .modernSkinName)
             // ModernSkinEngine.loadPreferredSkin() is called in AppDelegate before state restore,
             // but we set the UserDefaults value here so subsequent launches use it
         }
         
         // Restore audio output device
         if let deviceUID = state.selectedOutputDeviceUID {
-            UserDefaults.standard.set(deviceUID, forKey: "selectedOutputDeviceUID")
+            UserDefaults.standard.set(deviceUID, forKey: .selectedOutputDeviceUID)
         }
         
         // Check if the saved state's UI mode matches the current mode.

--- a/Sources/NullPlayer/App/ContextMenuBuilder.swift
+++ b/Sources/NullPlayer/App/ContextMenuBuilder.swift
@@ -205,7 +205,7 @@ class ContextMenuBuilder {
         let isModern = WindowManager.shared.isModernUIEnabled
 
         // Last used modern skin for quick switch (shown at top when in classic mode)
-        let lastModernSkin = UserDefaults.standard.string(forKey: "modernSkinName")
+        let lastModernSkin = UserDefaults.standard.string(forKey: .modernSkinName)
         if !isModern {
             let switchItem = NSMenuItem(
                 title: "Switch to Modern" + (lastModernSkin.map { " (\($0))" } ?? ""),
@@ -290,7 +290,7 @@ class ContextMenuBuilder {
         modernMenu.autoenablesItems = false
         
         // Last used modern skin for quick switch (shown at top when in classic mode)
-        let lastModernSkin = UserDefaults.standard.string(forKey: "modernSkinName")
+        let lastModernSkin = UserDefaults.standard.string(forKey: .modernSkinName)
         if !isModern {
             let switchItem = NSMenuItem(
                 title: "Switch to Modern" + (lastModernSkin.map { " (\($0))" } ?? ""),
@@ -345,7 +345,7 @@ class ContextMenuBuilder {
         classicMenu.autoenablesItems = false
         
         // Last used classic skin for quick switch (shown at top when in modern mode)
-        let lastClassicSkinPath = UserDefaults.standard.string(forKey: "lastClassicSkinPath")
+        let lastClassicSkinPath = UserDefaults.standard.string(forKey: .lastClassicSkinPath)
         if isModern {
             let lastSkinName = lastClassicSkinPath.map { URL(fileURLWithPath: $0).deletingPathExtension().lastPathComponent }
             let switchItem = NSMenuItem(
@@ -806,7 +806,7 @@ class ContextMenuBuilder {
         let visMenu = NSMenu()
         visMenu.autoenablesItems = false
         
-        let currentMode = UserDefaults.standard.string(forKey: "mainWindowVisMode")
+        let currentMode = UserDefaults.standard.string(forKey: .mainWindowVisMode)
             .flatMap { MainWindowVisMode(rawValue: $0) } ?? .spectrum
         
         // Mode submenu
@@ -834,7 +834,7 @@ class ContextMenuBuilder {
         let responsivenessMenu = NSMenu()
         responsivenessMenu.autoenablesItems = false
         
-        let currentDecay = UserDefaults.standard.string(forKey: "mainWindowDecayMode")
+        let currentDecay = UserDefaults.standard.string(forKey: .mainWindowDecayMode)
             .flatMap { SpectrumDecayMode(rawValue: $0) } ?? .snappy
         
         for mode in SpectrumDecayMode.allCases {
@@ -853,7 +853,7 @@ class ContextMenuBuilder {
             let normMenu = NSMenu()
             normMenu.autoenablesItems = false
             
-            let currentNorm = UserDefaults.standard.string(forKey: "mainWindowNormalizationMode")
+            let currentNorm = UserDefaults.standard.string(forKey: .mainWindowNormalizationMode)
                 .flatMap { SpectrumNormalizationMode(rawValue: $0) } ?? .accurate
             
             for mode in SpectrumNormalizationMode.allCases {
@@ -873,7 +873,7 @@ class ContextMenuBuilder {
             let flameStyleMenu = NSMenu()
             flameStyleMenu.autoenablesItems = false
             
-            let currentStyle = UserDefaults.standard.string(forKey: "mainWindowFlameStyle")
+            let currentStyle = UserDefaults.standard.string(forKey: .mainWindowFlameStyle)
                 .flatMap { FlameStyle(rawValue: $0) } ?? .inferno
             
             for style in FlameStyle.allCases {
@@ -892,7 +892,7 @@ class ContextMenuBuilder {
             let flameIntensityMenu = NSMenu()
             flameIntensityMenu.autoenablesItems = false
             
-            let currentIntensity = UserDefaults.standard.string(forKey: "mainWindowFlameIntensity")
+            let currentIntensity = UserDefaults.standard.string(forKey: .mainWindowFlameIntensity)
                 .flatMap { FlameIntensity(rawValue: $0) } ?? .mellow
             
             for intensity in FlameIntensity.allCases {
@@ -913,7 +913,7 @@ class ContextMenuBuilder {
             let lightningStyleMenu = NSMenu()
             lightningStyleMenu.autoenablesItems = false
             
-            let currentStyle = UserDefaults.standard.string(forKey: "mainWindowLightningStyle")
+            let currentStyle = UserDefaults.standard.string(forKey: .mainWindowLightningStyle)
                 .flatMap { LightningStyle(rawValue: $0) } ?? .classic
             
             for style in LightningStyle.allCases {
@@ -935,7 +935,7 @@ class ContextMenuBuilder {
             let matrixColorMenu = NSMenu()
             matrixColorMenu.autoenablesItems = false
             
-            let currentMatrixColor = UserDefaults.standard.string(forKey: "mainWindowMatrixColorScheme")
+            let currentMatrixColor = UserDefaults.standard.string(forKey: .mainWindowMatrixColorScheme)
                 .flatMap { MatrixColorScheme(rawValue: $0) } ?? .classic
             
             for scheme in MatrixColorScheme.allCases {
@@ -954,7 +954,7 @@ class ContextMenuBuilder {
             let matrixIntensityMenu = NSMenu()
             matrixIntensityMenu.autoenablesItems = false
             
-            let currentMatrixIntensity = UserDefaults.standard.string(forKey: "mainWindowMatrixIntensity")
+            let currentMatrixIntensity = UserDefaults.standard.string(forKey: .mainWindowMatrixIntensity)
                 .flatMap { MatrixIntensity(rawValue: $0) } ?? .subtle
             
             for intensity in MatrixIntensity.allCases {
@@ -1065,7 +1065,7 @@ class ContextMenuBuilder {
         let modeMenu = NSMenu()
         modeMenu.autoenablesItems = false
         
-        let currentQuality = UserDefaults.standard.string(forKey: "spectrumQualityMode")
+        let currentQuality = UserDefaults.standard.string(forKey: .spectrumQualityMode)
             .flatMap { SpectrumQualityMode(rawValue: $0) } ?? .classic
         
         for mode in SpectrumQualityMode.allCases {
@@ -1087,7 +1087,7 @@ class ContextMenuBuilder {
         let responsivenessMenu = NSMenu()
         responsivenessMenu.autoenablesItems = false
         
-        let currentDecay = UserDefaults.standard.string(forKey: "spectrumDecayMode")
+        let currentDecay = UserDefaults.standard.string(forKey: .spectrumDecayMode)
             .flatMap { SpectrumDecayMode(rawValue: $0) } ?? .snappy
         
         for mode in SpectrumDecayMode.allCases {
@@ -1105,7 +1105,7 @@ class ContextMenuBuilder {
         let normMenu = NSMenu()
         normMenu.autoenablesItems = false
         
-        let currentNorm = UserDefaults.standard.string(forKey: "spectrumNormalizationMode")
+        let currentNorm = UserDefaults.standard.string(forKey: .spectrumNormalizationMode)
             .flatMap { SpectrumNormalizationMode(rawValue: $0) } ?? .accurate
         
         for mode in SpectrumNormalizationMode.allCases {
@@ -1124,7 +1124,7 @@ class ContextMenuBuilder {
             let flameStyleMenu = NSMenu()
             flameStyleMenu.autoenablesItems = false
             
-            let currentStyle = UserDefaults.standard.string(forKey: "flameStyle")
+            let currentStyle = UserDefaults.standard.string(forKey: .flameStyle)
                 .flatMap { FlameStyle(rawValue: $0) } ?? .inferno
             
             for style in FlameStyle.allCases {
@@ -1143,7 +1143,7 @@ class ContextMenuBuilder {
             let flameIntensityMenu = NSMenu()
             flameIntensityMenu.autoenablesItems = false
             
-            let currentIntensity = UserDefaults.standard.string(forKey: "flameIntensity")
+            let currentIntensity = UserDefaults.standard.string(forKey: .flameIntensity)
                 .flatMap { FlameIntensity(rawValue: $0) } ?? .mellow
             
             for intensity in FlameIntensity.allCases {
@@ -1164,7 +1164,7 @@ class ContextMenuBuilder {
             let lightningStyleMenu = NSMenu()
             lightningStyleMenu.autoenablesItems = false
             
-            let currentStyle = UserDefaults.standard.string(forKey: "lightningStyle")
+            let currentStyle = UserDefaults.standard.string(forKey: .lightningStyle)
                 .flatMap { LightningStyle(rawValue: $0) } ?? .classic
             
             for style in LightningStyle.allCases {
@@ -1186,7 +1186,7 @@ class ContextMenuBuilder {
             let matrixColorMenu = NSMenu()
             matrixColorMenu.autoenablesItems = false
             
-            let currentMatrixColor = UserDefaults.standard.string(forKey: "matrixColorScheme")
+            let currentMatrixColor = UserDefaults.standard.string(forKey: .matrixColorScheme)
                 .flatMap { MatrixColorScheme(rawValue: $0) } ?? .classic
             
             for scheme in MatrixColorScheme.allCases {
@@ -1205,7 +1205,7 @@ class ContextMenuBuilder {
             let matrixIntensityMenu = NSMenu()
             matrixIntensityMenu.autoenablesItems = false
             
-            let currentMatrixIntensity = UserDefaults.standard.string(forKey: "matrixIntensity")
+            let currentMatrixIntensity = UserDefaults.standard.string(forKey: .matrixIntensity)
                 .flatMap { MatrixIntensity(rawValue: $0) } ?? .subtle
             
             for intensity in MatrixIntensity.allCases {
@@ -1297,7 +1297,7 @@ class ContextMenuBuilder {
 
         let cuePoints = NSMenuItem(title: "Show CUE Points", action: #selector(MenuActions.toggleWaveformCuePoints), keyEquivalent: "")
         cuePoints.target = MenuActions.shared
-        cuePoints.state = UserDefaults.standard.bool(forKey: "waveformShowCuePoints") ? .on : .off
+        cuePoints.state = UserDefaults.standard.bool(forKey: .waveformShowCuePoints) ? .on : .off
         menu.addItem(cuePoints)
 
         let transparentBackground = NSMenuItem(title: "Transparent Background", action: #selector(MenuActions.toggleWaveformTransparentBackground), keyEquivalent: "")
@@ -1307,7 +1307,7 @@ class ContextMenuBuilder {
 
         let hideTooltip = NSMenuItem(title: "Hide Waveform Tooltip", action: #selector(MenuActions.toggleWaveformTooltip), keyEquivalent: "")
         hideTooltip.target = MenuActions.shared
-        hideTooltip.state = UserDefaults.standard.bool(forKey: "waveformHideTooltip") ? .on : .off
+        hideTooltip.state = UserDefaults.standard.bool(forKey: .waveformHideTooltip) ? .on : .off
         menu.addItem(hideTooltip)
 
         return menu
@@ -3229,9 +3229,9 @@ class MenuActions: NSObject {
     
     @objc func loadDefaultClassicSkin() {
         let wm = WindowManager.shared
-        let previousSkinPath = UserDefaults.standard.string(forKey: "lastClassicSkinPath")
+        let previousSkinPath = UserDefaults.standard.string(forKey: .lastClassicSkinPath)
         // Clear the last used skin so the bundled default loads
-        UserDefaults.standard.removeObject(forKey: "lastClassicSkinPath")
+        UserDefaults.standard.removeObject(forKey: .lastClassicSkinPath)
         
         if wm.isRunningModernUI {
             // Switch to classic mode with default skin on next launch
@@ -3239,9 +3239,9 @@ class MenuActions: NSObject {
                 wm.isModernUIEnabled = false
             }) {
                 if let previousSkinPath = previousSkinPath {
-                    UserDefaults.standard.set(previousSkinPath, forKey: "lastClassicSkinPath")
+                    UserDefaults.standard.set(previousSkinPath, forKey: .lastClassicSkinPath)
                 } else {
-                    UserDefaults.standard.removeObject(forKey: "lastClassicSkinPath")
+                    UserDefaults.standard.removeObject(forKey: .lastClassicSkinPath)
                 }
             }
         } else {
@@ -3286,15 +3286,15 @@ class MenuActions: NSObject {
 
         guard panel.runModal() == .OK, let url = panel.url else { return }
 
-        let previousSkinName = UserDefaults.standard.string(forKey: "modernSkinName")
+        let previousSkinName = UserDefaults.standard.string(forKey: .modernSkinName)
         do {
             let importedSkinName = try ModernSkinEngine.shared.importSkinBundle(from: url)
             if WindowManager.shared.isRunningModernUI {
                 if !ModernSkinEngine.shared.loadSkin(named: importedSkinName) {
                     if let previousSkinName = previousSkinName {
-                        UserDefaults.standard.set(previousSkinName, forKey: "modernSkinName")
+                        UserDefaults.standard.set(previousSkinName, forKey: .modernSkinName)
                     } else {
-                        UserDefaults.standard.removeObject(forKey: "modernSkinName")
+                        UserDefaults.standard.removeObject(forKey: .modernSkinName)
                     }
                     let alert = NSAlert()
                     alert.messageText = "Failed to Load Modern Skin"
@@ -3320,7 +3320,7 @@ class MenuActions: NSObject {
     @objc func loadSkin(_ sender: NSMenuItem) {
         guard let url = sender.representedObject as? URL else { return }
         WindowManager.shared.loadSkin(from: url)
-        UserDefaults.standard.set(url.path, forKey: "lastClassicSkinPath")
+        UserDefaults.standard.set(url.path, forKey: .lastClassicSkinPath)
     }
     
     /// Select a classic skin and switch to classic mode if needed
@@ -3329,8 +3329,8 @@ class MenuActions: NSObject {
         let wm = WindowManager.shared
         
         // Persist the last used classic skin path
-        let previousSkinPath = UserDefaults.standard.string(forKey: "lastClassicSkinPath")
-        UserDefaults.standard.set(url.path, forKey: "lastClassicSkinPath")
+        let previousSkinPath = UserDefaults.standard.string(forKey: .lastClassicSkinPath)
+        UserDefaults.standard.set(url.path, forKey: .lastClassicSkinPath)
         
         if wm.isRunningModernUI {
             // Switch to classic mode and load this skin on next launch
@@ -3339,9 +3339,9 @@ class MenuActions: NSObject {
             }) {
                 // User cancelled — revert
                 if let previousSkinPath = previousSkinPath {
-                    UserDefaults.standard.set(previousSkinPath, forKey: "lastClassicSkinPath")
+                    UserDefaults.standard.set(previousSkinPath, forKey: .lastClassicSkinPath)
                 } else {
-                    UserDefaults.standard.removeObject(forKey: "lastClassicSkinPath")
+                    UserDefaults.standard.removeObject(forKey: .lastClassicSkinPath)
                 }
             }
         } else {
@@ -3357,8 +3357,8 @@ class MenuActions: NSObject {
         
         // Persist the selected modern skin name (ModernSkinEngine does this too, but
         // we need it set before restart when switching from classic mode)
-        let previousSkinName = UserDefaults.standard.string(forKey: "modernSkinName")
-        UserDefaults.standard.set(name, forKey: "modernSkinName")
+        let previousSkinName = UserDefaults.standard.string(forKey: .modernSkinName)
+        UserDefaults.standard.set(name, forKey: .modernSkinName)
         
         if !wm.isRunningModernUI {
             // Switch to modern mode — skin will load on next launch
@@ -3367,9 +3367,9 @@ class MenuActions: NSObject {
             }) {
                 // User cancelled — revert
                 if let previousSkinName = previousSkinName {
-                    UserDefaults.standard.set(previousSkinName, forKey: "modernSkinName")
+                    UserDefaults.standard.set(previousSkinName, forKey: .modernSkinName)
                 } else {
-                    UserDefaults.standard.removeObject(forKey: "modernSkinName")
+                    UserDefaults.standard.removeObject(forKey: .modernSkinName)
                 }
             }
         } else {
@@ -3660,81 +3660,81 @@ class MenuActions: NSObject {
 
     @objc func setMainVisMode(_ sender: NSMenuItem) {
         guard let mode = sender.representedObject as? MainWindowVisMode else { return }
-        UserDefaults.standard.set(mode.rawValue, forKey: "mainWindowVisMode")
+        UserDefaults.standard.set(mode.rawValue, forKey: .mainWindowVisMode)
         // Notify main window to update visualization mode
         NotificationCenter.default.post(name: NSNotification.Name("MainWindowVisChanged"), object: nil)
     }
     
     @objc func setMainVisFlameStyle(_ sender: NSMenuItem) {
         guard let style = sender.representedObject as? FlameStyle else { return }
-        UserDefaults.standard.set(style.rawValue, forKey: "mainWindowFlameStyle")
+        UserDefaults.standard.set(style.rawValue, forKey: .mainWindowFlameStyle)
         // Notify main window only (independent from spectrum window flame style)
         NotificationCenter.default.post(name: NSNotification.Name("MainWindowVisChanged"), object: nil)
     }
     
     @objc func setSpectrumFlameStyle(_ sender: NSMenuItem) {
         guard let style = sender.representedObject as? FlameStyle else { return }
-        UserDefaults.standard.set(style.rawValue, forKey: "flameStyle")
+        UserDefaults.standard.set(style.rawValue, forKey: .flameStyle)
         NotificationCenter.default.post(name: NSNotification.Name("SpectrumSettingsChanged"), object: nil)
     }
     
     @objc func setSpectrumLightningStyle(_ sender: NSMenuItem) {
         guard let style = sender.representedObject as? LightningStyle else { return }
-        UserDefaults.standard.set(style.rawValue, forKey: "lightningStyle")
+        UserDefaults.standard.set(style.rawValue, forKey: .lightningStyle)
         NotificationCenter.default.post(name: NSNotification.Name("SpectrumSettingsChanged"), object: nil)
     }
     
     @objc func setSpectrumFlameIntensity(_ sender: NSMenuItem) {
         guard let intensity = sender.representedObject as? FlameIntensity else { return }
-        UserDefaults.standard.set(intensity.rawValue, forKey: "flameIntensity")
+        UserDefaults.standard.set(intensity.rawValue, forKey: .flameIntensity)
         NotificationCenter.default.post(name: NSNotification.Name("SpectrumSettingsChanged"), object: nil)
     }
     
     @objc func setSpectrumMatrixColor(_ sender: NSMenuItem) {
         guard let scheme = sender.representedObject as? MatrixColorScheme else { return }
-        UserDefaults.standard.set(scheme.rawValue, forKey: "matrixColorScheme")
+        UserDefaults.standard.set(scheme.rawValue, forKey: .matrixColorScheme)
         NotificationCenter.default.post(name: NSNotification.Name("SpectrumSettingsChanged"), object: nil)
     }
     
     @objc func setSpectrumMatrixIntensity(_ sender: NSMenuItem) {
         guard let intensity = sender.representedObject as? MatrixIntensity else { return }
-        UserDefaults.standard.set(intensity.rawValue, forKey: "matrixIntensity")
+        UserDefaults.standard.set(intensity.rawValue, forKey: .matrixIntensity)
         NotificationCenter.default.post(name: NSNotification.Name("SpectrumSettingsChanged"), object: nil)
     }
     
     @objc func setMainVisFlameIntensity(_ sender: NSMenuItem) {
         guard let intensity = sender.representedObject as? FlameIntensity else { return }
-        UserDefaults.standard.set(intensity.rawValue, forKey: "mainWindowFlameIntensity")
+        UserDefaults.standard.set(intensity.rawValue, forKey: .mainWindowFlameIntensity)
         NotificationCenter.default.post(name: NSNotification.Name("MainWindowVisChanged"), object: nil)
     }
     
     @objc func setMainVisLightningStyle(_ sender: NSMenuItem) {
         guard let style = sender.representedObject as? LightningStyle else { return }
-        UserDefaults.standard.set(style.rawValue, forKey: "mainWindowLightningStyle")
+        UserDefaults.standard.set(style.rawValue, forKey: .mainWindowLightningStyle)
         NotificationCenter.default.post(name: NSNotification.Name("MainWindowVisChanged"), object: nil)
     }
     
     @objc func setMainVisMatrixColor(_ sender: NSMenuItem) {
         guard let scheme = sender.representedObject as? MatrixColorScheme else { return }
-        UserDefaults.standard.set(scheme.rawValue, forKey: "mainWindowMatrixColorScheme")
+        UserDefaults.standard.set(scheme.rawValue, forKey: .mainWindowMatrixColorScheme)
         NotificationCenter.default.post(name: NSNotification.Name("MainWindowVisChanged"), object: nil)
     }
     
     @objc func setMainVisMatrixIntensity(_ sender: NSMenuItem) {
         guard let intensity = sender.representedObject as? MatrixIntensity else { return }
-        UserDefaults.standard.set(intensity.rawValue, forKey: "mainWindowMatrixIntensity")
+        UserDefaults.standard.set(intensity.rawValue, forKey: .mainWindowMatrixIntensity)
         NotificationCenter.default.post(name: NSNotification.Name("MainWindowVisChanged"), object: nil)
     }
     
     @objc func setMainVisResponsiveness(_ sender: NSMenuItem) {
         guard let mode = sender.representedObject as? SpectrumDecayMode else { return }
-        UserDefaults.standard.set(mode.rawValue, forKey: "mainWindowDecayMode")
+        UserDefaults.standard.set(mode.rawValue, forKey: .mainWindowDecayMode)
         NotificationCenter.default.post(name: NSNotification.Name("MainWindowVisChanged"), object: nil)
     }
     
     @objc func setMainVisNormalization(_ sender: NSMenuItem) {
         guard let mode = sender.representedObject as? SpectrumNormalizationMode else { return }
-        UserDefaults.standard.set(mode.rawValue, forKey: "mainWindowNormalizationMode")
+        UserDefaults.standard.set(mode.rawValue, forKey: .mainWindowNormalizationMode)
         NotificationCenter.default.post(name: NSNotification.Name("MainWindowVisChanged"), object: nil)
     }
     
@@ -3742,21 +3742,21 @@ class MenuActions: NSObject {
     
     @objc func setSpectrumQuality(_ sender: NSMenuItem) {
         guard let mode = sender.representedObject as? SpectrumQualityMode else { return }
-        UserDefaults.standard.set(mode.rawValue, forKey: "spectrumQualityMode")
+        UserDefaults.standard.set(mode.rawValue, forKey: .spectrumQualityMode)
         // Notify spectrum analyzer views to update
         NotificationCenter.default.post(name: NSNotification.Name("SpectrumSettingsChanged"), object: nil)
     }
     
     @objc func setSpectrumResponsiveness(_ sender: NSMenuItem) {
         guard let mode = sender.representedObject as? SpectrumDecayMode else { return }
-        UserDefaults.standard.set(mode.rawValue, forKey: "spectrumDecayMode")
+        UserDefaults.standard.set(mode.rawValue, forKey: .spectrumDecayMode)
         // Notify spectrum analyzer views to update
         NotificationCenter.default.post(name: NSNotification.Name("SpectrumSettingsChanged"), object: nil)
     }
     
     @objc func setSpectrumNormalization(_ sender: NSMenuItem) {
         guard let mode = sender.representedObject as? SpectrumNormalizationMode else { return }
-        UserDefaults.standard.set(mode.rawValue, forKey: "spectrumNormalizationMode")
+        UserDefaults.standard.set(mode.rawValue, forKey: .spectrumNormalizationMode)
         // Normalization mode is read each frame, no notification needed
     }
 

--- a/Sources/NullPlayer/App/UserDefaults+Keys.swift
+++ b/Sources/NullPlayer/App/UserDefaults+Keys.swift
@@ -1,0 +1,220 @@
+//
+//  UserDefaults+Keys.swift
+//  NullPlayer
+//
+//  Centralized UserDefaults key names.
+//
+//  Every UserDefaults key used in the app is declared here as a static
+//  constant on `UserDefaults.Key`. Call sites pass the constant instead
+//  of a string literal:
+//
+//      UserDefaults.standard.set(value, forKey: .mainWindowFrame)
+//      let x = UserDefaults.standard.string(forKey: .modernSkinName)
+//
+//  Benefits:
+//    * Compile-time checking prevents typos
+//    * Rename refactors work (string literals don't)
+//    * Single place to audit what the app persists
+//    * Avoids silent key collisions
+//
+//  The raw string values MUST remain stable across releases — changing
+//  them orphans existing users' saved settings.
+//
+
+import Foundation
+
+// MARK: - Key type
+
+extension UserDefaults {
+
+    /// Type-safe wrapper for a UserDefaults key name.
+    ///
+    /// Backed by a String raw value that matches the legacy key names
+    /// used before centralization, so existing preferences continue to
+    /// load after upgrading.
+    ///
+    /// All known keys are declared as static constants on this type so
+    /// that dot-shorthand works at call sites:
+    ///
+    ///     UserDefaults.standard.bool(forKey: .modernUIEnabled)
+    ///
+    struct Key: RawRepresentable, Hashable, ExpressibleByStringLiteral {
+        let rawValue: String
+        init(rawValue: String) { self.rawValue = rawValue }
+        init(stringLiteral value: String) { self.rawValue = value }
+    }
+}
+
+// MARK: - Key constants
+
+extension UserDefaults.Key {
+
+    // MARK: Window frames
+
+    static let artVisualizerWindowFrame: Self = "ArtVisualizerWindowFrame"
+    static let equalizerWindowFrame:     Self = "EqualizerWindowFrame"
+    static let mainWindowFrame:          Self = "MainWindowFrame"
+    static let playlistWindowFrame:      Self = "PlaylistWindowFrame"
+    static let plexBrowserWindowFrame:   Self = "PlexBrowserWindowFrame"
+    static let projectMWindowFrame:      Self = "ProjectMWindowFrame"
+    static let spectrumWindowFrame:      Self = "SpectrumWindowFrame"
+    static let videoPlayerWindowFrame:   Self = "VideoPlayerWindowFrame"
+    static let waveformWindowFrame:      Self = "WaveformWindowFrame"
+
+    // MARK: Window layout
+
+    static let hideTitleBars:        Self = "hideTitleBars"
+    static let isAlwaysOnTop:        Self = "isAlwaysOnTop"
+    static let isWindowLayoutLocked: Self = "isWindowLayoutLocked"
+
+    // MARK: Library browser — columns
+
+    static let browserColumnSortAscending:   Self = "BrowserColumnSortAscending"
+    static let browserColumnSortId:          Self = "BrowserColumnSortId"
+    static let browserColumnWidths:          Self = "BrowserColumnWidths"
+    static let browserVisibleAlbumColumns:   Self = "BrowserVisibleAlbumColumns"
+    static let browserVisibleArtistColumns:  Self = "BrowserVisibleArtistColumns"
+    static let browserVisibleTrackColumns:   Self = "BrowserVisibleTrackColumns"
+    static let showBrowserArtworkBackground: Self = "showBrowserArtworkBackground"
+
+    // MARK: Library browser — visualization
+
+    static let browserVisDefaultEffect: Self = "browserVisDefaultEffect"
+    static let browserVisEffect:        Self = "browserVisEffect"
+    static let browserVisIntensity:     Self = "browserVisIntensity"
+
+    // MARK: Plex
+
+    static let plexCurrentLibraryID: Self = "PlexCurrentLibraryID"
+    static let plexCurrentServerID:  Self = "PlexCurrentServerID"
+
+    // MARK: Jellyfin
+
+    static let jellyfinCurrentMovieLibraryID: Self = "JellyfinCurrentMovieLibraryID"
+    static let jellyfinCurrentMusicLibraryID: Self = "JellyfinCurrentMusicLibraryID"
+    static let jellyfinCurrentServerID:       Self = "JellyfinCurrentServerID"
+    static let jellyfinCurrentShowLibraryID:  Self = "JellyfinCurrentShowLibraryID"
+
+    // MARK: Emby
+
+    static let embyCurrentMovieLibraryID: Self = "EmbyCurrentMovieLibraryID"
+    static let embyCurrentMusicLibraryID: Self = "EmbyCurrentMusicLibraryID"
+    static let embyCurrentServerID:       Self = "EmbyCurrentServerID"
+    static let embyCurrentShowLibraryID:  Self = "EmbyCurrentShowLibraryID"
+
+    // MARK: Subsonic
+
+    static let subsonicCurrentMusicFolderID: Self = "SubsonicCurrentMusicFolderID"
+    static let subsonicCurrentServerID:      Self = "SubsonicCurrentServerID"
+
+    // MARK: Radio
+
+    static let radioAutoReconnect:           Self = "RadioAutoReconnect"
+    static let embyRadioHistoryInterval:     Self = "embyRadioHistoryInterval"
+    static let jellyfinRadioHistoryInterval: Self = "jellyfinRadioHistoryInterval"
+    static let localRadioHistoryInterval:    Self = "localRadioHistoryInterval"
+    static let plexRadioHistoryInterval:     Self = "plexRadioHistoryInterval"
+    static let subsonicRadioHistoryInterval: Self = "subsonicRadioHistoryInterval"
+
+    // MARK: Equalizer
+
+    static let eqAutoEnabled: Self = "EQAutoEnabled"
+
+    // MARK: Audio output / playback
+
+    static let gaplessPlaybackEnabled:     Self = "gaplessPlaybackEnabled"
+    static let selectedOutputDeviceUID:    Self = "selectedOutputDeviceUID"
+    static let sweetFadeDuration:          Self = "sweetFadeDuration"
+    static let sweetFadeEnabled:           Self = "sweetFadeEnabled"
+    static let timeDisplayMode:            Self = "timeDisplayMode"
+    static let volumeNormalizationEnabled: Self = "volumeNormalizationEnabled"
+
+    // MARK: Skin
+
+    static let lastClassicSkinPath:       Self = "lastClassicSkinPath"
+    static let modernSkinName:            Self = "modernSkinName"
+    static let modernUIEnabled:           Self = "modernUIEnabled"
+    static let visClassicFitToWidth:      Self = "visClassicFitToWidth"
+    static let visClassicLastProfileName: Self = "visClassicLastProfileName"
+
+    // MARK: Main-window visualization
+
+    static let mainWindowDecayMode:         Self = "mainWindowDecayMode"
+    static let mainWindowFlameIntensity:    Self = "mainWindowFlameIntensity"
+    static let mainWindowFlameStyle:        Self = "mainWindowFlameStyle"
+    static let mainWindowLightningStyle:    Self = "mainWindowLightningStyle"
+    static let mainWindowMatrixColorScheme: Self = "mainWindowMatrixColorScheme"
+    static let mainWindowMatrixIntensity:   Self = "mainWindowMatrixIntensity"
+    static let mainWindowNormalizationMode: Self = "mainWindowNormalizationMode"
+    static let mainWindowVisMode:           Self = "mainWindowVisMode"
+    static let modernMainWindowVisMode:     Self = "modernMainWindowVisMode"
+
+    // MARK: Shared visualization settings
+
+    static let flameIntensity:          Self = "flameIntensity"
+    static let flameStyle:              Self = "flameStyle"
+    static let lightningStyle:          Self = "lightningStyle"
+    static let matrixColorScheme:       Self = "matrixColorScheme"
+    static let matrixIntensity:         Self = "matrixIntensity"
+    static let visualizationEngineType: Self = "visualizationEngineType"
+
+    // MARK: Spectrum window
+
+    static let spectrumDecayMode:         Self = "spectrumDecayMode"
+    static let spectrumNormalizationMode: Self = "spectrumNormalizationMode"
+    static let spectrumQualityMode:       Self = "spectrumQualityMode"
+
+    // MARK: ProjectM
+
+    static let projectMBeatSensitivity: Self = "projectMBeatSensitivity"
+    static let projectMLowPowerMode:    Self = "projectMLowPowerMode"
+    static let projectMPCMGain:         Self = "projectMPCMGain"
+
+    // MARK: Waveform
+
+    static let waveformHideTooltip:   Self = "waveformHideTooltip"
+    static let waveformShowCuePoints: Self = "waveformShowCuePoints"
+
+    // MARK: Migrations / housekeeping
+
+    static let trackArtistsBackfillComplete: Self = "trackArtistsBackfillComplete"
+}
+
+// MARK: - UserDefaults convenience accessors taking typed keys
+
+extension UserDefaults {
+
+    // Reading
+
+    func object(forKey key: Key) -> Any?               { object(forKey: key.rawValue) }
+    func string(forKey key: Key) -> String?             { string(forKey: key.rawValue) }
+    func array(forKey key: Key) -> [Any]?               { array(forKey: key.rawValue) }
+    func dictionary(forKey key: Key) -> [String: Any]?  { dictionary(forKey: key.rawValue) }
+    func stringArray(forKey key: Key) -> [String]?      { stringArray(forKey: key.rawValue) }
+    func data(forKey key: Key) -> Data?                 { data(forKey: key.rawValue) }
+    func bool(forKey key: Key) -> Bool                  { bool(forKey: key.rawValue) }
+    func integer(forKey key: Key) -> Int                { integer(forKey: key.rawValue) }
+    func float(forKey key: Key) -> Float                { float(forKey: key.rawValue) }
+    func double(forKey key: Key) -> Double              { double(forKey: key.rawValue) }
+    func url(forKey key: Key) -> URL?                   { url(forKey: key.rawValue) }
+
+    // Writing
+    //
+    // We mirror each Foundation setter overload so that Swift's overload
+    // resolution picks the same typed variant it would for String keys.
+    // Without the full set, Swift reports "ambiguous use" or
+    // "cannot resolve member" at call sites where the value type
+    // (Int, Bool, etc.) would normally disambiguate.
+
+    func set(_ value: Any?, forKey key: Key)   { set(value, forKey: key.rawValue) }
+    func set(_ value: Bool, forKey key: Key)   { set(value, forKey: key.rawValue) }
+    func set(_ value: Int, forKey key: Key)    { set(value, forKey: key.rawValue) }
+    func set(_ value: Float, forKey key: Key)  { set(value, forKey: key.rawValue) }
+    func set(_ value: Double, forKey key: Key) { set(value, forKey: key.rawValue) }
+    func set(_ value: URL?, forKey key: Key)   { set(value, forKey: key.rawValue) }
+
+    // Deleting / checking
+
+    func removeObject(forKey key: Key) { removeObject(forKey: key.rawValue) }
+    func contains(_ key: Key) -> Bool  { object(forKey: key.rawValue) != nil }
+}

--- a/Sources/NullPlayer/App/WindowManager.swift
+++ b/Sources/NullPlayer/App/WindowManager.swift
@@ -65,7 +65,7 @@ class WindowManager {
     /// Time display mode (elapsed vs remaining)
     var timeDisplayMode: TimeDisplayMode = .elapsed {
         didSet {
-            UserDefaults.standard.set(timeDisplayMode.rawValue, forKey: "timeDisplayMode")
+            UserDefaults.standard.set(timeDisplayMode.rawValue, forKey: .timeDisplayMode)
             NotificationCenter.default.post(name: .timeDisplayModeDidChange, object: nil)
         }
     }
@@ -87,7 +87,7 @@ class WindowManager {
     /// Always on top mode (floating window level)
     var isAlwaysOnTop: Bool = false {
         didSet {
-            UserDefaults.standard.set(isAlwaysOnTop, forKey: "isAlwaysOnTop")
+            UserDefaults.standard.set(isAlwaysOnTop, forKey: .isAlwaysOnTop)
             NSLog("WindowManager: isAlwaysOnTop changed to %d, applying to windows", isAlwaysOnTop ? 1 : 0)
             applyAlwaysOnTop()
         }
@@ -96,7 +96,7 @@ class WindowManager {
     /// Lock connected windows so dragging keeps connected groups together.
     var isWindowLayoutLocked: Bool = false {
         didSet {
-            UserDefaults.standard.set(isWindowLayoutLocked, forKey: "isWindowLayoutLocked")
+            UserDefaults.standard.set(isWindowLayoutLocked, forKey: .isWindowLayoutLocked)
             NSLog("WindowManager: isWindowLayoutLocked changed to %d", isWindowLayoutLocked ? 1 : 0)
         }
     }
@@ -106,8 +106,8 @@ class WindowManager {
     
     /// Whether the modern UI is enabled (requires restart to take effect)
     var isModernUIEnabled: Bool {
-        get { UserDefaults.standard.bool(forKey: "modernUIEnabled") }
-        set { UserDefaults.standard.set(newValue, forKey: "modernUIEnabled") }
+        get { UserDefaults.standard.bool(forKey: .modernUIEnabled) }
+        set { UserDefaults.standard.set(newValue, forKey: .modernUIEnabled) }
     }
 
     /// Runtime UI mode inferred from the active main window controller.
@@ -122,8 +122,8 @@ class WindowManager {
     
     /// Whether title bars are hidden on all windows (only applies in modern UI mode)
     var hideTitleBars: Bool {
-        get { isRunningModernUI && UserDefaults.standard.bool(forKey: "hideTitleBars") }
-        set { UserDefaults.standard.set(newValue, forKey: "hideTitleBars") }
+        get { isRunningModernUI && UserDefaults.standard.bool(forKey: .hideTitleBars) }
+        set { UserDefaults.standard.set(newValue, forKey: .hideTitleBars) }
     }
 
     /// Ensure modern main window keeps full-height geometry in HT mode at startup/restore.
@@ -434,16 +434,16 @@ class WindowManager {
     
     /// Load preferences from UserDefaults
     private func loadPreferences() {
-        if let mode = UserDefaults.standard.string(forKey: "timeDisplayMode"),
+        if let mode = UserDefaults.standard.string(forKey: .timeDisplayMode),
            let displayMode = TimeDisplayMode(rawValue: mode) {
             timeDisplayMode = displayMode
         }
         // Note: isDoubleSize always starts false - windows are created at 1x size
         // and we apply double size after they're created if needed
-        let savedAlwaysOnTop = UserDefaults.standard.bool(forKey: "isAlwaysOnTop")
+        let savedAlwaysOnTop = UserDefaults.standard.bool(forKey: .isAlwaysOnTop)
         isAlwaysOnTop = savedAlwaysOnTop
         NSLog("WindowManager: Loaded isAlwaysOnTop = %d from UserDefaults", savedAlwaysOnTop ? 1 : 0)
-        let savedWindowLayoutLocked = UserDefaults.standard.bool(forKey: "isWindowLayoutLocked")
+        let savedWindowLayoutLocked = UserDefaults.standard.bool(forKey: .isWindowLayoutLocked)
         isWindowLayoutLocked = savedWindowLayoutLocked
         NSLog("WindowManager: Loaded isWindowLayoutLocked = %d from UserDefaults", savedWindowLayoutLocked ? 1 : 0)
     }
@@ -1543,8 +1543,8 @@ class WindowManager {
     }
 
     func toggleWaveformCuePoints() {
-        let current = UserDefaults.standard.bool(forKey: "waveformShowCuePoints")
-        UserDefaults.standard.set(!current, forKey: "waveformShowCuePoints")
+        let current = UserDefaults.standard.bool(forKey: .waveformShowCuePoints)
+        UserDefaults.standard.set(!current, forKey: .waveformShowCuePoints)
         waveformWindowController?.updateTrack(audioEngine.currentTrack)
     }
 
@@ -1560,8 +1560,8 @@ class WindowManager {
     }
 
     func toggleWaveformTooltip() {
-        let current = UserDefaults.standard.bool(forKey: "waveformHideTooltip")
-        UserDefaults.standard.set(!current, forKey: "waveformHideTooltip")
+        let current = UserDefaults.standard.bool(forKey: .waveformHideTooltip)
+        UserDefaults.standard.set(!current, forKey: .waveformHideTooltip)
         waveformWindowController?.updateTrack(audioEngine.currentTrack)
     }
     
@@ -1640,13 +1640,13 @@ class WindowManager {
     var showBrowserArtworkBackground: Bool {
         get {
             // Default to true (enabled) if not set
-            if UserDefaults.standard.object(forKey: "showBrowserArtworkBackground") == nil {
+            if UserDefaults.standard.object(forKey: .showBrowserArtworkBackground) == nil {
                 return true
             }
-            return UserDefaults.standard.bool(forKey: "showBrowserArtworkBackground")
+            return UserDefaults.standard.bool(forKey: .showBrowserArtworkBackground)
         }
         set {
-            UserDefaults.standard.set(newValue, forKey: "showBrowserArtworkBackground")
+            UserDefaults.standard.set(newValue, forKey: .showBrowserArtworkBackground)
             // Trigger browser redraw
             plexBrowserWindowController?.window?.contentView?.needsDisplay = true
         }
@@ -1659,7 +1659,7 @@ class WindowManager {
             currentSkin = skin
             currentSkinPath = url.path
             // Persist last used classic skin for easy reload when switching UI modes
-            userDefaults.set(url.path, forKey: "lastClassicSkinPath")
+            userDefaults.set(url.path, forKey: .lastClassicSkinPath)
             applyClassicVisualizationDefaults(notify: true)
             notifySkinChanged()
             return true
@@ -1678,7 +1678,7 @@ class WindowManager {
     
     private func loadDefaultSkin() {
         // 1. Try last used skin from UserDefaults
-        if let lastPath = UserDefaults.standard.string(forKey: "lastClassicSkinPath"),
+        if let lastPath = UserDefaults.standard.string(forKey: .lastClassicSkinPath),
            FileManager.default.fileExists(atPath: lastPath) {
             do {
                 currentSkin = try SkinLoader.shared.load(from: URL(fileURLWithPath: lastPath))
@@ -1729,7 +1729,7 @@ class WindowManager {
             do {
                 currentSkin = try SkinLoader.shared.load(from: bundledURL)
                 currentSkinPath = nil
-                UserDefaults.standard.removeObject(forKey: "lastClassicSkinPath")
+                UserDefaults.standard.removeObject(forKey: .lastClassicSkinPath)
                 applyClassicVisualizationDefaults(notify: true)
                 notifySkinChanged()
                 return
@@ -1740,7 +1740,7 @@ class WindowManager {
         // Fallback: unskinned
         currentSkin = SkinLoader.shared.loadDefault()
         currentSkinPath = nil
-        UserDefaults.standard.removeObject(forKey: "lastClassicSkinPath")
+        UserDefaults.standard.removeObject(forKey: .lastClassicSkinPath)
         applyClassicVisualizationDefaults(notify: true)
         notifySkinChanged()
     }
@@ -1758,9 +1758,9 @@ class WindowManager {
         let visClassicMode = MainWindowVisMode.visClassicExact.rawValue
         let classicProfile = "Purple Neon"
 
-        defaults.set(visClassicMode, forKey: "mainWindowVisMode")
-        defaults.set(visClassicMode, forKey: "modernMainWindowVisMode")
-        defaults.set(SpectrumQualityMode.visClassicExact.rawValue, forKey: "spectrumQualityMode")
+        defaults.set(visClassicMode, forKey: .mainWindowVisMode)
+        defaults.set(visClassicMode, forKey: .modernMainWindowVisMode)
+        defaults.set(SpectrumQualityMode.visClassicExact.rawValue, forKey: .spectrumQualityMode)
 
         defaults.set(classicProfile, forKey: "visClassicLastProfileName.mainWindow")
         defaults.set(classicProfile, forKey: "visClassicLastProfileName.spectrumWindow")
@@ -1768,8 +1768,8 @@ class WindowManager {
         defaults.set(true, forKey: "visClassicFitToWidth.spectrumWindow")
 
         // Legacy fallback keys are still read by VisClassicBridge.
-        defaults.set(classicProfile, forKey: "visClassicLastProfileName")
-        defaults.set(true, forKey: "visClassicFitToWidth")
+        defaults.set(classicProfile, forKey: .visClassicLastProfileName)
+        defaults.set(true, forKey: .visClassicFitToWidth)
 
         guard notify else { return }
 
@@ -2413,15 +2413,15 @@ class WindowManager {
         }
         
         // Clear any saved positions (windows will be positioned relative to main on open)
-        defaults.removeObject(forKey: "MainWindowFrame")
-        defaults.removeObject(forKey: "EqualizerWindowFrame")
-        defaults.removeObject(forKey: "PlaylistWindowFrame")
-        defaults.removeObject(forKey: "PlexBrowserWindowFrame")
-        defaults.removeObject(forKey: "ProjectMWindowFrame")
-        defaults.removeObject(forKey: "VideoPlayerWindowFrame")
-        defaults.removeObject(forKey: "ArtVisualizerWindowFrame")
-        defaults.removeObject(forKey: "SpectrumWindowFrame")
-        defaults.removeObject(forKey: "WaveformWindowFrame")
+        defaults.removeObject(forKey: .mainWindowFrame)
+        defaults.removeObject(forKey: .equalizerWindowFrame)
+        defaults.removeObject(forKey: .playlistWindowFrame)
+        defaults.removeObject(forKey: .plexBrowserWindowFrame)
+        defaults.removeObject(forKey: .projectMWindowFrame)
+        defaults.removeObject(forKey: .videoPlayerWindowFrame)
+        defaults.removeObject(forKey: .artVisualizerWindowFrame)
+        defaults.removeObject(forKey: .spectrumWindowFrame)
+        defaults.removeObject(forKey: .waveformWindowFrame)
         
         // Disable snapping during programmatic frame changes to prevent interference
         isSnappingWindow = true
@@ -3456,62 +3456,62 @@ class WindowManager {
         let defaults = UserDefaults.standard
         
         if let frame = mainWindowController?.window?.frame {
-            defaults.set(NSStringFromRect(frame), forKey: "MainWindowFrame")
+            defaults.set(NSStringFromRect(frame), forKey: .mainWindowFrame)
         }
         if let frame = playlistWindowController?.window?.frame {
-            defaults.set(NSStringFromRect(frame), forKey: "PlaylistWindowFrame")
+            defaults.set(NSStringFromRect(frame), forKey: .playlistWindowFrame)
         }
         if let frame = equalizerWindowController?.window?.frame {
-            defaults.set(NSStringFromRect(frame), forKey: "EqualizerWindowFrame")
+            defaults.set(NSStringFromRect(frame), forKey: .equalizerWindowFrame)
         }
         if let frame = plexBrowserWindowController?.window?.frame {
-            defaults.set(NSStringFromRect(frame), forKey: "PlexBrowserWindowFrame")
+            defaults.set(NSStringFromRect(frame), forKey: .plexBrowserWindowFrame)
         }
         if let frame = videoPlayerWindowController?.window?.frame {
-            defaults.set(NSStringFromRect(frame), forKey: "VideoPlayerWindowFrame")
+            defaults.set(NSStringFromRect(frame), forKey: .videoPlayerWindowFrame)
         }
         if let frame = projectMWindowController?.window?.frame {
-            defaults.set(NSStringFromRect(frame), forKey: "ProjectMWindowFrame")
+            defaults.set(NSStringFromRect(frame), forKey: .projectMWindowFrame)
         }
         if let frame = spectrumWindowController?.window?.frame {
-            defaults.set(NSStringFromRect(frame), forKey: "SpectrumWindowFrame")
+            defaults.set(NSStringFromRect(frame), forKey: .spectrumWindowFrame)
         }
     }
     
     func restoreWindowPositions() {
         let defaults = UserDefaults.standard
         
-        if let frameString = defaults.string(forKey: "MainWindowFrame"),
+        if let frameString = defaults.string(forKey: .mainWindowFrame),
            let window = mainWindowController?.window {
             let frame = NSRectFromString(frameString)
             window.setFrame(frame, display: true)
         }
-        if let frameString = defaults.string(forKey: "PlaylistWindowFrame"),
+        if let frameString = defaults.string(forKey: .playlistWindowFrame),
            let window = playlistWindowController?.window {
             let frame = NSRectFromString(frameString)
             window.setFrame(frame, display: true)
         }
-        if let frameString = defaults.string(forKey: "EqualizerWindowFrame"),
+        if let frameString = defaults.string(forKey: .equalizerWindowFrame),
            let window = equalizerWindowController?.window {
             let frame = NSRectFromString(frameString)
             window.setFrame(frame, display: true)
         }
-        if let frameString = defaults.string(forKey: "PlexBrowserWindowFrame"),
+        if let frameString = defaults.string(forKey: .plexBrowserWindowFrame),
            let window = plexBrowserWindowController?.window {
             let frame = NSRectFromString(frameString)
             window.setFrame(frame, display: true)
         }
-        if let frameString = defaults.string(forKey: "VideoPlayerWindowFrame"),
+        if let frameString = defaults.string(forKey: .videoPlayerWindowFrame),
            let window = videoPlayerWindowController?.window {
             let frame = NSRectFromString(frameString)
             window.setFrame(frame, display: true)
         }
-        if let frameString = defaults.string(forKey: "ProjectMWindowFrame"),
+        if let frameString = defaults.string(forKey: .projectMWindowFrame),
            let window = projectMWindowController?.window {
             let frame = NSRectFromString(frameString)
             window.setFrame(frame, display: true)
         }
-        if let frameString = defaults.string(forKey: "SpectrumWindowFrame"),
+        if let frameString = defaults.string(forKey: .spectrumWindowFrame),
            let window = spectrumWindowController?.window {
             let frame = NSRectFromString(frameString)
             window.setFrame(frame, display: true)

--- a/Sources/NullPlayer/Audio/AudioEngine.swift
+++ b/Sources/NullPlayer/Audio/AudioEngine.swift
@@ -258,7 +258,7 @@ class AudioEngine {
     /// Gapless playback mode - pre-schedules next track for seamless transitions
     var gaplessPlaybackEnabled: Bool = false {
         didSet {
-            UserDefaults.standard.set(gaplessPlaybackEnabled, forKey: "gaplessPlaybackEnabled")
+            UserDefaults.standard.set(gaplessPlaybackEnabled, forKey: .gaplessPlaybackEnabled)
             // If enabling and currently playing, schedule next track
             if gaplessPlaybackEnabled && state == .playing {
                 scheduleNextTrackForGapless()
@@ -270,7 +270,7 @@ class AudioEngine {
     /// Volume normalization - analyzes and normalizes track loudness
     var volumeNormalizationEnabled: Bool = false {
         didSet {
-            UserDefaults.standard.set(volumeNormalizationEnabled, forKey: "volumeNormalizationEnabled")
+            UserDefaults.standard.set(volumeNormalizationEnabled, forKey: .volumeNormalizationEnabled)
             // Recalculate normalization for current track
             if volumeNormalizationEnabled {
                 applyNormalizationGain()
@@ -293,7 +293,7 @@ class AudioEngine {
     /// Sweet Fades (crossfade) enabled - smooth transition between tracks
     var sweetFadeEnabled: Bool = false {
         didSet {
-            UserDefaults.standard.set(sweetFadeEnabled, forKey: "sweetFadeEnabled")
+            UserDefaults.standard.set(sweetFadeEnabled, forKey: .sweetFadeEnabled)
             NSLog("AudioEngine: Sweet Fades %@", sweetFadeEnabled ? "enabled" : "disabled")
             notifyPlaybackOptionsChanged()
         }
@@ -302,7 +302,7 @@ class AudioEngine {
     /// Crossfade duration in seconds (default 5s)
     var sweetFadeDuration: TimeInterval = 5.0 {
         didSet {
-            UserDefaults.standard.set(sweetFadeDuration, forKey: "sweetFadeDuration")
+            UserDefaults.standard.set(sweetFadeDuration, forKey: .sweetFadeDuration)
             NSLog("AudioEngine: Sweet Fades duration set to %.1fs", sweetFadeDuration)
             notifyPlaybackOptionsChanged()
         }
@@ -534,13 +534,13 @@ class AudioEngine {
     // MARK: - Initialization
     
     init() {
-        let modernUIEnabled = UserDefaults.standard.bool(forKey: "modernUIEnabled")
+        let modernUIEnabled = UserDefaults.standard.bool(forKey: .modernUIEnabled)
         isModernUIEnabled = modernUIEnabled
         activeEQConfiguration = EQConfiguration.forModernUI(modernUIEnabled)
         eqNode = AVAudioUnitEQ(numberOfBands: activeEQConfiguration.bandCount)
 
         // Initialize cached normalization mode from UserDefaults
-        if let saved = UserDefaults.standard.string(forKey: "spectrumNormalizationMode"),
+        if let saved = UserDefaults.standard.string(forKey: .spectrumNormalizationMode),
            let mode = SpectrumNormalizationMode(rawValue: saved) {
             spectrumNormalizationMode = mode
         }
@@ -895,7 +895,7 @@ class AudioEngine {
     }
     
     @objc private func handleSpectrumSettingsChanged() {
-        if let saved = UserDefaults.standard.string(forKey: "spectrumNormalizationMode"),
+        if let saved = UserDefaults.standard.string(forKey: .spectrumNormalizationMode),
            let mode = SpectrumNormalizationMode(rawValue: saved) {
             spectrumNormalizationMode = mode
         }
@@ -942,7 +942,7 @@ class AudioEngine {
     }
 
     @objc private func handleModernUIChanged() {
-        isModernUIEnabled = UserDefaults.standard.bool(forKey: "modernUIEnabled")
+        isModernUIEnabled = UserDefaults.standard.bool(forKey: .modernUIEnabled)
     }
 
     // MARK: - Setup
@@ -989,11 +989,11 @@ class AudioEngine {
     
     /// Load audio quality preferences from UserDefaults
     private func loadAudioPreferences() {
-        gaplessPlaybackEnabled = UserDefaults.standard.bool(forKey: "gaplessPlaybackEnabled")
-        volumeNormalizationEnabled = UserDefaults.standard.bool(forKey: "volumeNormalizationEnabled")
-        sweetFadeEnabled = UserDefaults.standard.bool(forKey: "sweetFadeEnabled")
+        gaplessPlaybackEnabled = UserDefaults.standard.bool(forKey: .gaplessPlaybackEnabled)
+        volumeNormalizationEnabled = UserDefaults.standard.bool(forKey: .volumeNormalizationEnabled)
+        sweetFadeEnabled = UserDefaults.standard.bool(forKey: .sweetFadeEnabled)
         // Load sweet fade duration with default of 5.0 seconds
-        let savedDuration = UserDefaults.standard.double(forKey: "sweetFadeDuration")
+        let savedDuration = UserDefaults.standard.double(forKey: .sweetFadeDuration)
         sweetFadeDuration = savedDuration > 0 ? savedDuration : 5.0
     }
     
@@ -1077,7 +1077,7 @@ class AudioEngine {
     
     /// Restore saved output device preference
     private func restoreSavedOutputDevice() {
-        guard let savedDeviceUID = UserDefaults.standard.string(forKey: "selectedOutputDeviceUID") else {
+        guard let savedDeviceUID = UserDefaults.standard.string(forKey: .selectedOutputDeviceUID) else {
             return
         }
         
@@ -4827,11 +4827,11 @@ class AudioEngine {
         // Save device UID for restoration on next launch
         if let deviceID = deviceID,
            let device = AudioOutputManager.shared.outputDevices.first(where: { $0.id == deviceID }) {
-            UserDefaults.standard.set(device.uid, forKey: "selectedOutputDeviceUID")
+            UserDefaults.standard.set(device.uid, forKey: .selectedOutputDeviceUID)
             NSLog("AudioEngine: Saved output device preference: %@ (%@)", device.name, device.uid)
         } else {
             // System default - clear the preference
-            UserDefaults.standard.removeObject(forKey: "selectedOutputDeviceUID")
+            UserDefaults.standard.removeObject(forKey: .selectedOutputDeviceUID)
             NSLog("AudioEngine: Cleared output device preference (using system default)")
         }
         

--- a/Sources/NullPlayer/Audio/StreamingAudioPlayer.swift
+++ b/Sources/NullPlayer/Audio/StreamingAudioPlayer.swift
@@ -42,7 +42,7 @@ class StreamingAudioPlayer {
     var waveformNeeded: Bool = false
 
     /// Cached value of modernUIEnabled to avoid 60x/sec UserDefaults reads
-    var isModernUIEnabled: Bool = UserDefaults.standard.bool(forKey: "modernUIEnabled")
+    var isModernUIEnabled: Bool = UserDefaults.standard.bool(forKey: .modernUIEnabled)
 
     /// FFT setup for spectrum analysis
     private var fftSetup: vDSP_DFT_Setup?
@@ -179,11 +179,11 @@ class StreamingAudioPlayer {
     
     // MARK: - Initialization
     
-    init(eqConfiguration: EQConfiguration = .forModernUI(UserDefaults.standard.bool(forKey: "modernUIEnabled"))) {
+    init(eqConfiguration: EQConfiguration = .forModernUI(UserDefaults.standard.bool(forKey: .modernUIEnabled))) {
         self.eqConfiguration = eqConfiguration
 
         // Initialize cached normalization mode from UserDefaults
-        if let saved = UserDefaults.standard.string(forKey: "spectrumNormalizationMode"),
+        if let saved = UserDefaults.standard.string(forKey: .spectrumNormalizationMode),
            let mode = SpectrumNormalizationMode(rawValue: saved) {
             spectrumNormalizationMode = mode
         }
@@ -222,7 +222,7 @@ class StreamingAudioPlayer {
     }
     
     @objc private func handleSpectrumSettingsChanged() {
-        if let saved = UserDefaults.standard.string(forKey: "spectrumNormalizationMode"),
+        if let saved = UserDefaults.standard.string(forKey: .spectrumNormalizationMode),
            let mode = SpectrumNormalizationMode(rawValue: saved) {
             spectrumNormalizationMode = mode
         }

--- a/Sources/NullPlayer/Data/Models/EQPreset.swift
+++ b/Sources/NullPlayer/Data/Models/EQPreset.swift
@@ -26,7 +26,7 @@ struct EQPreset: Identifiable, Codable {
     private static let presetSourceLayout = EQConfiguration.classic10
 
     private static var activeLayout: EQConfiguration {
-        EQConfiguration.forModernUI(UserDefaults.standard.bool(forKey: "modernUIEnabled"))
+        EQConfiguration.forModernUI(UserDefaults.standard.bool(forKey: .modernUIEnabled))
     }
 
     private static func preset(stableID: UUID, name: String, preamp: Float = 0, classicBands: [Float]) -> EQPreset {

--- a/Sources/NullPlayer/Data/Models/LocalRadioHistory.swift
+++ b/Sources/NullPlayer/Data/Models/LocalRadioHistory.swift
@@ -109,11 +109,11 @@ class LocalRadioHistory {
 
     var retentionInterval: LocalRadioHistoryInterval {
         get {
-            let raw = UserDefaults.standard.string(forKey: "localRadioHistoryInterval") ?? LocalRadioHistoryInterval.oneMonth.rawValue
+            let raw = UserDefaults.standard.string(forKey: .localRadioHistoryInterval) ?? LocalRadioHistoryInterval.oneMonth.rawValue
             return LocalRadioHistoryInterval(rawValue: raw) ?? .oneMonth
         }
         set {
-            UserDefaults.standard.set(newValue.rawValue, forKey: "localRadioHistoryInterval")
+            UserDefaults.standard.set(newValue.rawValue, forKey: .localRadioHistoryInterval)
         }
     }
 

--- a/Sources/NullPlayer/Data/Models/MediaLibrary.swift
+++ b/Sources/NullPlayer/Data/Models/MediaLibrary.swift
@@ -519,7 +519,7 @@ class MediaLibrary {
         setupVolumeMonitoring()
 
         // Trigger backfill if v2→v3 migration ran and track_artists are not yet populated
-        if !UserDefaults.standard.bool(forKey: "trackArtistsBackfillComplete") {
+        if !UserDefaults.standard.bool(forKey: .trackArtistsBackfillComplete) {
             store.backfillTrackArtistsIfNeeded {
                 self.loadLibrary()
                 NotificationCenter.default.post(name: MediaLibrary.libraryDidChangeNotification, object: nil)

--- a/Sources/NullPlayer/Data/Models/MediaLibraryStore.swift
+++ b/Sources/NullPlayer/Data/Models/MediaLibraryStore.swift
@@ -183,7 +183,7 @@ final class MediaLibraryStore {
             try connection.run("CREATE INDEX IF NOT EXISTS idx_track_artists_name ON track_artists(artist_name)")
             try connection.run("CREATE INDEX IF NOT EXISTS idx_track_artists_url ON track_artists(track_url)")
             try connection.run("PRAGMA user_version = 3")
-            UserDefaults.standard.set(false, forKey: "trackArtistsBackfillComplete")
+            UserDefaults.standard.set(false, forKey: .trackArtistsBackfillComplete)
             currentVersion = 3
         }
         if currentVersion == 3 {
@@ -1531,7 +1531,7 @@ final class MediaLibraryStore {
                 }
                 offset += batchSize
             }
-            UserDefaults.standard.set(true, forKey: "trackArtistsBackfillComplete")
+            UserDefaults.standard.set(true, forKey: .trackArtistsBackfillComplete)
             DispatchQueue.main.async { completion() }
         }
     }

--- a/Sources/NullPlayer/Emby/EmbyManager.swift
+++ b/Sources/NullPlayer/Emby/EmbyManager.swift
@@ -37,7 +37,7 @@ class EmbyManager {
                     serverClient = EmbyServerClient(credentials: credentials)
                 }
             }
-            UserDefaults.standard.set(currentServer?.id, forKey: "EmbyCurrentServerID")
+            UserDefaults.standard.set(currentServer?.id, forKey: .embyCurrentServerID)
         }
     }
 
@@ -52,7 +52,7 @@ class EmbyManager {
     /// Currently selected music library
     private(set) var currentMusicLibrary: EmbyMusicLibrary? {
         didSet {
-            UserDefaults.standard.set(currentMusicLibrary?.id, forKey: "EmbyCurrentMusicLibraryID")
+            UserDefaults.standard.set(currentMusicLibrary?.id, forKey: .embyCurrentMusicLibraryID)
             NotificationCenter.default.post(name: Self.musicLibraryDidChangeNotification, object: self)
         }
     }
@@ -65,7 +65,7 @@ class EmbyManager {
     /// Currently selected movie library
     private(set) var currentMovieLibrary: EmbyMusicLibrary? {
         didSet {
-            UserDefaults.standard.set(currentMovieLibrary?.id, forKey: "EmbyCurrentMovieLibraryID")
+            UserDefaults.standard.set(currentMovieLibrary?.id, forKey: .embyCurrentMovieLibraryID)
             NotificationCenter.default.post(name: Self.videoLibraryDidChangeNotification, object: self)
         }
     }
@@ -73,7 +73,7 @@ class EmbyManager {
     /// Currently selected TV show library
     private(set) var currentShowLibrary: EmbyMusicLibrary? {
         didSet {
-            UserDefaults.standard.set(currentShowLibrary?.id, forKey: "EmbyCurrentShowLibraryID")
+            UserDefaults.standard.set(currentShowLibrary?.id, forKey: .embyCurrentShowLibraryID)
             NotificationCenter.default.post(name: Self.videoLibraryDidChangeNotification, object: self)
         }
     }
@@ -142,7 +142,7 @@ class EmbyManager {
         NSLog("EmbyManager: Loaded %d saved servers", servers.count)
 
         // Restore previous server selection
-        if let savedServerID = UserDefaults.standard.string(forKey: "EmbyCurrentServerID"),
+        if let savedServerID = UserDefaults.standard.string(forKey: .embyCurrentServerID),
            let savedServer = servers.first(where: { $0.id == savedServerID }) {
             serverConnectTask = Task {
                 await connectInBackground(to: savedServer)
@@ -317,7 +317,7 @@ class EmbyManager {
                 self.connectionState = .connected
 
                 // Auto-select music library
-                if let savedLibId = UserDefaults.standard.string(forKey: "EmbyCurrentMusicLibraryID"),
+                if let savedLibId = UserDefaults.standard.string(forKey: .embyCurrentMusicLibraryID),
                    let savedLib = libraries.first(where: { $0.id == savedLibId }) {
                     self.currentMusicLibrary = savedLib
                 } else if libraries.count == 1 {
@@ -325,7 +325,7 @@ class EmbyManager {
                 }
 
                 // Auto-select movie library: prefer saved, then find first "movies" type, then single fallback
-                if let savedMovieLibId = UserDefaults.standard.string(forKey: "EmbyCurrentMovieLibraryID"),
+                if let savedMovieLibId = UserDefaults.standard.string(forKey: .embyCurrentMovieLibraryID),
                    let savedLib = vidLibraries.first(where: { $0.id == savedMovieLibId }) {
                     self.currentMovieLibrary = savedLib
                 } else if let movieLib = vidLibraries.first(where: { $0.collectionType == "movies" }) {
@@ -335,7 +335,7 @@ class EmbyManager {
                 }
 
                 // Auto-select show library: prefer saved, then find first "tvshows" type, then single fallback
-                if let savedShowLibId = UserDefaults.standard.string(forKey: "EmbyCurrentShowLibraryID"),
+                if let savedShowLibId = UserDefaults.standard.string(forKey: .embyCurrentShowLibraryID),
                    let savedLib = vidLibraries.first(where: { $0.id == savedShowLibId }) {
                     self.currentShowLibrary = savedLib
                 } else if let showLib = vidLibraries.first(where: { $0.collectionType == "tvshows" }) {
@@ -378,10 +378,10 @@ class EmbyManager {
         currentMovieLibrary = nil
         currentShowLibrary = nil
         clearCachedContent()
-        UserDefaults.standard.removeObject(forKey: "EmbyCurrentServerID")
-        UserDefaults.standard.removeObject(forKey: "EmbyCurrentMusicLibraryID")
-        UserDefaults.standard.removeObject(forKey: "EmbyCurrentMovieLibraryID")
-        UserDefaults.standard.removeObject(forKey: "EmbyCurrentShowLibraryID")
+        UserDefaults.standard.removeObject(forKey: .embyCurrentServerID)
+        UserDefaults.standard.removeObject(forKey: .embyCurrentMusicLibraryID)
+        UserDefaults.standard.removeObject(forKey: .embyCurrentMovieLibraryID)
+        UserDefaults.standard.removeObject(forKey: .embyCurrentShowLibraryID)
     }
 
     /// Select a music library

--- a/Sources/NullPlayer/Emby/EmbyRadioHistory.swift
+++ b/Sources/NullPlayer/Emby/EmbyRadioHistory.swift
@@ -112,11 +112,11 @@ class EmbyRadioHistory {
 
     var retentionInterval: EmbyRadioHistoryInterval {
         get {
-            let raw = UserDefaults.standard.string(forKey: "embyRadioHistoryInterval") ?? EmbyRadioHistoryInterval.oneMonth.rawValue
+            let raw = UserDefaults.standard.string(forKey: .embyRadioHistoryInterval) ?? EmbyRadioHistoryInterval.oneMonth.rawValue
             return EmbyRadioHistoryInterval(rawValue: raw) ?? .oneMonth
         }
         set {
-            UserDefaults.standard.set(newValue.rawValue, forKey: "embyRadioHistoryInterval")
+            UserDefaults.standard.set(newValue.rawValue, forKey: .embyRadioHistoryInterval)
         }
     }
 

--- a/Sources/NullPlayer/Jellyfin/JellyfinManager.swift
+++ b/Sources/NullPlayer/Jellyfin/JellyfinManager.swift
@@ -37,7 +37,7 @@ class JellyfinManager {
                     serverClient = JellyfinServerClient(credentials: credentials)
                 }
             }
-            UserDefaults.standard.set(currentServer?.id, forKey: "JellyfinCurrentServerID")
+            UserDefaults.standard.set(currentServer?.id, forKey: .jellyfinCurrentServerID)
         }
     }
     
@@ -52,7 +52,7 @@ class JellyfinManager {
     /// Currently selected music library
     private(set) var currentMusicLibrary: JellyfinMusicLibrary? {
         didSet {
-            UserDefaults.standard.set(currentMusicLibrary?.id, forKey: "JellyfinCurrentMusicLibraryID")
+            UserDefaults.standard.set(currentMusicLibrary?.id, forKey: .jellyfinCurrentMusicLibraryID)
             NotificationCenter.default.post(name: Self.musicLibraryDidChangeNotification, object: self)
         }
     }
@@ -65,7 +65,7 @@ class JellyfinManager {
     /// Currently selected movie library
     private(set) var currentMovieLibrary: JellyfinMusicLibrary? {
         didSet {
-            UserDefaults.standard.set(currentMovieLibrary?.id, forKey: "JellyfinCurrentMovieLibraryID")
+            UserDefaults.standard.set(currentMovieLibrary?.id, forKey: .jellyfinCurrentMovieLibraryID)
             NotificationCenter.default.post(name: Self.videoLibraryDidChangeNotification, object: self)
         }
     }
@@ -73,7 +73,7 @@ class JellyfinManager {
     /// Currently selected TV show library
     private(set) var currentShowLibrary: JellyfinMusicLibrary? {
         didSet {
-            UserDefaults.standard.set(currentShowLibrary?.id, forKey: "JellyfinCurrentShowLibraryID")
+            UserDefaults.standard.set(currentShowLibrary?.id, forKey: .jellyfinCurrentShowLibraryID)
             NotificationCenter.default.post(name: Self.videoLibraryDidChangeNotification, object: self)
         }
     }
@@ -142,7 +142,7 @@ class JellyfinManager {
         NSLog("JellyfinManager: Loaded %d saved servers", servers.count)
         
         // Restore previous server selection
-        if let savedServerID = UserDefaults.standard.string(forKey: "JellyfinCurrentServerID"),
+        if let savedServerID = UserDefaults.standard.string(forKey: .jellyfinCurrentServerID),
            let savedServer = servers.first(where: { $0.id == savedServerID }) {
             serverConnectTask = Task {
                 await connectInBackground(to: savedServer)
@@ -317,7 +317,7 @@ class JellyfinManager {
                 self.connectionState = .connected
                 
                 // Auto-select music library
-                if let savedLibId = UserDefaults.standard.string(forKey: "JellyfinCurrentMusicLibraryID"),
+                if let savedLibId = UserDefaults.standard.string(forKey: .jellyfinCurrentMusicLibraryID),
                    let savedLib = libraries.first(where: { $0.id == savedLibId }) {
                     self.currentMusicLibrary = savedLib
                 } else if libraries.count == 1 {
@@ -325,7 +325,7 @@ class JellyfinManager {
                 }
                 
                 // Auto-select movie library: prefer saved, then find first "movies" type, then single fallback
-                if let savedMovieLibId = UserDefaults.standard.string(forKey: "JellyfinCurrentMovieLibraryID"),
+                if let savedMovieLibId = UserDefaults.standard.string(forKey: .jellyfinCurrentMovieLibraryID),
                    let savedLib = vidLibraries.first(where: { $0.id == savedMovieLibId }) {
                     self.currentMovieLibrary = savedLib
                 } else if let movieLib = vidLibraries.first(where: { $0.collectionType == "movies" }) {
@@ -335,7 +335,7 @@ class JellyfinManager {
                 }
                 
                 // Auto-select show library: prefer saved, then find first "tvshows" type, then single fallback
-                if let savedShowLibId = UserDefaults.standard.string(forKey: "JellyfinCurrentShowLibraryID"),
+                if let savedShowLibId = UserDefaults.standard.string(forKey: .jellyfinCurrentShowLibraryID),
                    let savedLib = vidLibraries.first(where: { $0.id == savedShowLibId }) {
                     self.currentShowLibrary = savedLib
                 } else if let showLib = vidLibraries.first(where: { $0.collectionType == "tvshows" }) {
@@ -380,10 +380,10 @@ class JellyfinManager {
         currentMovieLibrary = nil
         currentShowLibrary = nil
         clearCachedContent()
-        UserDefaults.standard.removeObject(forKey: "JellyfinCurrentServerID")
-        UserDefaults.standard.removeObject(forKey: "JellyfinCurrentMusicLibraryID")
-        UserDefaults.standard.removeObject(forKey: "JellyfinCurrentMovieLibraryID")
-        UserDefaults.standard.removeObject(forKey: "JellyfinCurrentShowLibraryID")
+        UserDefaults.standard.removeObject(forKey: .jellyfinCurrentServerID)
+        UserDefaults.standard.removeObject(forKey: .jellyfinCurrentMusicLibraryID)
+        UserDefaults.standard.removeObject(forKey: .jellyfinCurrentMovieLibraryID)
+        UserDefaults.standard.removeObject(forKey: .jellyfinCurrentShowLibraryID)
     }
     
     /// Select a music library

--- a/Sources/NullPlayer/Jellyfin/JellyfinRadioHistory.swift
+++ b/Sources/NullPlayer/Jellyfin/JellyfinRadioHistory.swift
@@ -112,11 +112,11 @@ class JellyfinRadioHistory {
 
     var retentionInterval: JellyfinRadioHistoryInterval {
         get {
-            let raw = UserDefaults.standard.string(forKey: "jellyfinRadioHistoryInterval") ?? JellyfinRadioHistoryInterval.oneMonth.rawValue
+            let raw = UserDefaults.standard.string(forKey: .jellyfinRadioHistoryInterval) ?? JellyfinRadioHistoryInterval.oneMonth.rawValue
             return JellyfinRadioHistoryInterval(rawValue: raw) ?? .oneMonth
         }
         set {
-            UserDefaults.standard.set(newValue.rawValue, forKey: "jellyfinRadioHistoryInterval")
+            UserDefaults.standard.set(newValue.rawValue, forKey: .jellyfinRadioHistoryInterval)
         }
     }
 

--- a/Sources/NullPlayer/ModernSkin/ModernSkinEngine.swift
+++ b/Sources/NullPlayer/ModernSkin/ModernSkinEngine.swift
@@ -237,8 +237,8 @@ class ModernSkinEngine {
                    !SpectrumAnalyzerView.isShaderAvailable(for: qualityMode) {
                     NSLog("ModernSkinEngine: Ignoring unsupported mainWindowMode '%@' (shader unavailable)", modeRaw)
                 } else {
-                    defaults.set(mode.rawValue, forKey: "mainWindowVisMode")
-                    defaults.set(mode.rawValue, forKey: "modernMainWindowVisMode")
+                    defaults.set(mode.rawValue, forKey: .mainWindowVisMode)
+                    defaults.set(mode.rawValue, forKey: .modernMainWindowVisMode)
                     mainVisChanged = true
                 }
             } else {
@@ -249,7 +249,7 @@ class ModernSkinEngine {
         if let modeRaw = config?.spectrumWindowMode {
             if let mode = SpectrumQualityMode(rawValue: modeRaw) {
                 if SpectrumAnalyzerView.isShaderAvailable(for: mode) {
-                    defaults.set(mode.rawValue, forKey: "spectrumQualityMode")
+                    defaults.set(mode.rawValue, forKey: .spectrumQualityMode)
                     spectrumSettingsChanged = true
                 } else {
                     NSLog("ModernSkinEngine: Ignoring unsupported spectrumWindowMode '%@' (shader unavailable)", modeRaw)
@@ -307,7 +307,7 @@ class ModernSkinEngine {
         if let fire = config?.fire {
             if let styleRaw = fire.mainWindowStyle,
                let style = FlameStyle(rawValue: styleRaw) {
-                defaults.set(style.rawValue, forKey: "mainWindowFlameStyle")
+                defaults.set(style.rawValue, forKey: .mainWindowFlameStyle)
                 mainVisChanged = true
             } else if let styleRaw = fire.mainWindowStyle {
                 NSLog("ModernSkinEngine: Ignoring unknown fire.mainWindowStyle '%@'", styleRaw)
@@ -315,7 +315,7 @@ class ModernSkinEngine {
 
             if let intensityRaw = fire.mainWindowIntensity,
                let intensity = FlameIntensity(rawValue: intensityRaw) {
-                defaults.set(intensity.rawValue, forKey: "mainWindowFlameIntensity")
+                defaults.set(intensity.rawValue, forKey: .mainWindowFlameIntensity)
                 mainVisChanged = true
             } else if let intensityRaw = fire.mainWindowIntensity {
                 NSLog("ModernSkinEngine: Ignoring unknown fire.mainWindowIntensity '%@'", intensityRaw)
@@ -323,7 +323,7 @@ class ModernSkinEngine {
 
             if let styleRaw = fire.spectrumWindowStyle,
                let style = FlameStyle(rawValue: styleRaw) {
-                defaults.set(style.rawValue, forKey: "flameStyle")
+                defaults.set(style.rawValue, forKey: .flameStyle)
                 spectrumSettingsChanged = true
             } else if let styleRaw = fire.spectrumWindowStyle {
                 NSLog("ModernSkinEngine: Ignoring unknown fire.spectrumWindowStyle '%@'", styleRaw)
@@ -331,7 +331,7 @@ class ModernSkinEngine {
 
             if let intensityRaw = fire.spectrumWindowIntensity,
                let intensity = FlameIntensity(rawValue: intensityRaw) {
-                defaults.set(intensity.rawValue, forKey: "flameIntensity")
+                defaults.set(intensity.rawValue, forKey: .flameIntensity)
                 spectrumSettingsChanged = true
             } else if let intensityRaw = fire.spectrumWindowIntensity {
                 NSLog("ModernSkinEngine: Ignoring unknown fire.spectrumWindowIntensity '%@'", intensityRaw)
@@ -341,7 +341,7 @@ class ModernSkinEngine {
         if let lightning = config?.lightning {
             if let styleRaw = lightning.mainWindowStyle,
                let style = LightningStyle(rawValue: styleRaw) {
-                defaults.set(style.rawValue, forKey: "mainWindowLightningStyle")
+                defaults.set(style.rawValue, forKey: .mainWindowLightningStyle)
                 mainVisChanged = true
             } else if let styleRaw = lightning.mainWindowStyle {
                 NSLog("ModernSkinEngine: Ignoring unknown lightning.mainWindowStyle '%@'", styleRaw)
@@ -349,7 +349,7 @@ class ModernSkinEngine {
 
             if let styleRaw = lightning.spectrumWindowStyle,
                let style = LightningStyle(rawValue: styleRaw) {
-                defaults.set(style.rawValue, forKey: "lightningStyle")
+                defaults.set(style.rawValue, forKey: .lightningStyle)
                 spectrumSettingsChanged = true
             } else if let styleRaw = lightning.spectrumWindowStyle {
                 NSLog("ModernSkinEngine: Ignoring unknown lightning.spectrumWindowStyle '%@'", styleRaw)
@@ -359,7 +359,7 @@ class ModernSkinEngine {
         if let matrix = config?.matrix {
             if let schemeRaw = matrix.mainWindowColorScheme,
                let scheme = MatrixColorScheme(rawValue: schemeRaw) {
-                defaults.set(scheme.rawValue, forKey: "mainWindowMatrixColorScheme")
+                defaults.set(scheme.rawValue, forKey: .mainWindowMatrixColorScheme)
                 mainVisChanged = true
             } else if let schemeRaw = matrix.mainWindowColorScheme {
                 NSLog("ModernSkinEngine: Ignoring unknown matrix.mainWindowColorScheme '%@'", schemeRaw)
@@ -367,7 +367,7 @@ class ModernSkinEngine {
 
             if let intensityRaw = matrix.mainWindowIntensity,
                let intensity = MatrixIntensity(rawValue: intensityRaw) {
-                defaults.set(intensity.rawValue, forKey: "mainWindowMatrixIntensity")
+                defaults.set(intensity.rawValue, forKey: .mainWindowMatrixIntensity)
                 mainVisChanged = true
             } else if let intensityRaw = matrix.mainWindowIntensity {
                 NSLog("ModernSkinEngine: Ignoring unknown matrix.mainWindowIntensity '%@'", intensityRaw)
@@ -375,7 +375,7 @@ class ModernSkinEngine {
 
             if let schemeRaw = matrix.spectrumWindowColorScheme,
                let scheme = MatrixColorScheme(rawValue: schemeRaw) {
-                defaults.set(scheme.rawValue, forKey: "matrixColorScheme")
+                defaults.set(scheme.rawValue, forKey: .matrixColorScheme)
                 spectrumSettingsChanged = true
             } else if let schemeRaw = matrix.spectrumWindowColorScheme {
                 NSLog("ModernSkinEngine: Ignoring unknown matrix.spectrumWindowColorScheme '%@'", schemeRaw)
@@ -383,7 +383,7 @@ class ModernSkinEngine {
 
             if let intensityRaw = matrix.spectrumWindowIntensity,
                let intensity = MatrixIntensity(rawValue: intensityRaw) {
-                defaults.set(intensity.rawValue, forKey: "matrixIntensity")
+                defaults.set(intensity.rawValue, forKey: .matrixIntensity)
                 spectrumSettingsChanged = true
             } else if let intensityRaw = matrix.spectrumWindowIntensity {
                 NSLog("ModernSkinEngine: Ignoring unknown matrix.spectrumWindowIntensity '%@'", intensityRaw)

--- a/Sources/NullPlayer/Plex/PlexManager.swift
+++ b/Sources/NullPlayer/Plex/PlexManager.swift
@@ -51,7 +51,7 @@ class PlexManager {
             }
             // Only save to UserDefaults if we have a valid server (don't overwrite with nil)
             if let serverId = currentServer?.id {
-                UserDefaults.standard.set(serverId, forKey: "PlexCurrentServerID")
+                UserDefaults.standard.set(serverId, forKey: .plexCurrentServerID)
             }
         }
     }
@@ -66,7 +66,7 @@ class PlexManager {
             NotificationCenter.default.post(name: Self.libraryDidChangeNotification, object: self)
             // Only save to UserDefaults if we have a valid library (don't overwrite with nil)
             if let libraryId = currentLibrary?.id {
-                UserDefaults.standard.set(libraryId, forKey: "PlexCurrentLibraryID")
+                UserDefaults.standard.set(libraryId, forKey: .plexCurrentLibraryID)
             }
         }
     }
@@ -238,8 +238,8 @@ class PlexManager {
         
         // Clear saved data
         KeychainHelper.shared.clearPlexCredentials()
-        UserDefaults.standard.removeObject(forKey: "PlexCurrentServerID")
-        UserDefaults.standard.removeObject(forKey: "PlexCurrentLibraryID")
+        UserDefaults.standard.removeObject(forKey: .plexCurrentServerID)
+        UserDefaults.standard.removeObject(forKey: .plexCurrentLibraryID)
     }
     
     // MARK: - Server Management
@@ -272,7 +272,7 @@ class PlexManager {
             // Determine which server to connect to
             var serverToConnect: PlexServer? = nil
             
-            if let savedServerID = UserDefaults.standard.string(forKey: "PlexCurrentServerID"),
+            if let savedServerID = UserDefaults.standard.string(forKey: .plexCurrentServerID),
                let savedServer = fetchedServers.first(where: { $0.id == savedServerID }) {
                 serverToConnect = savedServer
                 NSLog("PlexManager: Will connect to saved server: %@", savedServer.name)
@@ -518,7 +518,7 @@ class PlexManager {
             self.availableLibraries = allLibraries
             
             // Restore previous library selection, or default to first music library, or first library
-            if let savedLibraryID = UserDefaults.standard.string(forKey: "PlexCurrentLibraryID"),
+            if let savedLibraryID = UserDefaults.standard.string(forKey: .plexCurrentLibraryID),
                let savedLibrary = allLibraries.first(where: { $0.id == savedLibraryID }) {
                 // Restore saved library
                 self.currentLibrary = savedLibrary

--- a/Sources/NullPlayer/Plex/PlexRadioHistory.swift
+++ b/Sources/NullPlayer/Plex/PlexRadioHistory.swift
@@ -112,11 +112,11 @@ class PlexRadioHistory {
 
     var retentionInterval: PlexRadioHistoryInterval {
         get {
-            let raw = UserDefaults.standard.string(forKey: "plexRadioHistoryInterval") ?? PlexRadioHistoryInterval.oneMonth.rawValue
+            let raw = UserDefaults.standard.string(forKey: .plexRadioHistoryInterval) ?? PlexRadioHistoryInterval.oneMonth.rawValue
             return PlexRadioHistoryInterval(rawValue: raw) ?? .oneMonth
         }
         set {
-            UserDefaults.standard.set(newValue.rawValue, forKey: "plexRadioHistoryInterval")
+            UserDefaults.standard.set(newValue.rawValue, forKey: .plexRadioHistoryInterval)
         }
     }
 

--- a/Sources/NullPlayer/Radio/RadioManager.swift
+++ b/Sources/NullPlayer/Radio/RadioManager.swift
@@ -110,8 +110,8 @@ class RadioManager {
     
     /// Whether auto-reconnect is enabled (default: true)
     var autoReconnectEnabled: Bool {
-        get { UserDefaults.standard.object(forKey: "RadioAutoReconnect") as? Bool ?? true }
-        set { UserDefaults.standard.set(newValue, forKey: "RadioAutoReconnect") }
+        get { UserDefaults.standard.object(forKey: .radioAutoReconnect) as? Bool ?? true }
+        set { UserDefaults.standard.set(newValue, forKey: .radioAutoReconnect) }
     }
     
     /// Maximum number of reconnect attempts

--- a/Sources/NullPlayer/Subsonic/SubsonicManager.swift
+++ b/Sources/NullPlayer/Subsonic/SubsonicManager.swift
@@ -36,7 +36,7 @@ class SubsonicManager {
                     serverClient = SubsonicServerClient(credentials: credentials)
                 }
             }
-            UserDefaults.standard.set(currentServer?.id, forKey: "SubsonicCurrentServerID")
+            UserDefaults.standard.set(currentServer?.id, forKey: .subsonicCurrentServerID)
         }
     }
     
@@ -51,7 +51,7 @@ class SubsonicManager {
     /// Currently selected music folder (nil = all folders)
     private(set) var currentMusicFolder: SubsonicMusicFolder? {
         didSet {
-            UserDefaults.standard.set(currentMusicFolder?.id, forKey: "SubsonicCurrentMusicFolderID")
+            UserDefaults.standard.set(currentMusicFolder?.id, forKey: .subsonicCurrentMusicFolderID)
             NotificationCenter.default.post(name: Self.musicFolderDidChangeNotification, object: self)
         }
     }
@@ -113,7 +113,7 @@ class SubsonicManager {
         NSLog("SubsonicManager: Loaded %d saved servers", servers.count)
         
         // Restore previous server selection
-        if let savedServerID = UserDefaults.standard.string(forKey: "SubsonicCurrentServerID"),
+        if let savedServerID = UserDefaults.standard.string(forKey: .subsonicCurrentServerID),
            let savedServer = servers.first(where: { $0.id == savedServerID }) {
             serverConnectTask = Task {
                 await connectInBackground(to: savedServer)
@@ -276,7 +276,7 @@ class SubsonicManager {
                 self.musicFolders = folders
                 
                 // Auto-select saved folder, or leave nil (all folders)
-                if let savedId = UserDefaults.standard.string(forKey: "SubsonicCurrentMusicFolderID"),
+                if let savedId = UserDefaults.standard.string(forKey: .subsonicCurrentMusicFolderID),
                    let savedFolder = folders.first(where: { $0.id == savedId }) {
                     self.currentMusicFolder = savedFolder
                 } else {
@@ -314,8 +314,8 @@ class SubsonicManager {
         clearCachedContent()
         musicFolders = []
         currentMusicFolder = nil
-        UserDefaults.standard.removeObject(forKey: "SubsonicCurrentServerID")
-        UserDefaults.standard.removeObject(forKey: "SubsonicCurrentMusicFolderID")
+        UserDefaults.standard.removeObject(forKey: .subsonicCurrentServerID)
+        UserDefaults.standard.removeObject(forKey: .subsonicCurrentMusicFolderID)
     }
     
     // MARK: - Library Preloading

--- a/Sources/NullPlayer/Subsonic/SubsonicRadioHistory.swift
+++ b/Sources/NullPlayer/Subsonic/SubsonicRadioHistory.swift
@@ -112,11 +112,11 @@ class SubsonicRadioHistory {
 
     var retentionInterval: SubsonicRadioHistoryInterval {
         get {
-            let raw = UserDefaults.standard.string(forKey: "subsonicRadioHistoryInterval") ?? SubsonicRadioHistoryInterval.oneMonth.rawValue
+            let raw = UserDefaults.standard.string(forKey: .subsonicRadioHistoryInterval) ?? SubsonicRadioHistoryInterval.oneMonth.rawValue
             return SubsonicRadioHistoryInterval(rawValue: raw) ?? .oneMonth
         }
         set {
-            UserDefaults.standard.set(newValue.rawValue, forKey: "subsonicRadioHistoryInterval")
+            UserDefaults.standard.set(newValue.rawValue, forKey: .subsonicRadioHistoryInterval)
         }
     }
 

--- a/Sources/NullPlayer/Visualization/SpectrumAnalyzerView.swift
+++ b/Sources/NullPlayer/Visualization/SpectrumAnalyzerView.swift
@@ -370,7 +370,7 @@ class SpectrumAnalyzerView: NSView {
     var qualityMode: SpectrumQualityMode = .classic {
         didSet {
             if !isEmbedded {
-                UserDefaults.standard.set(qualityMode.rawValue, forKey: "spectrumQualityMode")
+                UserDefaults.standard.set(qualityMode.rawValue, forKey: .spectrumQualityMode)
             }
             let mode = qualityMode
             dataLock.withLock {
@@ -445,7 +445,7 @@ class SpectrumAnalyzerView: NSView {
     var decayMode: SpectrumDecayMode = .snappy {
         didSet {
             if !isEmbedded {
-                UserDefaults.standard.set(decayMode.rawValue, forKey: "spectrumDecayMode")
+                UserDefaults.standard.set(decayMode.rawValue, forKey: .spectrumDecayMode)
             }
             let factor = decayMode.decayFactor
             dataLock.withLock {
@@ -514,7 +514,7 @@ class SpectrumAnalyzerView: NSView {
     var lightningStyle: LightningStyle = .classic {
         didSet {
             if !isEmbedded {
-                UserDefaults.standard.set(lightningStyle.rawValue, forKey: "lightningStyle")
+                UserDefaults.standard.set(lightningStyle.rawValue, forKey: .lightningStyle)
             }
             let style = lightningStyle
             dataLock.withLock { renderLightningStyle = style }
@@ -525,7 +525,7 @@ class SpectrumAnalyzerView: NSView {
     var matrixColorScheme: MatrixColorScheme = .classic {
         didSet {
             if !isEmbedded {
-                UserDefaults.standard.set(matrixColorScheme.rawValue, forKey: "matrixColorScheme")
+                UserDefaults.standard.set(matrixColorScheme.rawValue, forKey: .matrixColorScheme)
             }
             let scheme = matrixColorScheme
             dataLock.withLock { renderMatrixColorScheme = scheme }
@@ -536,7 +536,7 @@ class SpectrumAnalyzerView: NSView {
     var matrixIntensity: MatrixIntensity = .subtle {
         didSet {
             if !isEmbedded {
-                UserDefaults.standard.set(matrixIntensity.rawValue, forKey: "matrixIntensity")
+                UserDefaults.standard.set(matrixIntensity.rawValue, forKey: .matrixIntensity)
             }
             let intensity = matrixIntensity
             dataLock.withLock { renderMatrixIntensity = intensity }
@@ -547,7 +547,7 @@ class SpectrumAnalyzerView: NSView {
     var flameStyle: FlameStyle = .inferno {
         didSet {
             if !isEmbedded {
-                UserDefaults.standard.set(flameStyle.rawValue, forKey: "flameStyle")
+                UserDefaults.standard.set(flameStyle.rawValue, forKey: .flameStyle)
             }
             let style = flameStyle
             dataLock.withLock { renderFlameStyle = style }
@@ -558,7 +558,7 @@ class SpectrumAnalyzerView: NSView {
     var flameIntensity: FlameIntensity = .mellow {
         didSet {
             if !isEmbedded {
-                UserDefaults.standard.set(flameIntensity.rawValue, forKey: "flameIntensity")
+                UserDefaults.standard.set(flameIntensity.rawValue, forKey: .flameIntensity)
             }
             let intensity = flameIntensity
             dataLock.withLock { renderFlameIntensity = intensity }
@@ -763,39 +763,39 @@ class SpectrumAnalyzerView: NSView {
         wantsLayer = true
         
         // Restore saved settings
-        if let savedQuality = UserDefaults.standard.string(forKey: "spectrumQualityMode"),
+        if let savedQuality = UserDefaults.standard.string(forKey: .spectrumQualityMode),
            let mode = SpectrumQualityMode(rawValue: savedQuality) {
             qualityMode = mode
         }
         
-        if let savedDecay = UserDefaults.standard.string(forKey: "spectrumDecayMode"),
+        if let savedDecay = UserDefaults.standard.string(forKey: .spectrumDecayMode),
            let mode = SpectrumDecayMode(rawValue: savedDecay) {
             decayMode = mode
         }
         
-        if let saved = UserDefaults.standard.string(forKey: "flameStyle"),
+        if let saved = UserDefaults.standard.string(forKey: .flameStyle),
            let style = FlameStyle(rawValue: saved) {
             flameStyle = style
         }
-        if let saved = UserDefaults.standard.string(forKey: "flameIntensity"),
+        if let saved = UserDefaults.standard.string(forKey: .flameIntensity),
            let intensity = FlameIntensity(rawValue: saved) {
             flameIntensity = intensity
         }
         renderFlameStyle = flameStyle
         renderFlameIntensity = flameIntensity
         
-        if let saved = UserDefaults.standard.string(forKey: "lightningStyle"),
+        if let saved = UserDefaults.standard.string(forKey: .lightningStyle),
            let style = LightningStyle(rawValue: saved) {
             lightningStyle = style
         }
         renderLightningStyle = lightningStyle
         
-        if let saved = UserDefaults.standard.string(forKey: "matrixColorScheme"),
+        if let saved = UserDefaults.standard.string(forKey: .matrixColorScheme),
            let scheme = MatrixColorScheme(rawValue: saved) {
             matrixColorScheme = scheme
         }
         renderMatrixColorScheme = matrixColorScheme
-        if let saved = UserDefaults.standard.string(forKey: "matrixIntensity"),
+        if let saved = UserDefaults.standard.string(forKey: .matrixIntensity),
            let intensity = MatrixIntensity(rawValue: saved) {
             matrixIntensity = intensity
         }
@@ -935,12 +935,12 @@ class SpectrumAnalyzerView: NSView {
         // and only respond to flame style changes (which are shared)
         if !isEmbedded {
             // Reload settings from UserDefaults
-            if let savedQuality = UserDefaults.standard.string(forKey: "spectrumQualityMode"),
+            if let savedQuality = UserDefaults.standard.string(forKey: .spectrumQualityMode),
                let mode = SpectrumQualityMode(rawValue: savedQuality) {
                 qualityMode = mode
             }
             
-            if let savedDecay = UserDefaults.standard.string(forKey: "spectrumDecayMode"),
+            if let savedDecay = UserDefaults.standard.string(forKey: .spectrumDecayMode),
                let mode = SpectrumDecayMode(rawValue: savedDecay) {
                 decayMode = mode
             }
@@ -948,23 +948,23 @@ class SpectrumAnalyzerView: NSView {
         
         // Reload flame style and intensity (only for non-embedded views; embedded overlay uses its own key)
         if !isEmbedded {
-            if let savedStyle = UserDefaults.standard.string(forKey: "flameStyle"),
+            if let savedStyle = UserDefaults.standard.string(forKey: .flameStyle),
                let style = FlameStyle(rawValue: savedStyle) {
                 flameStyle = style
             }
-            if let savedIntensity = UserDefaults.standard.string(forKey: "flameIntensity"),
+            if let savedIntensity = UserDefaults.standard.string(forKey: .flameIntensity),
                let intensity = FlameIntensity(rawValue: savedIntensity) {
                 flameIntensity = intensity
             }
-            if let savedStyle = UserDefaults.standard.string(forKey: "lightningStyle"),
+            if let savedStyle = UserDefaults.standard.string(forKey: .lightningStyle),
                let style = LightningStyle(rawValue: savedStyle) {
                 lightningStyle = style
             }
-            if let savedScheme = UserDefaults.standard.string(forKey: "matrixColorScheme"),
+            if let savedScheme = UserDefaults.standard.string(forKey: .matrixColorScheme),
                let scheme = MatrixColorScheme(rawValue: savedScheme) {
                 matrixColorScheme = scheme
             }
-            if let savedMatIntensity = UserDefaults.standard.string(forKey: "matrixIntensity"),
+            if let savedMatIntensity = UserDefaults.standard.string(forKey: .matrixIntensity),
                let matIntensity = MatrixIntensity(rawValue: savedMatIntensity) {
                 matrixIntensity = matIntensity
             }

--- a/Sources/NullPlayer/Visualization/VisualizationGLView.swift
+++ b/Sources/NullPlayer/Visualization/VisualizationGLView.swift
@@ -59,7 +59,7 @@ class VisualizationGLView: NSOpenGLView {
     /// User-configurable via context menu, persisted in UserDefaults
     private(set) var normalBeatSensitivity: Float = 1.0 {
         didSet {
-            UserDefaults.standard.set(normalBeatSensitivity, forKey: "projectMBeatSensitivity")
+            UserDefaults.standard.set(normalBeatSensitivity, forKey: .projectMBeatSensitivity)
         }
     }
     
@@ -95,7 +95,7 @@ class VisualizationGLView: NSOpenGLView {
     /// Saved to UserDefaults for persistence
     private(set) var isLowPowerMode: Bool = true {
         didSet {
-            UserDefaults.standard.set(isLowPowerMode, forKey: "projectMLowPowerMode")
+            UserDefaults.standard.set(isLowPowerMode, forKey: .projectMLowPowerMode)
         }
     }
     
@@ -104,7 +104,7 @@ class VisualizationGLView: NSOpenGLView {
     /// Range: 0.5 to 3.0, default 1.0 (unity gain)
     private(set) var pcmGain: Float = 1.0 {
         didSet {
-            UserDefaults.standard.set(pcmGain, forKey: "projectMPCMGain")
+            UserDefaults.standard.set(pcmGain, forKey: .projectMPCMGain)
         }
     }
     
@@ -135,24 +135,24 @@ class VisualizationGLView: NSOpenGLView {
         wantsBestResolutionOpenGLSurface = true
 
         // Load saved engine type preference (defaults to ProjectM)
-        if let savedType = UserDefaults.standard.string(forKey: "visualizationEngineType"),
+        if let savedType = UserDefaults.standard.string(forKey: .visualizationEngineType),
            let type = VisualizationType(rawValue: savedType) {
             currentEngineType = type
         }
         
         // Load saved performance mode preference (defaults to low power / 30fps)
-        if UserDefaults.standard.object(forKey: "projectMLowPowerMode") != nil {
-            isLowPowerMode = UserDefaults.standard.bool(forKey: "projectMLowPowerMode")
+        if UserDefaults.standard.object(forKey: .projectMLowPowerMode) != nil {
+            isLowPowerMode = UserDefaults.standard.bool(forKey: .projectMLowPowerMode)
         }
         
         // Load saved PCM gain preference (defaults to 1.0 / unity gain)
-        if UserDefaults.standard.object(forKey: "projectMPCMGain") != nil {
-            pcmGain = UserDefaults.standard.float(forKey: "projectMPCMGain")
+        if UserDefaults.standard.object(forKey: .projectMPCMGain) != nil {
+            pcmGain = UserDefaults.standard.float(forKey: .projectMPCMGain)
         }
         
         // Load saved beat sensitivity preference (defaults to 1.0 / normal)
-        if UserDefaults.standard.object(forKey: "projectMBeatSensitivity") != nil {
-            normalBeatSensitivity = UserDefaults.standard.float(forKey: "projectMBeatSensitivity")
+        if UserDefaults.standard.object(forKey: .projectMBeatSensitivity) != nil {
+            normalBeatSensitivity = UserDefaults.standard.float(forKey: .projectMBeatSensitivity)
         }
 
         // Set up OpenGL context
@@ -168,24 +168,24 @@ class VisualizationGLView: NSOpenGLView {
         super.init(coder: coder)
 
         // Load saved engine type preference (defaults to ProjectM)
-        if let savedType = UserDefaults.standard.string(forKey: "visualizationEngineType"),
+        if let savedType = UserDefaults.standard.string(forKey: .visualizationEngineType),
            let type = VisualizationType(rawValue: savedType) {
             currentEngineType = type
         }
 
         // Load saved performance mode preference (defaults to low power / 30fps)
-        if UserDefaults.standard.object(forKey: "projectMLowPowerMode") != nil {
-            isLowPowerMode = UserDefaults.standard.bool(forKey: "projectMLowPowerMode")
+        if UserDefaults.standard.object(forKey: .projectMLowPowerMode) != nil {
+            isLowPowerMode = UserDefaults.standard.bool(forKey: .projectMLowPowerMode)
         }
 
         // Load saved PCM gain preference (defaults to 1.0 / unity gain)
-        if UserDefaults.standard.object(forKey: "projectMPCMGain") != nil {
-            pcmGain = UserDefaults.standard.float(forKey: "projectMPCMGain")
+        if UserDefaults.standard.object(forKey: .projectMPCMGain) != nil {
+            pcmGain = UserDefaults.standard.float(forKey: .projectMPCMGain)
         }
 
         // Load saved beat sensitivity preference (defaults to 1.0 / normal)
-        if UserDefaults.standard.object(forKey: "projectMBeatSensitivity") != nil {
-            normalBeatSensitivity = UserDefaults.standard.float(forKey: "projectMBeatSensitivity")
+        if UserDefaults.standard.object(forKey: .projectMBeatSensitivity) != nil {
+            normalBeatSensitivity = UserDefaults.standard.float(forKey: .projectMBeatSensitivity)
         }
 
         setupOpenGL()
@@ -312,7 +312,7 @@ class VisualizationGLView: NSOpenGLView {
         currentEngineType = type
 
         // Save preference
-        UserDefaults.standard.set(type.rawValue, forKey: "visualizationEngineType")
+        UserDefaults.standard.set(type.rawValue, forKey: .visualizationEngineType)
 
         // Mark engine for reinitialization on next render
         engineNeedsSetup = true

--- a/Sources/NullPlayer/Waveform/BaseWaveformView.swift
+++ b/Sources/NullPlayer/Waveform/BaseWaveformView.swift
@@ -47,21 +47,21 @@ class BaseWaveformView: NSView {
 
     var isTooltipHidden: Bool {
         get {
-            if UserDefaults.standard.object(forKey: "waveformHideTooltip") == nil {
+            if UserDefaults.standard.object(forKey: .waveformHideTooltip) == nil {
                 return false
             }
-            return UserDefaults.standard.bool(forKey: "waveformHideTooltip")
+            return UserDefaults.standard.bool(forKey: .waveformHideTooltip)
         }
         set {
-            UserDefaults.standard.set(newValue, forKey: "waveformHideTooltip")
+            UserDefaults.standard.set(newValue, forKey: .waveformHideTooltip)
             refreshToolTips()
         }
     }
 
     var showsCuePoints: Bool {
-        get { UserDefaults.standard.bool(forKey: "waveformShowCuePoints") }
+        get { UserDefaults.standard.bool(forKey: .waveformShowCuePoints) }
         set {
-            UserDefaults.standard.set(newValue, forKey: "waveformShowCuePoints")
+            UserDefaults.standard.set(newValue, forKey: .waveformShowCuePoints)
             requestCuePoints(for: currentTrack)
         }
     }

--- a/Sources/NullPlayer/Windows/Equalizer/EQView.swift
+++ b/Sources/NullPlayer/Windows/Equalizer/EQView.swift
@@ -163,7 +163,7 @@ class EQView: NSView {
         // Load Auto EQ state from UserDefaults only if "Remember State" is enabled
         // Otherwise default to off (Auto EQ doesn't persist across restarts)
         if AppStateManager.shared.isEnabled {
-            isAuto = UserDefaults.standard.bool(forKey: "EQAutoEnabled")
+            isAuto = UserDefaults.standard.bool(forKey: .eqAutoEnabled)
         } else {
             isAuto = false
         }
@@ -589,7 +589,7 @@ class EQView: NSView {
             
             // Only persist Auto EQ state if "Remember State" is enabled
             if AppStateManager.shared.isEnabled {
-                UserDefaults.standard.set(isAuto, forKey: "EQAutoEnabled")
+                UserDefaults.standard.set(isAuto, forKey: .eqAutoEnabled)
             }
             
             // If Auto was just enabled, immediately apply genre preset for current track

--- a/Sources/NullPlayer/Windows/MainWindow/MainWindowView.swift
+++ b/Sources/NullPlayer/Windows/MainWindow/MainWindowView.swift
@@ -69,7 +69,7 @@ class MainWindowView: NSView {
     /// Main window visualization mode (spectrum bars vs GPU-rendered modes)
     private var mainVisMode: MainWindowVisMode = .spectrum {
         didSet {
-            UserDefaults.standard.set(mainVisMode.rawValue, forKey: "mainWindowVisMode")
+            UserDefaults.standard.set(mainVisMode.rawValue, forKey: .mainWindowVisMode)
             updateMetalOverlayVisibility()
         }
     }
@@ -161,7 +161,7 @@ class MainWindowView: NSView {
         registerForDraggedTypes([.fileURL])
         
         // Restore saved visualization mode
-        if let savedMode = UserDefaults.standard.string(forKey: "mainWindowVisMode"),
+        if let savedMode = UserDefaults.standard.string(forKey: .mainWindowVisMode),
            let mode = MainWindowVisMode(rawValue: savedMode) {
             // Validate shader availability before restoring a GPU mode — if the shader file
             // is missing (e.g., not included in DMG), fall back to Spectrum to prevent crashes
@@ -355,27 +355,27 @@ class MainWindowView: NSView {
             overlay.qualityMode = qualityMode
         }
         // Restore all mode-specific settings from main window's own UserDefaults keys
-        if let savedStyle = UserDefaults.standard.string(forKey: "mainWindowFlameStyle"),
+        if let savedStyle = UserDefaults.standard.string(forKey: .mainWindowFlameStyle),
            let style = FlameStyle(rawValue: savedStyle) {
             overlay.flameStyle = style
         }
-        if let savedIntensity = UserDefaults.standard.string(forKey: "mainWindowFlameIntensity"),
+        if let savedIntensity = UserDefaults.standard.string(forKey: .mainWindowFlameIntensity),
            let intensity = FlameIntensity(rawValue: savedIntensity) {
             overlay.flameIntensity = intensity
         }
-        if let savedStyle = UserDefaults.standard.string(forKey: "mainWindowLightningStyle"),
+        if let savedStyle = UserDefaults.standard.string(forKey: .mainWindowLightningStyle),
            let style = LightningStyle(rawValue: savedStyle) {
             overlay.lightningStyle = style
         }
-        if let savedScheme = UserDefaults.standard.string(forKey: "mainWindowMatrixColorScheme"),
+        if let savedScheme = UserDefaults.standard.string(forKey: .mainWindowMatrixColorScheme),
            let scheme = MatrixColorScheme(rawValue: savedScheme) {
             overlay.matrixColorScheme = scheme
         }
-        if let savedIntensity = UserDefaults.standard.string(forKey: "mainWindowMatrixIntensity"),
+        if let savedIntensity = UserDefaults.standard.string(forKey: .mainWindowMatrixIntensity),
            let intensity = MatrixIntensity(rawValue: savedIntensity) {
             overlay.matrixIntensity = intensity
         }
-        if let savedDecay = UserDefaults.standard.string(forKey: "mainWindowDecayMode"),
+        if let savedDecay = UserDefaults.standard.string(forKey: .mainWindowDecayMode),
            let mode = SpectrumDecayMode(rawValue: savedDecay) {
             overlay.decayMode = mode
         }
@@ -480,7 +480,7 @@ class MainWindowView: NSView {
     
     @objc private func mainVisSettingsChanged() {
         // Reload vis mode from UserDefaults
-        if let savedMode = UserDefaults.standard.string(forKey: "mainWindowVisMode"),
+        if let savedMode = UserDefaults.standard.string(forKey: .mainWindowVisMode),
            let mode = MainWindowVisMode(rawValue: savedMode) {
             // Validate shader availability before applying a GPU mode
             if let qualityMode = mode.spectrumQualityMode,
@@ -498,30 +498,30 @@ class MainWindowView: NSView {
                 overlay.qualityMode = qualityMode
             }
             // Flame settings
-            if let savedStyle = UserDefaults.standard.string(forKey: "mainWindowFlameStyle"),
+            if let savedStyle = UserDefaults.standard.string(forKey: .mainWindowFlameStyle),
                let style = FlameStyle(rawValue: savedStyle) {
                 overlay.flameStyle = style
             }
-            if let savedIntensity = UserDefaults.standard.string(forKey: "mainWindowFlameIntensity"),
+            if let savedIntensity = UserDefaults.standard.string(forKey: .mainWindowFlameIntensity),
                let intensity = FlameIntensity(rawValue: savedIntensity) {
                 overlay.flameIntensity = intensity
             }
             // Lightning settings
-            if let savedStyle = UserDefaults.standard.string(forKey: "mainWindowLightningStyle"),
+            if let savedStyle = UserDefaults.standard.string(forKey: .mainWindowLightningStyle),
                let style = LightningStyle(rawValue: savedStyle) {
                 overlay.lightningStyle = style
             }
             // Matrix settings
-            if let savedScheme = UserDefaults.standard.string(forKey: "mainWindowMatrixColorScheme"),
+            if let savedScheme = UserDefaults.standard.string(forKey: .mainWindowMatrixColorScheme),
                let scheme = MatrixColorScheme(rawValue: savedScheme) {
                 overlay.matrixColorScheme = scheme
             }
-            if let savedIntensity = UserDefaults.standard.string(forKey: "mainWindowMatrixIntensity"),
+            if let savedIntensity = UserDefaults.standard.string(forKey: .mainWindowMatrixIntensity),
                let intensity = MatrixIntensity(rawValue: savedIntensity) {
                 overlay.matrixIntensity = intensity
             }
             // Decay/responsiveness
-            if let savedDecay = UserDefaults.standard.string(forKey: "mainWindowDecayMode"),
+            if let savedDecay = UserDefaults.standard.string(forKey: .mainWindowDecayMode),
                let mode = SpectrumDecayMode(rawValue: savedDecay) {
                 overlay.decayMode = mode
             }

--- a/Sources/NullPlayer/Windows/ModernEQ/ModernEQView.swift
+++ b/Sources/NullPlayer/Windows/ModernEQ/ModernEQView.swift
@@ -210,7 +210,7 @@ class ModernEQView: NSView {
         
         // Load Auto EQ state from UserDefaults only if "Remember State" is enabled
         if AppStateManager.shared.isEnabled {
-            isAuto = UserDefaults.standard.bool(forKey: "EQAutoEnabled")
+            isAuto = UserDefaults.standard.bool(forKey: .eqAutoEnabled)
         } else {
             isAuto = false
         }
@@ -1201,7 +1201,7 @@ class ModernEQView: NSView {
             isAuto.toggle()
             
             if AppStateManager.shared.isEnabled {
-                UserDefaults.standard.set(isAuto, forKey: "EQAutoEnabled")
+                UserDefaults.standard.set(isAuto, forKey: .eqAutoEnabled)
             }
             
             if isAuto {

--- a/Sources/NullPlayer/Windows/ModernLibraryBrowser/ModernLibraryBrowserView.swift
+++ b/Sources/NullPlayer/Windows/ModernLibraryBrowser/ModernLibraryBrowserView.swift
@@ -624,13 +624,13 @@ class ModernLibraryBrowserView: NSView {
         isArtOnlyMode = false
         
         // Load saved visualizer preferences — default effect takes priority over last-used
-        let defaultEffectKey = UserDefaults.standard.string(forKey: "browserVisDefaultEffect")
-        let lastUsedKey = UserDefaults.standard.string(forKey: "browserVisEffect")
+        let defaultEffectKey = UserDefaults.standard.string(forKey: .browserVisDefaultEffect)
+        let lastUsedKey = UserDefaults.standard.string(forKey: .browserVisEffect)
         if let raw = defaultEffectKey ?? lastUsedKey, let effect = VisEffect(rawValue: raw) {
             currentVisEffect = effect
         }
-        if UserDefaults.standard.object(forKey: "browserVisIntensity") != nil {
-            visEffectIntensity = CGFloat(UserDefaults.standard.double(forKey: "browserVisIntensity"))
+        if UserDefaults.standard.object(forKey: .browserVisIntensity) != nil {
+            visEffectIntensity = CGFloat(UserDefaults.standard.double(forKey: .browserVisIntensity))
         }
         
         // Register notifications
@@ -2466,46 +2466,46 @@ class ModernLibraryBrowserView: NSView {
     }
     
     private func saveColumnWidths() {
-        UserDefaults.standard.set(columnWidths, forKey: "BrowserColumnWidths")
+        UserDefaults.standard.set(columnWidths, forKey: .browserColumnWidths)
     }
     
     private func loadColumnWidths() {
-        if let saved = UserDefaults.standard.dictionary(forKey: "BrowserColumnWidths") as? [String: CGFloat] {
+        if let saved = UserDefaults.standard.dictionary(forKey: .browserColumnWidths) as? [String: CGFloat] {
             columnWidths = saved
         }
     }
     
     private func saveColumnSort() {
         if let id = columnSortId {
-            UserDefaults.standard.set(id, forKey: "BrowserColumnSortId")
-            UserDefaults.standard.set(columnSortAscending, forKey: "BrowserColumnSortAscending")
+            UserDefaults.standard.set(id, forKey: .browserColumnSortId)
+            UserDefaults.standard.set(columnSortAscending, forKey: .browserColumnSortAscending)
         } else {
-            UserDefaults.standard.removeObject(forKey: "BrowserColumnSortId")
+            UserDefaults.standard.removeObject(forKey: .browserColumnSortId)
         }
     }
     
     private func loadColumnSort() {
-        columnSortId = UserDefaults.standard.string(forKey: "BrowserColumnSortId")
-        columnSortAscending = UserDefaults.standard.bool(forKey: "BrowserColumnSortAscending")
-        if UserDefaults.standard.object(forKey: "BrowserColumnSortAscending") == nil {
+        columnSortId = UserDefaults.standard.string(forKey: .browserColumnSortId)
+        columnSortAscending = UserDefaults.standard.bool(forKey: .browserColumnSortAscending)
+        if UserDefaults.standard.object(forKey: .browserColumnSortAscending) == nil {
             columnSortAscending = true
         }
     }
     
     private func saveVisibleColumns() {
-        UserDefaults.standard.set(visibleTrackColumnIds, forKey: "BrowserVisibleTrackColumns")
-        UserDefaults.standard.set(visibleAlbumColumnIds, forKey: "BrowserVisibleAlbumColumns")
-        UserDefaults.standard.set(visibleArtistColumnIds, forKey: "BrowserVisibleArtistColumns")
+        UserDefaults.standard.set(visibleTrackColumnIds, forKey: .browserVisibleTrackColumns)
+        UserDefaults.standard.set(visibleAlbumColumnIds, forKey: .browserVisibleAlbumColumns)
+        UserDefaults.standard.set(visibleArtistColumnIds, forKey: .browserVisibleArtistColumns)
     }
     
     private func loadVisibleColumns() {
-        if let saved = UserDefaults.standard.stringArray(forKey: "BrowserVisibleTrackColumns") {
+        if let saved = UserDefaults.standard.stringArray(forKey: .browserVisibleTrackColumns) {
             visibleTrackColumnIds = saved
         }
-        if let saved = UserDefaults.standard.stringArray(forKey: "BrowserVisibleAlbumColumns") {
+        if let saved = UserDefaults.standard.stringArray(forKey: .browserVisibleAlbumColumns) {
             visibleAlbumColumnIds = saved
         }
-        if let saved = UserDefaults.standard.stringArray(forKey: "BrowserVisibleArtistColumns") {
+        if let saved = UserDefaults.standard.stringArray(forKey: .browserVisibleArtistColumns) {
             visibleArtistColumnIds = saved
         }
     }
@@ -4194,7 +4194,7 @@ class ModernLibraryBrowserView: NSView {
     /// Appends grouped effect submenus to `menu`. Each item is checked when it
     /// matches `currentVisEffect`; bullet-marked when it matches the saved default.
     private func buildVisEffectGroupSubmenus(into menu: NSMenu) {
-        let savedDefault = UserDefaults.standard.string(forKey: "browserVisDefaultEffect")
+        let savedDefault = UserDefaults.standard.string(forKey: .browserVisDefaultEffect)
         for group in VisEffect.groups {
             let groupItem = NSMenuItem(title: group.title, action: nil, keyEquivalent: "")
             let sub = NSMenu(title: group.title)
@@ -4948,11 +4948,11 @@ class ModernLibraryBrowserView: NSView {
               let effect = VisEffect(rawValue: raw) else { return }
         visMode = .single
         currentVisEffect = effect
-        UserDefaults.standard.set(effect.rawValue, forKey: "browserVisEffect")
+        UserDefaults.standard.set(effect.rawValue, forKey: .browserVisEffect)
     }
 
     @objc private func menuSetDefaultEffect() {
-        UserDefaults.standard.set(currentVisEffect.rawValue, forKey: "browserVisDefaultEffect")
+        UserDefaults.standard.set(currentVisEffect.rawValue, forKey: .browserVisDefaultEffect)
     }
     @objc private func enableArtVisualization() { isVisualizingArt = true }
     @objc private func exitArtView() { isArtOnlyMode = false }

--- a/Sources/NullPlayer/Windows/ModernMainWindow/ModernMainWindowView.swift
+++ b/Sources/NullPlayer/Windows/ModernMainWindow/ModernMainWindowView.swift
@@ -38,8 +38,8 @@ class ModernMainWindowView: NSView {
     /// Main window visualization mode (persisted)
     private var mainVisMode: MainWindowVisMode = .spectrum {
         didSet {
-            UserDefaults.standard.set(mainVisMode.rawValue, forKey: "modernMainWindowVisMode")
-            UserDefaults.standard.set(mainVisMode.rawValue, forKey: "mainWindowVisMode")
+            UserDefaults.standard.set(mainVisMode.rawValue, forKey: .modernMainWindowVisMode)
+            UserDefaults.standard.set(mainVisMode.rawValue, forKey: .mainWindowVisMode)
             updateMetalOverlay()
         }
     }
@@ -1095,17 +1095,17 @@ class ModernMainWindowView: NSView {
                 }
 
                 // Load mode-specific settings from main-window-specific keys
-                if let savedStyle = UserDefaults.standard.string(forKey: "mainWindowFlameStyle"),
+                if let savedStyle = UserDefaults.standard.string(forKey: .mainWindowFlameStyle),
                    let style = FlameStyle(rawValue: savedStyle) { overlay.flameStyle = style }
-                if let savedIntensity = UserDefaults.standard.string(forKey: "mainWindowFlameIntensity"),
+                if let savedIntensity = UserDefaults.standard.string(forKey: .mainWindowFlameIntensity),
                    let intensity = FlameIntensity(rawValue: savedIntensity) { overlay.flameIntensity = intensity }
-                if let savedStyle = UserDefaults.standard.string(forKey: "mainWindowLightningStyle"),
+                if let savedStyle = UserDefaults.standard.string(forKey: .mainWindowLightningStyle),
                    let style = LightningStyle(rawValue: savedStyle) { overlay.lightningStyle = style }
-                if let savedScheme = UserDefaults.standard.string(forKey: "mainWindowMatrixColorScheme"),
+                if let savedScheme = UserDefaults.standard.string(forKey: .mainWindowMatrixColorScheme),
                    let scheme = MatrixColorScheme(rawValue: savedScheme) { overlay.matrixColorScheme = scheme }
-                if let savedIntensity = UserDefaults.standard.string(forKey: "mainWindowMatrixIntensity"),
+                if let savedIntensity = UserDefaults.standard.string(forKey: .mainWindowMatrixIntensity),
                    let intensity = MatrixIntensity(rawValue: savedIntensity) { overlay.matrixIntensity = intensity }
-                if let savedDecay = UserDefaults.standard.string(forKey: "mainWindowDecayMode"),
+                if let savedDecay = UserDefaults.standard.string(forKey: .mainWindowDecayMode),
                    let mode = SpectrumDecayMode(rawValue: savedDecay) { overlay.decayMode = mode }
 
                 addSubview(overlay)
@@ -1131,7 +1131,7 @@ class ModernMainWindowView: NSView {
     }
     
     private func restoreVisMode() {
-        if let savedMode = UserDefaults.standard.string(forKey: "modernMainWindowVisMode"),
+        if let savedMode = UserDefaults.standard.string(forKey: .modernMainWindowVisMode),
            let mode = MainWindowVisMode(rawValue: savedMode) {
             // Validate shader availability before restoring a GPU mode — if the shader file
             // is missing (e.g., not included in DMG), fall back to Spectrum to prevent crashes
@@ -1155,7 +1155,7 @@ class ModernMainWindowView: NSView {
     }
 
     @objc private func mainVisSettingsChanged() {
-        if let savedMode = UserDefaults.standard.string(forKey: "mainWindowVisMode"),
+        if let savedMode = UserDefaults.standard.string(forKey: .mainWindowVisMode),
            let mode = MainWindowVisMode(rawValue: savedMode) {
             if let qualityMode = mode.spectrumQualityMode,
                !SpectrumAnalyzerView.isShaderAvailable(for: qualityMode) {
@@ -1169,17 +1169,17 @@ class ModernMainWindowView: NSView {
             if let qualityMode = mainVisMode.spectrumQualityMode {
                 overlay.qualityMode = qualityMode
             }
-            if let savedStyle = UserDefaults.standard.string(forKey: "mainWindowFlameStyle"),
+            if let savedStyle = UserDefaults.standard.string(forKey: .mainWindowFlameStyle),
                let style = FlameStyle(rawValue: savedStyle) { overlay.flameStyle = style }
-            if let savedIntensity = UserDefaults.standard.string(forKey: "mainWindowFlameIntensity"),
+            if let savedIntensity = UserDefaults.standard.string(forKey: .mainWindowFlameIntensity),
                let intensity = FlameIntensity(rawValue: savedIntensity) { overlay.flameIntensity = intensity }
-            if let savedStyle = UserDefaults.standard.string(forKey: "mainWindowLightningStyle"),
+            if let savedStyle = UserDefaults.standard.string(forKey: .mainWindowLightningStyle),
                let style = LightningStyle(rawValue: savedStyle) { overlay.lightningStyle = style }
-            if let savedScheme = UserDefaults.standard.string(forKey: "mainWindowMatrixColorScheme"),
+            if let savedScheme = UserDefaults.standard.string(forKey: .mainWindowMatrixColorScheme),
                let scheme = MatrixColorScheme(rawValue: savedScheme) { overlay.matrixColorScheme = scheme }
-            if let savedIntensity = UserDefaults.standard.string(forKey: "mainWindowMatrixIntensity"),
+            if let savedIntensity = UserDefaults.standard.string(forKey: .mainWindowMatrixIntensity),
                let intensity = MatrixIntensity(rawValue: savedIntensity) { overlay.matrixIntensity = intensity }
-            if let savedDecay = UserDefaults.standard.string(forKey: "mainWindowDecayMode"),
+            if let savedDecay = UserDefaults.standard.string(forKey: .mainWindowDecayMode),
                let mode = SpectrumDecayMode(rawValue: savedDecay) { overlay.decayMode = mode }
             if mainVisMode == .visClassicExact {
                 let enabled = VisClassicBridge.transparentBgDefault(for: .mainWindow)

--- a/Sources/NullPlayer/Windows/ModernSpectrum/ModernSpectrumView.swift
+++ b/Sources/NullPlayer/Windows/ModernSpectrum/ModernSpectrumView.swift
@@ -558,7 +558,7 @@ class ModernSpectrumView: NSView {
         }
         let newMode = modes[newIdx]
         view.qualityMode = newMode
-        UserDefaults.standard.set(newMode.rawValue, forKey: "spectrumQualityMode")
+        UserDefaults.standard.set(newMode.rawValue, forKey: .spectrumQualityMode)
     }
     
     private func cycleFlameStyle(forward: Bool) {
@@ -620,7 +620,7 @@ class ModernSpectrumView: NSView {
         // Normalization Mode submenu (not shown for Flame mode)
         if spectrumAnalyzerView?.qualityMode != .flame {
             let normMenu = NSMenu()
-            let currentNormMode = UserDefaults.standard.string(forKey: "spectrumNormalizationMode")
+            let currentNormMode = UserDefaults.standard.string(forKey: .spectrumNormalizationMode)
                 .flatMap { SpectrumNormalizationMode(rawValue: $0) } ?? .accurate
             for mode in SpectrumNormalizationMode.allCases {
                 let item = NSMenuItem(title: "\(mode.displayName) - \(mode.description)", action: #selector(setNormalizationMode(_:)), keyEquivalent: "")
@@ -800,7 +800,7 @@ class ModernSpectrumView: NSView {
     
     @objc private func setNormalizationMode(_ sender: NSMenuItem) {
         guard let mode = sender.representedObject as? SpectrumNormalizationMode else { return }
-        UserDefaults.standard.set(mode.rawValue, forKey: "spectrumNormalizationMode")
+        UserDefaults.standard.set(mode.rawValue, forKey: .spectrumNormalizationMode)
     }
     
     @objc private func setFlameStyle(_ sender: NSMenuItem) {

--- a/Sources/NullPlayer/Windows/PlexBrowser/PlexBrowserView.swift
+++ b/Sources/NullPlayer/Windows/PlexBrowser/PlexBrowserView.swift
@@ -325,19 +325,19 @@ class PlexBrowserView: NSView {
     /// Save column sort to UserDefaults
     private func saveColumnSort() {
         if let id = columnSortId {
-            UserDefaults.standard.set(id, forKey: "BrowserColumnSortId")
-            UserDefaults.standard.set(columnSortAscending, forKey: "BrowserColumnSortAscending")
+            UserDefaults.standard.set(id, forKey: .browserColumnSortId)
+            UserDefaults.standard.set(columnSortAscending, forKey: .browserColumnSortAscending)
         } else {
-            UserDefaults.standard.removeObject(forKey: "BrowserColumnSortId")
+            UserDefaults.standard.removeObject(forKey: .browserColumnSortId)
         }
     }
     
     /// Load column sort from UserDefaults
     private func loadColumnSort() {
-        columnSortId = UserDefaults.standard.string(forKey: "BrowserColumnSortId")
-        columnSortAscending = UserDefaults.standard.bool(forKey: "BrowserColumnSortAscending")
+        columnSortId = UserDefaults.standard.string(forKey: .browserColumnSortId)
+        columnSortAscending = UserDefaults.standard.bool(forKey: .browserColumnSortAscending)
         // Default to true if not set
-        if UserDefaults.standard.object(forKey: "BrowserColumnSortAscending") == nil {
+        if UserDefaults.standard.object(forKey: .browserColumnSortAscending) == nil {
             columnSortAscending = true
         }
     }
@@ -444,12 +444,12 @@ class PlexBrowserView: NSView {
     
     /// Save column widths to UserDefaults
     private func saveColumnWidths() {
-        UserDefaults.standard.set(columnWidths, forKey: "BrowserColumnWidths")
+        UserDefaults.standard.set(columnWidths, forKey: .browserColumnWidths)
     }
     
     /// Load column widths from UserDefaults
     private func loadColumnWidths() {
-        if let saved = UserDefaults.standard.dictionary(forKey: "BrowserColumnWidths") as? [String: CGFloat] {
+        if let saved = UserDefaults.standard.dictionary(forKey: .browserColumnWidths) as? [String: CGFloat] {
             columnWidths = saved
         }
     }
@@ -1065,13 +1065,13 @@ class PlexBrowserView: NSView {
         isArtOnlyMode = false
         
         // Load saved visualizer preferences — default effect takes priority over last-used
-        let defaultEffectKey = UserDefaults.standard.string(forKey: "browserVisDefaultEffect")
-        let lastUsedKey = UserDefaults.standard.string(forKey: "browserVisEffect")
+        let defaultEffectKey = UserDefaults.standard.string(forKey: .browserVisDefaultEffect)
+        let lastUsedKey = UserDefaults.standard.string(forKey: .browserVisEffect)
         if let raw = defaultEffectKey ?? lastUsedKey, let effect = VisEffect(rawValue: raw) {
             currentVisEffect = effect
         }
-        if UserDefaults.standard.object(forKey: "browserVisIntensity") != nil {
-            visEffectIntensity = CGFloat(UserDefaults.standard.double(forKey: "browserVisIntensity"))
+        if UserDefaults.standard.object(forKey: .browserVisIntensity) != nil {
+            visEffectIntensity = CGFloat(UserDefaults.standard.double(forKey: .browserVisIntensity))
         }
         
         // Observe Plex manager changes
@@ -6902,7 +6902,7 @@ class PlexBrowserView: NSView {
     }
     
     @objc private func menuSetDefaultEffect() {
-        UserDefaults.standard.set(currentVisEffect.rawValue, forKey: "browserVisDefaultEffect")
+        UserDefaults.standard.set(currentVisEffect.rawValue, forKey: .browserVisDefaultEffect)
     }
 
     @objc private func menuNextEffect() {
@@ -6934,7 +6934,7 @@ class PlexBrowserView: NSView {
     /// Appends grouped effect submenus to `menu`. Each item is checked when it
     /// matches `currentVisEffect`; bullet-marked when it matches the saved default.
     private func buildVisEffectGroupSubmenus(into menu: NSMenu) {
-        let savedDefault = UserDefaults.standard.string(forKey: "browserVisDefaultEffect")
+        let savedDefault = UserDefaults.standard.string(forKey: .browserVisDefaultEffect)
         for group in VisEffect.groups {
             let groupItem = NSMenuItem(title: group.title, action: nil, keyEquivalent: "")
             let sub = NSMenu(title: group.title)
@@ -6968,7 +6968,7 @@ class PlexBrowserView: NSView {
         if let effect = sender.representedObject as? VisEffect {
             currentVisEffect = effect
             visMode = .single  // Switch to single mode when selecting an effect
-            UserDefaults.standard.set(effect.rawValue, forKey: "browserVisEffect")
+            UserDefaults.standard.set(effect.rawValue, forKey: .browserVisEffect)
         }
     }
     
@@ -6992,7 +6992,7 @@ class PlexBrowserView: NSView {
     
     @objc private func selectVisIntensity(_ sender: NSMenuItem) {
         visEffectIntensity = CGFloat(sender.tag) / 100.0
-        UserDefaults.standard.set(visEffectIntensity, forKey: "browserVisIntensity")
+        UserDefaults.standard.set(visEffectIntensity, forKey: .browserVisIntensity)
     }
     
     @objc private func turnOffVisualization() {

--- a/Sources/NullPlayer/Windows/Spectrum/SpectrumView.swift
+++ b/Sources/NullPlayer/Windows/Spectrum/SpectrumView.swift
@@ -513,7 +513,7 @@ class SpectrumView: NSView {
         }
         let newMode = modes[newIdx]
         view.qualityMode = newMode
-        UserDefaults.standard.set(newMode.rawValue, forKey: "spectrumQualityMode")
+        UserDefaults.standard.set(newMode.rawValue, forKey: .spectrumQualityMode)
     }
     
     private func cycleFlameStyle(forward: Bool) {
@@ -575,7 +575,7 @@ class SpectrumView: NSView {
         // Normalization Mode submenu (not shown for Flame mode)
         if spectrumAnalyzerView?.qualityMode != .flame {
             let normMenu = NSMenu()
-            let currentNormMode = UserDefaults.standard.string(forKey: "spectrumNormalizationMode")
+            let currentNormMode = UserDefaults.standard.string(forKey: .spectrumNormalizationMode)
                 .flatMap { SpectrumNormalizationMode(rawValue: $0) } ?? .accurate
             for mode in SpectrumNormalizationMode.allCases {
                 let item = NSMenuItem(title: "\(mode.displayName) - \(mode.description)", action: #selector(setNormalizationMode(_:)), keyEquivalent: "")
@@ -753,7 +753,7 @@ class SpectrumView: NSView {
     
     @objc private func setNormalizationMode(_ sender: NSMenuItem) {
         guard let mode = sender.representedObject as? SpectrumNormalizationMode else { return }
-        UserDefaults.standard.set(mode.rawValue, forKey: "spectrumNormalizationMode")
+        UserDefaults.standard.set(mode.rawValue, forKey: .spectrumNormalizationMode)
     }
     
     @objc private func setFlameStyle(_ sender: NSMenuItem) {


### PR DESCRIPTION
Closes #168

Centralizes all 76 UserDefaults keys into type-safe constants and converts every call site (314 total, 30 files) from string literals to dot-shorthand.

## New file: `UserDefaults+Keys.swift`

```swift
extension UserDefaults {
    struct Key: RawRepresentable, Hashable, ExpressibleByStringLiteral { ... }
}

extension UserDefaults.Key {
    static let modernUIEnabled:    Self = "modernUIEnabled"
    static let mainWindowFrame:    Self = "MainWindowFrame"
    // ... 76 keys total, grouped by subsystem
}
```

Plus typed getter/setter overloads so call sites become:

```swift
// Before:
UserDefaults.standard.bool(forKey: "modernUIEnabled")
UserDefaults.standard.set(mode.rawValue, forKey: "mainWindowVisMode")

// After:
UserDefaults.standard.bool(forKey: .modernUIEnabled)
UserDefaults.standard.set(mode.rawValue, forKey: .mainWindowVisMode)
```

## Scope

- **314** call sites converted across **30** files
- **76** unique keys centralized (grouped: window frames, layout, browser columns, Plex, Jellyfin, Emby, Subsonic, radio, EQ, audio, skin, visualization, spectrum, ProjectM, waveform, migrations)
- Raw string values unchanged — **zero migration needed**, existing user preferences load as before

## Correctly untouched (42 calls)

- `CIFilter.setValue(_:forKey:)` — CIFilter shader parameter names (`inputRVector`, `inputTexture`, etc.)
- `CALayer.removeAnimation(forKey:)` / `.add(_:forKey:)` — Core Animation keys (`scroll`)
- 3 `KeychainHelper` calls using dynamic string interpolation (`"\(Keys.service).\(key)"`)

## Verification

```
Build complete! (0 errors)
grep -c 'forKey: "' (excluding Keys file, CIFilter, CALayer): 3 (all KeychainHelper dynamic keys)
```