### PR TITLE
feat: Sleep Timer (supersedes #162)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,6 @@
 # Changelog
 
-## 0.19.3
+## 0.20.0
 
 ### New Features
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,11 @@
 # Changelog
 
+## 0.19.3
+
+### New Features
+
+- **Sleep Timer** — pause or stop playback automatically via **Playback > Sleep Timer**. Three modes: timed durations (5, 10, 15, 30, 45, 60, 90 minutes, or 2, 5, 8, 12 hours) with a 10-second volume fade-out before firing; end of current track (fires on natural completion, not manual skip, including tracks that end via Sweet Fades crossfade); end of queue (fires when the last track in the playlist finishes). The active preset is shown as a live countdown in the submenu. Selecting the active preset again cancels it. Volume is restored if cancelled mid-fade or if the user adjusts volume during the fade.
+
 ## 0.19.2
 
 ### New Features

--- a/README.md
+++ b/README.md
@@ -39,6 +39,7 @@
 - Video playback: MKV, MP4, MOV, AVI, WebM, HEVC (KSPlayer/FFmpeg)
 - Gapless playback for seamless track transitions
 - Sweet Fades (crossfade) with configurable fade duration
+- Sleep Timer — timed (5 min – 12 hr with volume fade-out), end of current track, or end of queue
 - Media Drag and drop support
 - Album/Cover/Movie art browser with visualizations
 - Internet radio (Shoutcast/Icecast) with live metadata and auto-reconnect

--- a/Sources/NullPlayer/App/ContextMenuBuilder.swift
+++ b/Sources/NullPlayer/App/ContextMenuBuilder.swift
@@ -163,12 +163,77 @@ class ContextMenuBuilder {
 
         menu.addItem(NSMenuItem.separator())
 
+        // Sleep Timer submenu
+        let sleepTimerItem = NSMenuItem(title: "Sleep Timer", action: nil, keyEquivalent: "")
+        sleepTimerItem.submenu = buildSleepTimerMenu()
+        if SleepTimerManager.shared.isActive { sleepTimerItem.state = .on }
+        menu.addItem(sleepTimerItem)
+
+        menu.addItem(NSMenuItem.separator())
+
         let rememberState = NSMenuItem(title: "Remember State On Quit", action: #selector(MenuActions.toggleRememberState), keyEquivalent: "")
         rememberState.target = MenuActions.shared
         rememberState.state = AppStateManager.shared.isEnabled ? .on : .off
         menu.addItem(rememberState)
 
         menu.autoenablesItems = false
+        return menu
+    }
+
+    // MARK: - Sleep Timer Submenu
+
+    static func buildSleepTimerMenu() -> NSMenu {
+        let menu = NSMenu()
+        menu.autoenablesItems = false
+
+        let manager = SleepTimerManager.shared
+
+        if let description = manager.menuDescription {
+            let status = NSMenuItem(title: description, action: nil, keyEquivalent: "")
+            status.isEnabled = false
+            menu.addItem(status)
+
+            let cancel = NSMenuItem(title: "Cancel Sleep Timer", action: #selector(MenuActions.cancelSleepTimer), keyEquivalent: "")
+            cancel.target = MenuActions.shared
+            menu.addItem(cancel)
+
+            menu.addItem(NSMenuItem.separator())
+        }
+
+        for minutes in SleepTimerManager.timedChoicesMinutes {
+            let title: String
+            if minutes >= 60 {
+                let hours = Double(minutes) / 60.0
+                title = hours == floor(hours)
+                    ? "\(Int(hours)) hour\(Int(hours) == 1 ? "" : "s")"
+                    : String(format: "%.1f hours", hours)
+            } else {
+                title = "\(minutes) minutes"
+            }
+            let item = NSMenuItem(title: title, action: #selector(MenuActions.startSleepTimerMinutes(_:)), keyEquivalent: "")
+            item.target = MenuActions.shared
+            item.representedObject = minutes
+            if let state = manager.state,
+               state.mode == .timed,
+               let duration = state.originalDuration,
+               Int(duration / 60) == minutes {
+                item.state = .on
+            }
+            menu.addItem(item)
+        }
+
+        menu.addItem(NSMenuItem.separator())
+
+        let endOfTrack = NSMenuItem(title: "End of Current Track", action: #selector(MenuActions.startSleepTimerEndOfTrack), keyEquivalent: "")
+        endOfTrack.target = MenuActions.shared
+        if manager.state?.mode == .endOfTrack { endOfTrack.state = .on }
+        menu.addItem(endOfTrack)
+
+        let endOfQueue = NSMenuItem(title: "End of Queue", action: #selector(MenuActions.startSleepTimerEndOfQueue), keyEquivalent: "")
+        endOfQueue.target = MenuActions.shared
+        if manager.state?.mode == .endOfQueue { endOfQueue.state = .on }
+        menu.addItem(endOfQueue)
+
         return menu
     }
 
@@ -3486,6 +3551,40 @@ class MenuActions: NSObject {
     
     @objc func toggleBrowserArtworkBackground() {
         WindowManager.shared.showBrowserArtworkBackground.toggle()
+    }
+
+    // MARK: - Sleep Timer
+
+    @objc func startSleepTimerMinutes(_ sender: NSMenuItem) {
+        guard let minutes = sender.representedObject as? Int else { return }
+        if let state = SleepTimerManager.shared.state,
+           state.mode == .timed,
+           let duration = state.originalDuration,
+           Int(duration / 60) == minutes {
+            SleepTimerManager.shared.cancel()
+            return
+        }
+        SleepTimerManager.shared.startTimed(minutes: minutes)
+    }
+
+    @objc func startSleepTimerEndOfTrack() {
+        if SleepTimerManager.shared.state?.mode == .endOfTrack {
+            SleepTimerManager.shared.cancel()
+            return
+        }
+        SleepTimerManager.shared.startEndOfTrack()
+    }
+
+    @objc func startSleepTimerEndOfQueue() {
+        if SleepTimerManager.shared.state?.mode == .endOfQueue {
+            SleepTimerManager.shared.cancel()
+            return
+        }
+        SleepTimerManager.shared.startEndOfQueue()
+    }
+
+    @objc func cancelSleepTimer() {
+        SleepTimerManager.shared.cancel()
     }
 
     // MARK: - Plex Radio History

--- a/Sources/NullPlayer/App/ContextMenuBuilder.swift
+++ b/Sources/NullPlayer/App/ContextMenuBuilder.swift
@@ -185,11 +185,13 @@ class ContextMenuBuilder {
     static func buildSleepTimerMenu() -> NSMenu {
         let menu = NSMenu()
         menu.autoenablesItems = false
+        menu.delegate = SleepTimerManager.shared
 
         let manager = SleepTimerManager.shared
 
         if let description = manager.menuDescription {
             let status = NSMenuItem(title: description, action: nil, keyEquivalent: "")
+            status.tag = SleepTimerManager.menuStatusItemTag
             status.isEnabled = false
             menu.addItem(status)
 

--- a/Sources/NullPlayer/App/ContextMenuBuilder.swift
+++ b/Sources/NullPlayer/App/ContextMenuBuilder.swift
@@ -224,13 +224,17 @@ class ContextMenuBuilder {
 
         menu.addItem(NSMenuItem.separator())
 
+        let hasActiveTrack = WindowManager.shared.audioEngine.currentTrack != nil
+
         let endOfTrack = NSMenuItem(title: "End of Current Track", action: #selector(MenuActions.startSleepTimerEndOfTrack), keyEquivalent: "")
         endOfTrack.target = MenuActions.shared
+        endOfTrack.isEnabled = hasActiveTrack
         if manager.state?.mode == .endOfTrack { endOfTrack.state = .on }
         menu.addItem(endOfTrack)
 
         let endOfQueue = NSMenuItem(title: "End of Queue", action: #selector(MenuActions.startSleepTimerEndOfQueue), keyEquivalent: "")
         endOfQueue.target = MenuActions.shared
+        endOfQueue.isEnabled = hasActiveTrack
         if manager.state?.mode == .endOfQueue { endOfQueue.state = .on }
         menu.addItem(endOfQueue)
 

--- a/Sources/NullPlayer/App/ContextMenuBuilder.swift
+++ b/Sources/NullPlayer/App/ContextMenuBuilder.swift
@@ -33,6 +33,13 @@ class ContextMenuBuilder {
             menu.addItem(NSMenuItem.separator())
         }
 
+        // Sleep Timer submenu
+        let sleepTimerItem = NSMenuItem(title: "Sleep Timer", action: nil, keyEquivalent: "")
+        sleepTimerItem.submenu = buildSleepTimerMenu()
+        if SleepTimerManager.shared.isActive { sleepTimerItem.state = .on }
+        menu.addItem(sleepTimerItem)
+        menu.addItem(NSMenuItem.separator())
+
         // Output Devices submenu
         if includeOutputDevices {
             menu.addItem(buildOutputDevicesMenuItem())

--- a/Sources/NullPlayer/App/SleepTimerManager.swift
+++ b/Sources/NullPlayer/App/SleepTimerManager.swift
@@ -15,7 +15,7 @@ import AppKit
 // State is session-local (not persisted across launches).
 // =============================================================================
 
-final class SleepTimerManager {
+final class SleepTimerManager: NSObject {
     static let shared = SleepTimerManager()
 
     // MARK: - Notifications
@@ -58,8 +58,13 @@ final class SleepTimerManager {
     private var fadeStartVolume: Float?
     private var lastWrittenVolume: Float?
     private var isFading: Bool = false
+    private var menuUpdateTimer: Timer?
 
-    private init() {
+    // Tag used to locate the status item inside the sleep timer submenu for live updates.
+    static let menuStatusItemTag = 100
+
+    private override init() {
+        super.init()
         // Observe natural track completion (fires BEFORE currentTrack advances).
         // Used by both endOfTrack and endOfQueue modes.
         NotificationCenter.default.addObserver(
@@ -241,5 +246,24 @@ final class SleepTimerManager {
         case .endOfTrack: return "Sleep Timer: End of track"
         case .endOfQueue: return "Sleep Timer: End of queue"
         }
+    }
+}
+
+// MARK: - NSMenuDelegate (live countdown refresh)
+
+extension SleepTimerManager: NSMenuDelegate {
+    func menuWillOpen(_ menu: NSMenu) {
+        guard state?.mode == .timed else { return }
+        let tt = Timer(timeInterval: 1.0, repeats: true) { [weak menu] _ in
+            guard let item = menu?.item(withTag: SleepTimerManager.menuStatusItemTag) else { return }
+            item.title = SleepTimerManager.shared.menuDescription ?? ""
+        }
+        RunLoop.main.add(tt, forMode: .common)
+        menuUpdateTimer = tt
+    }
+
+    func menuDidClose(_ menu: NSMenu) {
+        menuUpdateTimer?.invalidate()
+        menuUpdateTimer = nil
     }
 }

--- a/Sources/NullPlayer/App/SleepTimerManager.swift
+++ b/Sources/NullPlayer/App/SleepTimerManager.swift
@@ -1,0 +1,245 @@
+import Foundation
+import AppKit
+
+// =============================================================================
+// SLEEP TIMER MANAGER
+// =============================================================================
+// Schedules an automatic pause/stop after a configurable duration.
+//
+// Three modes:
+//   1. Timed:       Pause/stop after N minutes (with optional volume fade-out)
+//   2. EndOfTrack:  Pause/stop when the current track finishes naturally
+//   3. EndOfQueue:  Pause/stop when the last playlist track finishes
+//
+// All public methods must be called from the main thread.
+// State is session-local (not persisted across launches).
+// =============================================================================
+
+final class SleepTimerManager {
+    static let shared = SleepTimerManager()
+
+    // MARK: - Notifications
+
+    static let stateDidChangeNotification = Notification.Name("NullPlayer.SleepTimer.stateDidChange")
+
+    // MARK: - Types
+
+    enum Mode: String { case timed, endOfTrack, endOfQueue }
+    enum Action: String { case pause, stop }
+
+    struct State {
+        let mode: Mode
+        let action: Action
+        let fireDate: Date?
+        let originalDuration: TimeInterval?
+        let fadeOut: Bool
+        let fadeOutSeconds: TimeInterval
+    }
+
+    // MARK: - Public State
+
+    private(set) var state: State?
+    var isActive: Bool { state != nil }
+
+    var remainingSeconds: TimeInterval? {
+        guard let state, let fire = state.fireDate else { return nil }
+        return max(0, fire.timeIntervalSinceNow)
+    }
+
+    // MARK: - Config
+
+    static let timedChoicesMinutes: [Int] = [5, 10, 15, 30, 45, 60, 90, 120]
+    static let defaultFadeOutSeconds: TimeInterval = 10
+
+    // MARK: - Internal
+
+    private var timer: Timer?
+    private var tickTimer: Timer?
+    private var fadeStartVolume: Float?
+    private var lastWrittenVolume: Float?
+    private var isFading: Bool = false
+
+    private init() {
+        // Observe natural track completion (fires BEFORE currentTrack advances).
+        // This lets endOfTrack mode distinguish natural completion from user skip.
+        NotificationCenter.default.addObserver(
+            self,
+            selector: #selector(trackDidFinishNaturally),
+            name: .audioTrackDidFinishNaturally,
+            object: nil
+        )
+        // Observe track changes for endOfQueue mode (nil track = queue ended).
+        NotificationCenter.default.addObserver(
+            self,
+            selector: #selector(trackDidChange),
+            name: .audioTrackDidChange,
+            object: nil
+        )
+    }
+
+    // MARK: - Public API
+
+    func startTimed(minutes: Int, action: Action = .pause, fadeOut: Bool = true) {
+        dispatchPrecondition(condition: .onQueue(.main))
+        cancel()
+        let duration = TimeInterval(max(1, minutes) * 60)
+        let fireDate = Date().addingTimeInterval(duration)
+        state = State(
+            mode: .timed, action: action, fireDate: fireDate,
+            originalDuration: duration, fadeOut: fadeOut,
+            fadeOutSeconds: Self.defaultFadeOutSeconds
+        )
+        fadeStartVolume = nil
+        lastWrittenVolume = nil
+        isFading = false
+        timer = Timer.scheduledTimer(withTimeInterval: duration, repeats: false) { [weak self] _ in
+            self?.fire()
+        }
+        tickTimer = Timer.scheduledTimer(withTimeInterval: 1.0, repeats: true) { [weak self] _ in
+            self?.tick()
+        }
+        notifyChange()
+    }
+
+    func startEndOfTrack(action: Action = .pause) {
+        dispatchPrecondition(condition: .onQueue(.main))
+        cancel()
+        state = State(
+            mode: .endOfTrack, action: action, fireDate: nil,
+            originalDuration: nil, fadeOut: false, fadeOutSeconds: 0
+        )
+        notifyChange()
+    }
+
+    func startEndOfQueue(action: Action = .pause) {
+        dispatchPrecondition(condition: .onQueue(.main))
+        cancel()
+        state = State(
+            mode: .endOfQueue, action: action, fireDate: nil,
+            originalDuration: nil, fadeOut: false, fadeOutSeconds: 0
+        )
+        notifyChange()
+    }
+
+    func cancel() {
+        dispatchPrecondition(condition: .onQueue(.main))
+        timer?.invalidate(); timer = nil
+        tickTimer?.invalidate(); tickTimer = nil
+        if isFading, let startVolume = fadeStartVolume {
+            let currentVolume = WindowManager.shared.audioEngine.volume
+            if let lastWritten = lastWrittenVolume,
+               abs(currentVolume - lastWritten) < 0.01 {
+                WindowManager.shared.audioEngine.volume = startVolume
+            }
+        }
+        fadeStartVolume = nil
+        lastWrittenVolume = nil
+        isFading = false
+        let wasActive = state != nil
+        state = nil
+        if wasActive { notifyChange() }
+    }
+
+    // MARK: - Tick / Fade
+
+    private func tick() {
+        guard let state, let fire = state.fireDate else { return }
+        let remaining = max(0, fire.timeIntervalSinceNow)
+        if state.fadeOut, state.fadeOutSeconds > 0, remaining <= state.fadeOutSeconds, !isFading {
+            beginFade(over: remaining)
+        } else if isFading {
+            if let lastWritten = lastWrittenVolume {
+                let currentVolume = WindowManager.shared.audioEngine.volume
+                if abs(currentVolume - lastWritten) > 0.01 {
+                    isFading = false
+                    fadeStartVolume = nil
+                    lastWrittenVolume = nil
+                    return
+                }
+            }
+            updateFade(remaining: remaining)
+        }
+        notifyChange()
+    }
+
+    private func beginFade(over remaining: TimeInterval) {
+        fadeStartVolume = WindowManager.shared.audioEngine.volume
+        lastWrittenVolume = nil
+        isFading = true
+        updateFade(remaining: remaining)
+    }
+
+    private func updateFade(remaining: TimeInterval) {
+        guard let state, let startVolume = fadeStartVolume else { return }
+        let progress = max(0, min(1, 1.0 - (max(0, remaining) / max(0.001, state.fadeOutSeconds))))
+        let newVolume = max(0, startVolume * Float(1.0 - progress))
+        WindowManager.shared.audioEngine.volume = newVolume
+        lastWrittenVolume = newVolume
+    }
+
+    // MARK: - Firing
+
+    private func fire() {
+        guard let state else { return }
+        applyAction(state.action)
+        if isFading, let startVolume = fadeStartVolume {
+            if let lastWritten = lastWrittenVolume,
+               abs(WindowManager.shared.audioEngine.volume - lastWritten) < 0.01 {
+                WindowManager.shared.audioEngine.volume = startVolume
+            }
+        }
+        timer?.invalidate(); timer = nil
+        tickTimer?.invalidate(); tickTimer = nil
+        self.state = nil
+        fadeStartVolume = nil
+        lastWrittenVolume = nil
+        isFading = false
+        notifyChange()
+    }
+
+    private func applyAction(_ action: Action) {
+        switch action {
+        case .pause: WindowManager.shared.audioEngine.pause()
+        case .stop:  WindowManager.shared.audioEngine.stop()
+        }
+    }
+
+    // MARK: - Track Completion Handlers
+
+    /// Fired when a track finishes playing naturally (BEFORE currentTrack advances).
+    /// This is the correct signal for endOfTrack mode.
+    @objc private func trackDidFinishNaturally(_ note: Notification) {
+        dispatchPrecondition(condition: .onQueue(.main))
+        guard let state, state.mode == .endOfTrack else { return }
+        fire()
+    }
+
+    /// Fired when currentTrack changes (AFTER advancement).
+    /// Used only for endOfQueue mode: fire when currentTrack becomes nil (queue ended).
+    @objc private func trackDidChange(_ note: Notification) {
+        dispatchPrecondition(condition: .onQueue(.main))
+        guard let state, state.mode == .endOfQueue else { return }
+        if WindowManager.shared.audioEngine.currentTrack == nil {
+            fire()
+        }
+    }
+
+    // MARK: - Helpers
+
+    private func notifyChange() {
+        NotificationCenter.default.post(name: Self.stateDidChangeNotification, object: nil)
+    }
+
+    var menuDescription: String? {
+        guard let state else { return nil }
+        switch state.mode {
+        case .timed:
+            guard let remaining = remainingSeconds else { return "Sleep Timer" }
+            let minutes = Int(remaining) / 60
+            let seconds = Int(remaining) % 60
+            return String(format: "Sleep Timer: %d:%02d", minutes, seconds)
+        case .endOfTrack: return "Sleep Timer: End of track"
+        case .endOfQueue: return "Sleep Timer: End of queue"
+        }
+    }
+}

--- a/Sources/NullPlayer/App/SleepTimerManager.swift
+++ b/Sources/NullPlayer/App/SleepTimerManager.swift
@@ -222,11 +222,12 @@ final class SleepTimerManager: NSObject {
     }
 
     /// Fired when the queue exhausts naturally (last track finished, no next track).
+    /// Always delivered on the main thread — handle synchronously so fire() runs
+    /// before AudioEngine decides whether to call stop().
     @objc private func queueDidExhaust(_ note: Notification) {
-        DispatchQueue.main.async { [weak self] in
-            guard let self, let state = self.state, state.mode == .endOfQueue else { return }
-            self.fire()
-        }
+        dispatchPrecondition(condition: .onQueue(.main))
+        guard let state, state.mode == .endOfQueue else { return }
+        fire()
     }
 
     // MARK: - Helpers

--- a/Sources/NullPlayer/App/SleepTimerManager.swift
+++ b/Sources/NullPlayer/App/SleepTimerManager.swift
@@ -61,18 +61,18 @@ final class SleepTimerManager {
 
     private init() {
         // Observe natural track completion (fires BEFORE currentTrack advances).
-        // This lets endOfTrack mode distinguish natural completion from user skip.
+        // Used by both endOfTrack and endOfQueue modes.
         NotificationCenter.default.addObserver(
             self,
             selector: #selector(trackDidFinishNaturally),
             name: .audioTrackDidFinishNaturally,
             object: nil
         )
-        // Observe track changes for endOfQueue mode (nil track = queue ended).
+        // Observe queue exhaustion for endOfQueue mode.
         NotificationCenter.default.addObserver(
             self,
-            selector: #selector(trackDidChange),
-            name: .audioTrackDidChange,
+            selector: #selector(queueDidExhaust),
+            name: .audioQueueDidExhaust,
             object: nil
         )
     }
@@ -92,12 +92,12 @@ final class SleepTimerManager {
         fadeStartVolume = nil
         lastWrittenVolume = nil
         isFading = false
-        timer = Timer.scheduledTimer(withTimeInterval: duration, repeats: false) { [weak self] _ in
-            self?.fire()
-        }
-        tickTimer = Timer.scheduledTimer(withTimeInterval: 1.0, repeats: true) { [weak self] _ in
-            self?.tick()
-        }
+        let t = Timer(timeInterval: duration, repeats: false) { [weak self] _ in self?.fire() }
+        RunLoop.main.add(t, forMode: .common)
+        timer = t
+        let tt = Timer(timeInterval: 1.0, repeats: true) { [weak self] _ in self?.tick() }
+        RunLoop.main.add(tt, forMode: .common)
+        tickTimer = tt
         notifyChange()
     }
 
@@ -154,6 +154,7 @@ final class SleepTimerManager {
                     isFading = false
                     fadeStartVolume = nil
                     lastWrittenVolume = nil
+                    notifyChange()
                     return
                 }
             }
@@ -207,20 +208,19 @@ final class SleepTimerManager {
     // MARK: - Track Completion Handlers
 
     /// Fired when a track finishes playing naturally (BEFORE currentTrack advances).
-    /// This is the correct signal for endOfTrack mode.
+    /// Handles endOfTrack mode; also fires before crossfade transitions.
     @objc private func trackDidFinishNaturally(_ note: Notification) {
-        dispatchPrecondition(condition: .onQueue(.main))
-        guard let state, state.mode == .endOfTrack else { return }
-        fire()
+        DispatchQueue.main.async { [weak self] in
+            guard let self, let state = self.state, state.mode == .endOfTrack else { return }
+            self.fire()
+        }
     }
 
-    /// Fired when currentTrack changes (AFTER advancement).
-    /// Used only for endOfQueue mode: fire when currentTrack becomes nil (queue ended).
-    @objc private func trackDidChange(_ note: Notification) {
-        dispatchPrecondition(condition: .onQueue(.main))
-        guard let state, state.mode == .endOfQueue else { return }
-        if WindowManager.shared.audioEngine.currentTrack == nil {
-            fire()
+    /// Fired when the queue exhausts naturally (last track finished, no next track).
+    @objc private func queueDidExhaust(_ note: Notification) {
+        DispatchQueue.main.async { [weak self] in
+            guard let self, let state = self.state, state.mode == .endOfQueue else { return }
+            self.fire()
         }
     }
 

--- a/Sources/NullPlayer/App/SleepTimerManager.swift
+++ b/Sources/NullPlayer/App/SleepTimerManager.swift
@@ -48,7 +48,7 @@ final class SleepTimerManager: NSObject {
 
     // MARK: - Config
 
-    static let timedChoicesMinutes: [Int] = [5, 10, 15, 30, 45, 60, 90, 120]
+    static let timedChoicesMinutes: [Int] = [5, 10, 15, 30, 45, 60, 90, 120, 300, 480, 720]
     static let defaultFadeOutSeconds: TimeInterval = 10
 
     // MARK: - Internal

--- a/Sources/NullPlayer/Audio/AudioEngine.swift
+++ b/Sources/NullPlayer/Audio/AudioEngine.swift
@@ -37,10 +37,15 @@ extension Notification.Name {
     static let bpmUpdated = Notification.Name("bpmUpdated")
 
     /// Posted when a track finishes playing naturally (not skipped by user).
-    /// Fired from `trackDidFinish()` BEFORE `currentTrack` advances to the next track.
+    /// Always delivered on the main thread.
+    /// Fired from `trackDidFinish()` and crossfade-complete paths BEFORE `currentTrack` advances.
     /// userInfo contains: "track" (Track) - the track that just finished
-    /// Used by SleepTimerManager to distinguish natural completion from manual skip.
     static let audioTrackDidFinishNaturally = Notification.Name("audioTrackDidFinishNaturally")
+
+    /// Posted when the last track in the queue finishes naturally (queue exhausted).
+    /// Always delivered on the main thread.
+    /// Fired from `trackDidFinish()` immediately before `stop()` when no next track exists.
+    static let audioQueueDidExhaust = Notification.Name("audioQueueDidExhaust")
 
 }
 
@@ -3943,7 +3948,7 @@ class AudioEngine {
             if shuffleEnabled {
                 // Repeat mode + shuffle: follow the shuffled cycle, reshuffling only after a full pass
                 guard let nextIndex = peekNextShuffleIndexForPlayback() else {
-                    stop()
+                    stopAfterQueueExhausted()
                     return
                 }
                 currentIndex = nextIndex
@@ -3956,7 +3961,7 @@ class AudioEngine {
             // No repeat mode: check if we're at the end of playlist
             if shuffleEnabled {
                 guard let nextIndex = peekNextShuffleIndexForPlayback() else {
-                    stop()
+                    stopAfterQueueExhausted()
                     return
                 }
                 currentIndex = nextIndex
@@ -3967,9 +3972,14 @@ class AudioEngine {
                 advanceToLocalTrackAsync(at: currentIndex)
             } else {
                 // End of playlist, stop playback
-                stop()
+                stopAfterQueueExhausted()
             }
         }
+    }
+
+    private func stopAfterQueueExhausted() {
+        NotificationCenter.default.post(name: .audioQueueDidExhaust, object: self)
+        stop()
     }
 
     /// Advance playback to the track at `index` after a natural EOF.
@@ -4390,6 +4400,15 @@ class AudioEngine {
             }
         }
 
+        // Notify natural track completion before advancing (allows endOfTrack sleep timer to fire)
+        if let outgoing = currentTrack {
+            NotificationCenter.default.post(
+                name: .audioTrackDidFinishNaturally,
+                object: self,
+                userInfo: ["track": outgoing]
+            )
+        }
+
         // Update state
         audioFile = nextFile
         currentIndex = nextIndex
@@ -4399,11 +4418,11 @@ class AudioEngine {
         lastReportedTime = 0
         playbackStartDate = Date()
         suspendedLocalPlaybackClockForSleep = false
-        
+
         // Reset crossfade state
         isCrossfading = false
         crossfadeTargetIndex = -1
-        
+
         // Notify delegate
         delegate?.audioEngineDidChangeTrack(currentTrack)
         
@@ -4499,6 +4518,15 @@ class AudioEngine {
                         id: eventId, title: track.title, artist: track.artist, album: track.album)
                 }
             }
+        }
+
+        // Notify natural track completion before advancing (allows endOfTrack sleep timer to fire)
+        if let outgoing = currentTrack {
+            NotificationCenter.default.post(
+                name: .audioTrackDidFinishNaturally,
+                object: self,
+                userInfo: ["track": outgoing]
+            )
         }
 
         // Update state

--- a/Sources/NullPlayer/Audio/AudioEngine.swift
+++ b/Sources/NullPlayer/Audio/AudioEngine.swift
@@ -3978,8 +3978,14 @@ class AudioEngine {
     }
 
     private func stopAfterQueueExhausted() {
+        // Check before posting — the notification is delivered synchronously on the main
+        // thread, so SleepTimerManager.fire() runs before we decide whether to stop().
+        // If it's handling end-of-queue it will call pause() or stop() itself.
+        let sleepTimerHandling = SleepTimerManager.shared.state?.mode == .endOfQueue
         NotificationCenter.default.post(name: .audioQueueDidExhaust, object: self)
-        stop()
+        if !sleepTimerHandling {
+            stop()
+        }
     }
 
     /// Advance playback to the track at `index` after a natural EOF.

--- a/Sources/NullPlayer/Audio/AudioEngine.swift
+++ b/Sources/NullPlayer/Audio/AudioEngine.swift
@@ -35,7 +35,13 @@ extension Notification.Name {
     /// Posted when BPM detection updates
     /// userInfo contains: "bpm" (Int) - 0 means no confident reading
     static let bpmUpdated = Notification.Name("bpmUpdated")
-    
+
+    /// Posted when a track finishes playing naturally (not skipped by user).
+    /// Fired from `trackDidFinish()` BEFORE `currentTrack` advances to the next track.
+    /// userInfo contains: "track" (Track) - the track that just finished
+    /// Used by SleepTimerManager to distinguish natural completion from manual skip.
+    static let audioTrackDidFinishNaturally = Notification.Name("audioTrackDidFinishNaturally")
+
 }
 
 /// Audio playback state
@@ -3763,7 +3769,17 @@ class AudioEngine {
             NSLog("trackDidFinish: Ignoring during crossfade")
             return
         }
-        
+
+        // Notify observers that the current track finished naturally BEFORE advancing.
+        // This lets SleepTimerManager distinguish natural completion from user skip.
+        if let finishedTrack = currentTrack {
+            NotificationCenter.default.post(
+                name: .audioTrackDidFinishNaturally,
+                object: self,
+                userInfo: ["track": finishedTrack]
+            )
+        }
+
         // Report track finished to Plex (natural end)
         let finishPosition = duration
         PlexPlaybackReporter.shared.trackDidStop(at: finishPosition, finished: true)

--- a/Sources/NullPlayer/ModernSkin/ModernSkinElements.swift
+++ b/Sources/NullPlayer/ModernSkin/ModernSkinElements.swift
@@ -88,14 +88,14 @@ enum ModernSkinElements {
     static let infoBitrate = Element("info_bitrate", NSRect(x: 95, y: 62, width: 40, height: 9))
     static let infoSampleRate = Element("info_samplerate", NSRect(x: 135, y: 62, width: 30, height: 9))
     static let infoBPM = Element("info_bpm", NSRect(x: 165, y: 62, width: 26, height: 9))
-    /// Sleep timer active indicator — shows "Z" when sleep timer is running.
-    /// Centered in the 2px gap on each side between infoBPM (right=191) and infoStereo (left=200).
-    static let infoSleepTimer = Element("info_sleep_timer", NSRect(x: 193, y: 62, width: 5, height: 9))
-    static let infoStereo = Element("info_stereo", NSRect(x: 200, y: 62, width: 30, height: 9),
+    /// Sleep timer active indicator — shows "Zz" when sleep timer is running.
+    /// 2px gap on each side between infoBPM (right=191) and infoStereo (left=205).
+    static let infoSleepTimer = Element("info_sleep_timer", NSRect(x: 193, y: 62, width: 10, height: 9))
+    static let infoStereo = Element("info_stereo", NSRect(x: 205, y: 62, width: 28, height: 9),
                                     states: ["off", "on"])
-    static let infoMono = Element("info_mono", NSRect(x: 200, y: 62, width: 30, height: 9),
+    static let infoMono = Element("info_mono", NSRect(x: 205, y: 62, width: 28, height: 9),
                                   states: ["off", "on"])
-    static let infoCast = Element("info_cast", NSRect(x: 232, y: 62, width: 32, height: 9),
+    static let infoCast = Element("info_cast", NSRect(x: 235, y: 62, width: 29, height: 9),
                                   states: ["off", "on"])
     
     // MARK: - Status Indicator (left of time display)

--- a/Sources/NullPlayer/ModernSkin/ModernSkinElements.swift
+++ b/Sources/NullPlayer/ModernSkin/ModernSkinElements.swift
@@ -91,9 +91,9 @@ enum ModernSkinElements {
     /// Sleep timer active indicator — shows "Zz" when sleep timer is running.
     /// 2px gap on each side between infoBPM (right=191) and infoStereo (left=205).
     static let infoSleepTimer = Element("info_sleep_timer", NSRect(x: 193, y: 62, width: 10, height: 9))
-    static let infoStereo = Element("info_stereo", NSRect(x: 205, y: 62, width: 28, height: 9),
+    static let infoStereo = Element("info_stereo", NSRect(x: 204, y: 62, width: 28, height: 9),
                                     states: ["off", "on"])
-    static let infoMono = Element("info_mono", NSRect(x: 205, y: 62, width: 28, height: 9),
+    static let infoMono = Element("info_mono", NSRect(x: 204, y: 62, width: 28, height: 9),
                                   states: ["off", "on"])
     static let infoCast = Element("info_cast", NSRect(x: 235, y: 62, width: 29, height: 9),
                                   states: ["off", "on"])

--- a/Sources/NullPlayer/ModernSkin/ModernSkinElements.swift
+++ b/Sources/NullPlayer/ModernSkin/ModernSkinElements.swift
@@ -83,16 +83,19 @@ enum ModernSkinElements {
     static let marqueeBackground = Element("marquee_bg", NSRect(x: 93, y: 60, width: 176, height: 34))
     
     /// Info labels row (below marquee text, inside marquee panel)
-    /// Layout: [bitrate] [samplerate] [bpm] [stereo/mono] [casting]
+    /// Layout: [bitrate] [samplerate] [bpm] [z] [stereo/mono] [casting]
     /// Total available width: x:95 to x:267 = 172 units
     static let infoBitrate = Element("info_bitrate", NSRect(x: 95, y: 62, width: 40, height: 9))
     static let infoSampleRate = Element("info_samplerate", NSRect(x: 135, y: 62, width: 30, height: 9))
-    static let infoBPM = Element("info_bpm", NSRect(x: 165, y: 62, width: 30, height: 9))
-    static let infoStereo = Element("info_stereo", NSRect(x: 198, y: 62, width: 32, height: 9),
+    static let infoBPM = Element("info_bpm", NSRect(x: 165, y: 62, width: 26, height: 9))
+    /// Sleep timer active indicator — shows "Z" when sleep timer is running.
+    /// Centered in the 2px gap on each side between infoBPM (right=191) and infoStereo (left=200).
+    static let infoSleepTimer = Element("info_sleep_timer", NSRect(x: 193, y: 62, width: 5, height: 9))
+    static let infoStereo = Element("info_stereo", NSRect(x: 200, y: 62, width: 30, height: 9),
                                     states: ["off", "on"])
-    static let infoMono = Element("info_mono", NSRect(x: 198, y: 62, width: 32, height: 9),
+    static let infoMono = Element("info_mono", NSRect(x: 200, y: 62, width: 30, height: 9),
                                   states: ["off", "on"])
-    static let infoCast = Element("info_cast", NSRect(x: 230, y: 62, width: 34, height: 9),
+    static let infoCast = Element("info_cast", NSRect(x: 232, y: 62, width: 32, height: 9),
                                   states: ["off", "on"])
     
     // MARK: - Status Indicator (left of time display)
@@ -332,7 +335,7 @@ enum ModernSkinElements {
         titleBar, titleBarText, btnClose, btnMinimize, btnShade,
         timeDisplay,
         marqueeBackground,
-        infoBitrate, infoSampleRate, infoBPM, infoStereo, infoMono, infoCast,
+        infoBitrate, infoSampleRate, infoBPM, infoSleepTimer, infoStereo, infoMono, infoCast,
         statusPlay, statusPause, statusStop,
         spectrumArea,
         btn2x, btnEQ, btnPlaylist, btnLibrary, btnProjectM, btnSpectrum,

--- a/Sources/NullPlayer/ModernSkin/ModernSkinElements.swift
+++ b/Sources/NullPlayer/ModernSkin/ModernSkinElements.swift
@@ -91,11 +91,11 @@ enum ModernSkinElements {
     /// Sleep timer active indicator — shows "Zz" when sleep timer is running.
     /// 2px gap on each side between infoBPM (right=191) and infoStereo (left=205).
     static let infoSleepTimer = Element("info_sleep_timer", NSRect(x: 193, y: 62, width: 10, height: 9))
-    static let infoStereo = Element("info_stereo", NSRect(x: 204, y: 62, width: 28, height: 9),
+    static let infoStereo = Element("info_stereo", NSRect(x: 235, y: 62, width: 29, height: 9),
                                     states: ["off", "on"])
-    static let infoMono = Element("info_mono", NSRect(x: 204, y: 62, width: 28, height: 9),
+    static let infoMono = Element("info_mono", NSRect(x: 235, y: 62, width: 29, height: 9),
                                   states: ["off", "on"])
-    static let infoCast = Element("info_cast", NSRect(x: 235, y: 62, width: 29, height: 9),
+    static let infoCast = Element("info_cast", NSRect(x: 204, y: 62, width: 28, height: 9),
                                   states: ["off", "on"])
     
     // MARK: - Status Indicator (left of time display)

--- a/Sources/NullPlayer/ModernSkin/ModernSkinElements.swift
+++ b/Sources/NullPlayer/ModernSkin/ModernSkinElements.swift
@@ -91,11 +91,11 @@ enum ModernSkinElements {
     /// Sleep timer active indicator — shows "Zz" when sleep timer is running.
     /// 2px gap on each side between infoBPM (right=191) and infoStereo (left=205).
     static let infoSleepTimer = Element("info_sleep_timer", NSRect(x: 193, y: 62, width: 10, height: 9))
-    static let infoStereo = Element("info_stereo", NSRect(x: 235, y: 62, width: 29, height: 9),
+    static let infoStereo = Element("info_stereo", NSRect(x: 237, y: 62, width: 27, height: 9),
                                     states: ["off", "on"])
-    static let infoMono = Element("info_mono", NSRect(x: 235, y: 62, width: 29, height: 9),
+    static let infoMono = Element("info_mono", NSRect(x: 237, y: 62, width: 27, height: 9),
                                   states: ["off", "on"])
-    static let infoCast = Element("info_cast", NSRect(x: 204, y: 62, width: 28, height: 9),
+    static let infoCast = Element("info_cast", NSRect(x: 204, y: 62, width: 32, height: 9),
                                   states: ["off", "on"])
     
     // MARK: - Status Indicator (left of time display)

--- a/Sources/NullPlayer/Windows/ModernMainWindow/ModernMainWindowView.swift
+++ b/Sources/NullPlayer/Windows/ModernMainWindow/ModernMainWindowView.swift
@@ -695,22 +695,20 @@ class ModernMainWindowView: NSView {
                                font: smallFont, color: infoColor, context: context)
         }
 
-        // Stereo/Mono -- brighter, with glow
+        // Stereo/Mono
         let isStereo = currentTrack?.channels ?? 2 >= 2
         let stereoLabel = isStereo ? "STEREO" : "MONO"
-        renderer.drawLabelWithGlow(stereoLabel,
-                                   in: ModernSkinElements.infoStereo.defaultRect,
-                                   font: smallFont, color: skin.textColor,
-                                   alignment: .right, context: context)
-        
-        // Casting indicator -- bright accent when active, hidden when off
-        let isCasting = CastManager.shared.isCasting
-        if isCasting {
-            let castColor = skin.elementColor(for: "info_cast")
-            renderer.drawLabelWithGlow("CASTING",
-                                       in: ModernSkinElements.infoCast.defaultRect,
-                                       font: smallFont, color: castColor,
-                                       alignment: .right, context: context)
+        renderer.drawLabel(stereoLabel,
+                           in: ModernSkinElements.infoStereo.defaultRect,
+                           font: smallFont, color: infoColor,
+                           alignment: .right, context: context)
+
+        // Casting indicator — hidden when off
+        if CastManager.shared.isCasting {
+            renderer.drawLabel("CASTING",
+                               in: ModernSkinElements.infoCast.defaultRect,
+                               font: smallFont, color: infoColor,
+                               alignment: .right, context: context)
         }
     }
     

--- a/Sources/NullPlayer/Windows/ModernMainWindow/ModernMainWindowView.swift
+++ b/Sources/NullPlayer/Windows/ModernMainWindow/ModernMainWindowView.swift
@@ -141,6 +141,10 @@ class ModernMainWindowView: NSView {
         NotificationCenter.default.addObserver(self, selector: #selector(playbackOptionsDidChange),
                                                 name: .audioPlaybackOptionsChanged, object: nil)
 
+        // Observe sleep timer state changes to show/hide the Z indicator
+        NotificationCenter.default.addObserver(self, selector: #selector(sleepTimerStateDidChange),
+                                                name: SleepTimerManager.stateDidChangeNotification, object: nil)
+
         // Observe main window vis mode changes from context menu
         NotificationCenter.default.addObserver(self, selector: #selector(mainVisSettingsChanged),
                                                 name: NSNotification.Name("MainWindowVisChanged"), object: nil)
@@ -684,6 +688,15 @@ class ModernMainWindowView: NSView {
                                font: smallFont, color: infoColor, context: context)
         }
         
+        // Sleep timer indicator — "Z" between BPM and stereo when active
+        if SleepTimerManager.shared.isActive {
+            let sleepColor = skin.elementColor(for: "info_sleep_timer", fallback: skin.textColor)
+            renderer.drawLabelWithGlow("Z",
+                                       in: ModernSkinElements.infoSleepTimer.defaultRect,
+                                       font: smallFont, color: sleepColor,
+                                       alignment: .center, context: context)
+        }
+
         // Stereo/Mono -- brighter, with glow
         let isStereo = currentTrack?.channels ?? 2 >= 2
         let stereoLabel = isStereo ? "STEREO" : "MONO"
@@ -992,6 +1005,11 @@ class ModernMainWindowView: NSView {
         guard newBPM != currentBPM else { return }
         currentBPM = newBPM
         // Only invalidate the info panel area where BPM is displayed
+        let infoRect = scaledRect(effectiveMarqueePanelRect)
+        setNeedsDisplay(infoRect)
+    }
+
+    @objc private func sleepTimerStateDidChange() {
         let infoRect = scaledRect(effectiveMarqueePanelRect)
         setNeedsDisplay(infoRect)
     }

--- a/Sources/NullPlayer/Windows/ModernMainWindow/ModernMainWindowView.swift
+++ b/Sources/NullPlayer/Windows/ModernMainWindow/ModernMainWindowView.swift
@@ -688,13 +688,11 @@ class ModernMainWindowView: NSView {
                                font: smallFont, color: infoColor, context: context)
         }
         
-        // Sleep timer indicator — "Z" between BPM and stereo when active
+        // Sleep timer indicator — "Zz" between BPM and stereo when active, dim like BPM
         if SleepTimerManager.shared.isActive {
-            let sleepColor = skin.elementColor(for: "info_sleep_timer", fallback: skin.textColor)
-            renderer.drawLabelWithGlow("Z",
-                                       in: ModernSkinElements.infoSleepTimer.defaultRect,
-                                       font: smallFont, color: sleepColor,
-                                       alignment: .center, context: context)
+            renderer.drawLabel("Zz",
+                               in: ModernSkinElements.infoSleepTimer.defaultRect,
+                               font: smallFont, color: infoColor, context: context)
         }
 
         // Stereo/Mono -- brighter, with glow

--- a/skills/user-guide/SKILL.md
+++ b/skills/user-guide/SKILL.md
@@ -198,6 +198,24 @@ Import discovery is now unified across classic + modern entry points (main windo
 - **Volume Normalization**: Consistent loudness (-14dB target)
 - **Remember State on Quit**: Restore session on launch
 
+### Sleep Timer
+Accessible via **Playback > Sleep Timer** (or the right-click context menu).
+
+**Modes**
+| Mode | Behaviour |
+|------|-----------|
+| **Timed** | Pause/stop after 5, 10, 15, 30, 45, 60, or 90 minutes, or 2, 5, 8, or 12 hours. A 10-second linear volume fade-out fires before the action. |
+| **End of Current Track** | Pause/stop when the currently playing track ends naturally. Does **not** fire on manual skip or previous. Works correctly with Sweet Fades crossfade. |
+| **End of Queue** | Pause/stop when the last track in the playlist finishes. |
+
+**Behaviour notes**
+- The submenu shows a live countdown (`Sleep Timer: 1:23`) while a timed timer is running.
+- Selecting the currently active preset again cancels it (toggle behaviour).
+- A **Cancel Sleep Timer** item appears at the top of the submenu while any timer is active.
+- If the volume is adjusted manually during a timed fade-out, the fade aborts and the volume is left at the new level.
+- If a timed timer is cancelled mid-fade, volume is restored to the level it was at when the timer started.
+- State is session-local — not persisted across launches.
+
 ### Spectrum Modes
 - **Accurate**: True signal levels (40dB range)
 - **Adaptive**: Global adaptive normalization


### PR DESCRIPTION
Supersedes #162. Incorporates jhmk's original implementation plus all review fixes and follow-on work.

## Changes from #162

**Bug fixes (from PR review)**
- `endOfQueue` mode never fired — replaced broken `audioTrackDidChange` observation with new `audioQueueDidExhaust` notification posted from all natural queue-end sites in `trackDidFinish()`
- `endOfTrack` failed with Sweet Fades — `audioTrackDidFinishNaturally` now posted from `completeCrossfade()` and `completeStreamingCrossfade()` before advancing `currentTrack`
- Timers use `.common` run loop mode so fire/tick callbacks continue during menu tracking
- Notification handlers use `DispatchQueue.main.async` instead of `dispatchPrecondition` (crash on background delivery)
- `endOfTrack`/`endOfQueue` menu items disabled when no track is playing
- `tick()` calls `notifyChange()` on fade-abort early return

**Enhancements**
- Added 5, 8, and 12 hour timed options
- Live countdown in submenu — `SleepTimerManager` conforms to `NSMenuDelegate`; a 1s `.common`-mode timer rewrites the status item title while the submenu is open

**Modern window info row**
- `Zz` indicator appears between BPM and casting when sleep timer is active, using dim `infoColor` to match the other labels
- STEREO/MONO and CASTING labels switched from glow to dim `infoColor` for consistency
- Info row layout adjusted to accommodate the new element; cast and stereo positions refined

**Docs**
- `CHANGELOG.md` — new `0.20.0` entry
- `README.md` — Sleep Timer added to feature list
- `skills/user-guide/SKILL.md` — Sleep Timer section with mode table and behaviour notes

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added Sleep Timer feature accessible via the Playback menu and context menu, with support for timed-duration presets (minute options), end-of-current-track, and end-of-queue modes. Automatically pauses or stops playback with a 10-second volume fade-out.
  * Added visual sleep timer indicator in the info panel displaying active timer status and countdown.

* **Documentation**
  * Updated README and user guide with comprehensive Sleep Timer feature documentation.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->