### PR TITLE
Rename UI menu label to Skins

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -293,7 +293,7 @@
 - **Per-corner window sharpness** — corners automatically sharpen when a window is aligned against a screen edge or adjacent docked window, so the UI looks clean against boundaries without hard corners everywhere else.
 - **XL mode** — the 2X double-size button is now XL at 1.5× scale, giving a more usable intermediate size. State buttons (shuffle, repeat, etc.) are reordered.
 - **Docking fixes** — resolved nine window behavior issues: over-eager snapping, window shift on undock, stack collapse gaps, HT startup sizing, and more.
-- **Menu bar parity** — key player actions are now available from the macOS menu bar with dynamically refreshed checkmarks/state (Windows, UI, Playback, Visuals, Libraries, Output).
+- **Menu bar parity** — key player actions are now available from the macOS menu bar with dynamically refreshed checkmarks/state (Windows, Skins, Playback, Visuals, Libraries, Output).
 
 ### Modern Glass Skins
 

--- a/README.md
+++ b/README.md
@@ -283,7 +283,7 @@ The bundled default skin ("NeonWave") is fully programmatic -- zero image assets
 
 **Creating a skin is as simple as writing a single JSON file.** See [SKINNING.md](SKINNING.md) for the complete guide.
 
-**Skin installation**: Place skin folders or `.nps` bundles in `~/Library/Application Support/NullPlayer/ModernSkins/`, then right-click the player and select your skin from **Modern UI > Select Skin**.
+**Skin installation**: Place skin folders or `.nps` bundles in `~/Library/Application Support/NullPlayer/ModernSkins/`, then right-click the player and select your skin from **Skins > Modern > Select Skin**.
 
 ## License
 

--- a/SKINNING.md
+++ b/SKINNING.md
@@ -47,7 +47,7 @@ Both approaches use the same `skin.json` configuration file. The difference is w
    }
    ```
 
-3. Right-click the player, go to **UI > Modern**, and choose "My First Skin".
+3. Right-click the player, go to **Skins > Modern**, and choose "My First Skin".
 
 That's it. Every button, slider, label, and window border now uses your orange palette.
 
@@ -818,7 +818,7 @@ Place your skin folder in:
 ~/Library/Application Support/NullPlayer/ModernSkins/
 ```
 
-Then right-click the player and select your skin from **UI > Modern**.
+Then right-click the player and select your skin from **Skins > Modern**.
 
 Skin changes take effect immediately -- no restart needed. However, if you're switching from Classic Mode to Modern Mode (or vice versa), NullPlayer will prompt you to restart.
 
@@ -831,7 +831,7 @@ cd MyAwesomeSkin/
 zip -r ../MyAwesomeSkin.nsz .
 ```
 
-Other users can import it with **UI > Modern > Load Skin...** or drop the `.nsz` file into their `ModernSkins/` directory.
+Other users can import it with **Skins > Modern > Load Skin...** or drop the `.nsz` file into their `ModernSkins/` directory.
 
 ### Using Folder-Based Skins (Development)
 

--- a/Sources/NullPlayer/App/AppDelegate.swift
+++ b/Sources/NullPlayer/App/AppDelegate.swift
@@ -249,7 +249,7 @@ class AppDelegate: NSObject, NSApplicationDelegate {
         appMenu.addItem(withTitle: "Quit nullPlayer", action: #selector(NSApplication.terminate(_:)), keyEquivalent: "q")
 
         addDynamicTopLevelMenu(title: "Windows", to: mainMenu, builder: ContextMenuBuilder.buildMenuBarWindowsMenu, refreshOnOpen: true)
-        addDynamicTopLevelMenu(title: "UI", to: mainMenu, builder: ContextMenuBuilder.buildMenuBarUIMenu, refreshOnOpen: true)
+        addDynamicTopLevelMenu(title: "Skins", to: mainMenu, builder: ContextMenuBuilder.buildMenuBarUIMenu, refreshOnOpen: true)
         addDynamicTopLevelMenu(title: "Playback", to: mainMenu, builder: ContextMenuBuilder.buildMenuBarPlaybackMenu, refreshOnOpen: true)
         addDynamicTopLevelMenu(title: "Visuals", to: mainMenu, builder: ContextMenuBuilder.buildMenuBarVisualsMenu, refreshOnOpen: true)
         addDynamicTopLevelMenu(title: "Libraries", to: mainMenu, builder: ContextMenuBuilder.buildMenuBarLibrariesMenu, refreshOnOpen: true)

--- a/Sources/NullPlayer/App/AppStateManager.swift
+++ b/Sources/NullPlayer/App/AppStateManager.swift
@@ -13,7 +13,7 @@ import NullPlayerCore
 /// - **EQ**: enabled, auto, preamp, active-layout bands (10 classic / 21 modern)
 /// - **Playlist**: all tracks (local, Plex, Subsonic, Jellyfin, radio) with metadata
 /// - **Playback position**: current track index, position in seconds
-/// - **UI**: timeDisplayMode, isAlwaysOnTop, double size mode (modern UI)
+/// - **Skins**: timeDisplayMode, isAlwaysOnTop, double size mode (modern UI)
 /// - **Skin**: classic custom skin path, modern skin name
 /// - **ProjectM**: preset index, fullscreen state
 /// - **Audio output**: selected device UID

--- a/Sources/NullPlayer/App/ContextMenuBuilder.swift
+++ b/Sources/NullPlayer/App/ContextMenuBuilder.swift
@@ -145,7 +145,7 @@ class ContextMenuBuilder {
         return menu
     }
 
-    /// Builds the top-level "UI" menu content for the macOS menu bar.
+    /// Builds the top-level "Skins" menu content for the macOS menu bar.
     static func buildMenuBarUIMenu() -> NSMenu {
         let menu = buildUIMenu()
         menu.autoenablesItems = false

--- a/docs/skins/README.md
+++ b/docs/skins/README.md
@@ -1,7 +1,7 @@
 # Skins Visualization Defaults
 
 This document defines how visualization defaults are configured per skin and what is applied automatically for classic `.wsz` skins.
-For modern skin portability, use `.nsz` ZIP bundles (import via **UI > Modern > Load Skin...**).
+For modern skin portability, use `.nsz` ZIP bundles (import via **Skins > Modern > Load Skin...**).
 
 ## `skin.json` `visualization` block (modern skins)
 

--- a/skills/modern-skin-guide/SKILL.md
+++ b/skills/modern-skin-guide/SKILL.md
@@ -274,7 +274,7 @@ Users place `.nsz` files or folders in:
 
 ### Selecting a Skin
 
-Right-click the player → **UI** → **Modern** → choose from the list (or use **Load Skin...** to import a `.nsz` bundle).
+Right-click the player → **Skins** → **Modern** → choose from the list (or use **Load Skin...** to import a `.nsz` bundle).
 
 Skin changes take effect immediately. Switching between Classic and Modern mode requires a restart.
 

--- a/skills/user-guide/SKILL.md
+++ b/skills/user-guide/SKILL.md
@@ -255,7 +255,7 @@ Spectrum, vis_classic, Fire, Enhanced, Ultra, JWST, Lightning, Matrix, Snow (dou
 - **Options > Use Modern UI** to enable modern skin engine
 - Requires restart to switch modes
 - Modern skins use `skin.json` format
-- Portable modern skin bundles use `.nsz` (ZIP) and can be imported via **UI > Modern > Load Skin...**
+- Portable modern skin bundles use `.nsz` (ZIP) and can be imported via **Skins > Modern > Load Skin...**
 - Bundled modern skins: NeonWave (default), Skulls
 
 ### Large UI Mode


### PR DESCRIPTION
## Summary
- rename the macOS top-level menu label from UI to Skins
- update related docs and comments to match the menu rename

## Testing
- not run (label and documentation change only)