### PR TITLE
[codex] Add YouTube Music player

### DIFF
--- a/Sources/NullPlayer/App/ContextMenuBuilder.swift
+++ b/Sources/NullPlayer/App/ContextMenuBuilder.swift
@@ -40,6 +40,11 @@ class ContextMenuBuilder {
         menu.addItem(sleepTimerItem)
         menu.addItem(NSMenuItem.separator())
 
+        let openYouTube = NSMenuItem(title: "Open YouTube Music...", action: #selector(MenuActions.openYouTubeMusicSource), keyEquivalent: "")
+        openYouTube.target = MenuActions.shared
+        menu.addItem(openYouTube)
+        menu.addItem(NSMenuItem.separator())
+
         // Output Devices submenu
         if includeOutputDevices {
             menu.addItem(buildOutputDevicesMenuItem())
@@ -98,6 +103,7 @@ class ContextMenuBuilder {
         menu.addItem(buildWindowItem("Playlist Editor", visible: wm.isPlaylistVisible, action: #selector(MenuActions.togglePlaylist)))
         menu.addItem(buildWindowItem("Waveform", visible: wm.isWaveformVisible, action: #selector(MenuActions.toggleWaveform)))
         menu.addItem(buildWindowItem("Library Browser", visible: wm.isPlexBrowserVisible, action: #selector(MenuActions.togglePlexBrowser)))
+        menu.addItem(buildWindowItem("YouTube Music", visible: wm.isYouTubeMusicPlayerVisible, action: #selector(MenuActions.toggleYouTubeMusicPlayer)))
         if wm.isRunningModernUI {
             menu.addItem(buildWindowItem("Play History", visible: wm.isLibraryHistoryVisible,
                                          action: #selector(MenuActions.toggleLibraryHistory)))
@@ -175,6 +181,10 @@ class ContextMenuBuilder {
         sleepTimerItem.submenu = buildSleepTimerMenu()
         if SleepTimerManager.shared.isActive { sleepTimerItem.state = .on }
         menu.addItem(sleepTimerItem)
+
+        let openYouTube = NSMenuItem(title: "Open YouTube Music...", action: #selector(MenuActions.openYouTubeMusicSource), keyEquivalent: "")
+        openYouTube.target = MenuActions.shared
+        menu.addItem(openYouTube)
 
         menu.addItem(NSMenuItem.separator())
 
@@ -2651,6 +2661,10 @@ class MenuActions: NSObject {
     @objc func togglePlexBrowser() {
         WindowManager.shared.togglePlexBrowser()
     }
+
+    @objc func toggleYouTubeMusicPlayer() {
+        WindowManager.shared.toggleYouTubeMusicPlayer()
+    }
     
     @objc func toggleProjectM() {
         WindowManager.shared.toggleProjectM()
@@ -4103,30 +4117,58 @@ class MenuActions: NSObject {
     // MARK: - Playback Controls
     
     @objc func previous() {
+        if YouTubeMusicController.shared.isActive {
+            YouTubeMusicController.shared.previous()
+            return
+        }
         WindowManager.shared.audioEngine.previous()
     }
     
     @objc func play() {
+        if YouTubeMusicController.shared.isActive {
+            YouTubeMusicController.shared.play()
+            return
+        }
         WindowManager.shared.audioEngine.play()
     }
     
     @objc func pause() {
+        if YouTubeMusicController.shared.isActive {
+            YouTubeMusicController.shared.pause()
+            return
+        }
         WindowManager.shared.audioEngine.pause()
     }
     
     @objc func stop() {
+        if YouTubeMusicController.shared.isActive {
+            YouTubeMusicController.shared.stop()
+            return
+        }
         WindowManager.shared.audioEngine.stop()
     }
     
     @objc func next() {
+        if YouTubeMusicController.shared.isActive {
+            YouTubeMusicController.shared.next()
+            return
+        }
         WindowManager.shared.audioEngine.next()
     }
     
     @objc func back5Seconds() {
+        if YouTubeMusicController.shared.isActive {
+            YouTubeMusicController.shared.seek(by: -5)
+            return
+        }
         WindowManager.shared.audioEngine.seekBy(seconds: -5)
     }
     
     @objc func fwd5Seconds() {
+        if YouTubeMusicController.shared.isActive {
+            YouTubeMusicController.shared.seek(by: 5)
+            return
+        }
         WindowManager.shared.audioEngine.seekBy(seconds: 5)
     }
     
@@ -5111,5 +5153,22 @@ class MenuActions: NSObject {
     
     @objc func exit() {
         NSApp.terminate(nil)
+    }
+
+    @objc func openYouTubeMusicSource() {
+        let alert = NSAlert()
+        alert.messageText = "Open YouTube Music"
+        alert.informativeText = "Paste a YouTube, YouTube Music, video, playlist, or search."
+        alert.alertStyle = .informational
+        alert.addButton(withTitle: "Play")
+        alert.addButton(withTitle: "Cancel")
+
+        let field = NSTextField(frame: NSRect(x: 0, y: 0, width: 460, height: 24))
+        field.placeholderString = "https://music.youtube.com/playlist?list=..."
+        alert.accessoryView = field
+
+        if alert.runModal() == .alertFirstButtonReturn {
+            WindowManager.shared.playYouTubeMusicSource(field.stringValue)
+        }
     }
 }

--- a/Sources/NullPlayer/App/WindowManager.swift
+++ b/Sources/NullPlayer/App/WindowManager.swift
@@ -349,6 +349,9 @@ class WindowManager {
     
     /// Debug console window controller
     private var debugWindowController: DebugWindowController?
+
+    /// YouTube / YouTube Music embedded player window controller
+    private var youTubeMusicPlayerWindowController: YouTubeMusicPlayerWindowController?
     
     /// Video playback time tracking
     private(set) var videoCurrentTime: TimeInterval = 0
@@ -819,6 +822,10 @@ class WindowManager {
     var isPlexBrowserVisible: Bool {
         plexBrowserWindowController?.window?.isVisible == true
     }
+
+    var isYouTubeMusicPlayerVisible: Bool {
+        youTubeMusicPlayerWindowController?.window?.isVisible == true
+    }
     
     /// Get the Plex Browser window frame if visible (for positioning other windows)
     var plexBrowserWindowFrame: NSRect? {
@@ -854,6 +861,31 @@ class WindowManager {
         }
         postLayoutChangeNotification()
         updateDockedChildWindows()
+    }
+
+    func showYouTubeMusicPlayer() {
+        if youTubeMusicPlayerWindowController == nil {
+            youTubeMusicPlayerWindowController = YouTubeMusicPlayerWindowController()
+        }
+        youTubeMusicPlayerWindowController?.showWindow(nil)
+        youTubeMusicPlayerWindowController?.window?.makeKeyAndOrderFront(nil)
+        applyAlwaysOnTopToWindow(youTubeMusicPlayerWindowController?.window)
+        postLayoutChangeNotification()
+    }
+
+    func toggleYouTubeMusicPlayer() {
+        if isYouTubeMusicPlayerVisible {
+            youTubeMusicPlayerWindowController?.window?.orderOut(nil)
+            postLayoutChangeNotification()
+        } else {
+            showYouTubeMusicPlayer()
+        }
+    }
+
+    func playYouTubeMusicSource(_ rawSource: String) {
+        audioEngine.stop()
+        showYouTubeMusicPlayer()
+        youTubeMusicPlayerWindowController?.load(rawSource: rawSource, autoplay: true)
     }
 
     // MARK: - Library History
@@ -3395,6 +3427,7 @@ class WindowManager {
         if let w = equalizerWindowController?.window, w.isVisible { windows.append(w) }
         if let w = plexBrowserWindowController?.window, w.isVisible { windows.append(w) }
         if let w = videoPlayerWindowController?.window, w.isVisible { windows.append(w) }
+        if let w = youTubeMusicPlayerWindowController?.window, w.isVisible { windows.append(w) }
         if let w = projectMWindowController?.window, w.isVisible { windows.append(w) }
         if let w = spectrumWindowController?.window, w.isVisible { windows.append(w) }
         if let w = waveformWindowController?.window, w.isVisible { windows.append(w) }

--- a/Sources/NullPlayer/Audio/AudioEngine.swift
+++ b/Sources/NullPlayer/Audio/AudioEngine.swift
@@ -223,6 +223,7 @@ class AudioEngine {
             // Apply volume with normalization gain for local playback
             applyNormalizationGain()
             streamingPlayer?.volume = volume
+            YouTubeMusicController.shared.setVolume(volume)
             
             // Apply volume to video player
             if !AudioEngine.isHeadless {
@@ -4901,6 +4902,9 @@ class AudioEngine {
     // MARK: - Playlist Management
     
     func clearPlaylist() {
+        if YouTubeMusicController.shared.isActive {
+            YouTubeMusicController.shared.stop()
+        }
         NSLog("clearPlaylist: isStreamingPlayback=%d", isStreamingPlayback)
         placeholderResolutionTasks.values.forEach { $0.cancel() }
         placeholderResolutionTasks.removeAll()
@@ -4978,6 +4982,9 @@ class AudioEngine {
     }
     
     func playTrack(at index: Int) {
+        if YouTubeMusicController.shared.isActive {
+            YouTubeMusicController.shared.stop()
+        }
         // Cancel any in-progress crossfade
         cancelCrossfade()
         

--- a/Sources/NullPlayer/YouTubeMusic/YouTubeMusicController.swift
+++ b/Sources/NullPlayer/YouTubeMusic/YouTubeMusicController.swift
@@ -1,0 +1,143 @@
+import AppKit
+import Foundation
+
+extension Notification.Name {
+    static let youTubeMusicStateChanged = Notification.Name("youTubeMusicStateChanged")
+    static let youTubeMusicTrackChanged = Notification.Name("youTubeMusicTrackChanged")
+}
+
+enum YouTubeMusicPlaybackState: String, Sendable {
+    case stopped
+    case playing
+    case paused
+    case buffering
+    case ended
+}
+
+final class YouTubeMusicController {
+    static let shared = YouTubeMusicController()
+
+    private(set) var queue: [YouTubeMusicTrack] = []
+    private(set) var currentIndex: Int = -1
+    private(set) var state: YouTubeMusicPlaybackState = .stopped {
+        didSet {
+            NotificationCenter.default.post(
+                name: .youTubeMusicStateChanged,
+                object: self,
+                userInfo: ["state": state.rawValue]
+            )
+        }
+    }
+
+    weak var playerView: YouTubeMusicPlayerView?
+
+    var isActive: Bool {
+        state != .stopped && currentIndex >= 0 && currentIndex < queue.count
+    }
+
+    var currentTrack: YouTubeMusicTrack? {
+        guard currentIndex >= 0 && currentIndex < queue.count else { return nil }
+        return queue[currentIndex]
+    }
+
+    private init() {}
+
+    func load(rawSource: String, autoplay: Bool = true) {
+        guard let track = YouTubeMusicURLParser.makeTrack(from: rawSource) else {
+            NSSound.beep()
+            return
+        }
+        load(queue: [track], startIndex: 0, autoplay: autoplay)
+    }
+
+    func load(queue nextQueue: [YouTubeMusicTrack], startIndex: Int = 0, autoplay: Bool = true) {
+        guard nextQueue.indices.contains(startIndex) else { return }
+        queue = nextQueue
+        currentIndex = startIndex
+        state = .buffering
+        NotificationCenter.default.post(name: .youTubeMusicTrackChanged, object: self)
+        playerView?.load(track: nextQueue[startIndex], autoplay: autoplay)
+    }
+
+    func playPause() {
+        switch state {
+        case .playing:
+            pause()
+        default:
+            play()
+        }
+    }
+
+    func play() {
+        ensurePlayerWindowVisible()
+        playerView?.play()
+        state = .playing
+    }
+
+    func pause() {
+        playerView?.pause()
+        state = .paused
+    }
+
+    func stop() {
+        playerView?.stop()
+        state = .stopped
+    }
+
+    func next() {
+        guard !queue.isEmpty else { return }
+        if currentIndex + 1 < queue.count {
+            currentIndex += 1
+        } else {
+            currentIndex = 0
+        }
+        state = .buffering
+        NotificationCenter.default.post(name: .youTubeMusicTrackChanged, object: self)
+        playerView?.load(track: queue[currentIndex], autoplay: true)
+    }
+
+    func previous() {
+        guard !queue.isEmpty else { return }
+        if currentIndex > 0 {
+            currentIndex -= 1
+        } else {
+            currentIndex = queue.count - 1
+        }
+        state = .buffering
+        NotificationCenter.default.post(name: .youTubeMusicTrackChanged, object: self)
+        playerView?.load(track: queue[currentIndex], autoplay: true)
+    }
+
+    func seek(to seconds: TimeInterval) {
+        playerView?.seek(to: seconds)
+    }
+
+    func seek(by seconds: TimeInterval) {
+        playerView?.seek(by: seconds)
+    }
+
+    func setVolume(_ value: Float) {
+        let clamped = max(0, min(1, value))
+        playerView?.setVolume(Int(clamped * 100))
+    }
+
+    func handlePlayerState(_ rawState: Int) {
+        switch rawState {
+        case -1, 3:
+            state = .buffering
+        case 0:
+            state = .ended
+            next()
+        case 1:
+            state = .playing
+        case 2:
+            state = .paused
+        default:
+            break
+        }
+    }
+
+    private func ensurePlayerWindowVisible() {
+        WindowManager.shared.showYouTubeMusicPlayer()
+    }
+}

--- a/Sources/NullPlayer/YouTubeMusic/YouTubeMusicPlayerView.swift
+++ b/Sources/NullPlayer/YouTubeMusic/YouTubeMusicPlayerView.swift
@@ -1,0 +1,173 @@
+import AppKit
+import WebKit
+
+final class YouTubeMusicPlayerView: NSView, WKScriptMessageHandler {
+    private let webView: WKWebView
+    private let statusLabel = NSTextField(labelWithString: "YouTube Music")
+
+    override init(frame frameRect: NSRect) {
+        let contentController = WKUserContentController()
+        let configuration = WKWebViewConfiguration()
+        configuration.userContentController = contentController
+        configuration.allowsAirPlayForMediaPlayback = true
+        configuration.mediaTypesRequiringUserActionForPlayback = []
+
+        webView = WKWebView(frame: .zero, configuration: configuration)
+        super.init(frame: frameRect)
+
+        contentController.add(self, name: "nullplayerYouTube")
+        wantsLayer = true
+        layer?.backgroundColor = NSColor.black.cgColor
+
+        statusLabel.font = .monospacedSystemFont(ofSize: 11, weight: .medium)
+        statusLabel.textColor = .secondaryLabelColor
+        statusLabel.translatesAutoresizingMaskIntoConstraints = false
+
+        webView.translatesAutoresizingMaskIntoConstraints = false
+        addSubview(webView)
+        addSubview(statusLabel)
+
+        NSLayoutConstraint.activate([
+            webView.leadingAnchor.constraint(equalTo: leadingAnchor),
+            webView.trailingAnchor.constraint(equalTo: trailingAnchor),
+            webView.topAnchor.constraint(equalTo: topAnchor),
+            webView.bottomAnchor.constraint(equalTo: bottomAnchor),
+
+            statusLabel.leadingAnchor.constraint(equalTo: leadingAnchor, constant: 10),
+            statusLabel.trailingAnchor.constraint(lessThanOrEqualTo: trailingAnchor, constant: -10),
+            statusLabel.bottomAnchor.constraint(equalTo: bottomAnchor, constant: -8)
+        ])
+
+        YouTubeMusicController.shared.playerView = self
+    }
+
+    required init?(coder: NSCoder) {
+        fatalError("init(coder:) has not been implemented")
+    }
+
+    func load(track: YouTubeMusicTrack, autoplay: Bool) {
+        statusLabel.stringValue = track.displayTitle
+        if track.kind == .search {
+            webView.load(URLRequest(url: track.sourceURL))
+            return
+        }
+        let html = makePlayerHTML(track: track, autoplay: autoplay)
+        webView.loadHTMLString(html, baseURL: URL(string: "https://www.youtube.com"))
+    }
+
+    func play() {
+        evaluate("player && player.playVideo && player.playVideo();")
+    }
+
+    func pause() {
+        evaluate("player && player.pauseVideo && player.pauseVideo();")
+    }
+
+    func stop() {
+        evaluate("player && player.stopVideo && player.stopVideo();")
+    }
+
+    func seek(to seconds: TimeInterval) {
+        evaluate("player && player.seekTo && player.seekTo(\(max(0, seconds)), true);")
+    }
+
+    func seek(by seconds: TimeInterval) {
+        evaluate("""
+        if (player && player.getCurrentTime && player.seekTo) {
+          player.seekTo(Math.max(0, player.getCurrentTime() + (\(seconds))), true);
+        }
+        """)
+    }
+
+    func setVolume(_ volume: Int) {
+        evaluate("player && player.setVolume && player.setVolume(\(max(0, min(100, volume))));")
+    }
+
+    nonisolated func userContentController(_ userContentController: WKUserContentController, didReceive message: WKScriptMessage) {
+        DispatchQueue.main.async {
+            guard message.name == "nullplayerYouTube" else { return }
+            if let body = message.body as? [String: Any],
+               let type = body["type"] as? String,
+               type == "state",
+               let rawState = body["value"] as? Int {
+                YouTubeMusicController.shared.handlePlayerState(rawState)
+            }
+        }
+    }
+
+    private func evaluate(_ js: String) {
+        webView.evaluateJavaScript(js) { _, error in
+            if let error {
+                NSLog("YouTubeMusicPlayerView JS error: %@", error.localizedDescription)
+            }
+        }
+    }
+
+    private func makePlayerHTML(track: YouTubeMusicTrack, autoplay: Bool) -> String {
+        let videoID = track.videoID ?? ""
+        let playlistID = track.playlistID ?? ""
+        let autoplayValue = autoplay ? 1 : 0
+        let initialVideo = videoID.isEmpty ? "" : escapeJS(videoID)
+        let escapedPlaylistID = escapeJS(playlistID)
+        let autoplayJS = autoplay ? "player.playVideo();" : ""
+        let playlistJS = playlistID.isEmpty ? "" : """
+              player.loadPlaylist({
+                listType: 'playlist',
+                list: '\(escapedPlaylistID)',
+                index: 0,
+                suggestedQuality: 'default'
+              });
+              \(autoplayJS)
+        """
+
+        return """
+        <!doctype html>
+        <html>
+        <head>
+          <meta name="viewport" content="width=device-width, initial-scale=1">
+          <style>
+            html, body, #player { margin: 0; width: 100%; height: 100%; background: #000; overflow: hidden; }
+          </style>
+        </head>
+        <body>
+          <div id="player"></div>
+          <script src="https://www.youtube.com/iframe_api"></script>
+          <script>
+            var player;
+            function post(type, value) {
+              window.webkit.messageHandlers.nullplayerYouTube.postMessage({ type: type, value: value });
+            }
+            function onYouTubeIframeAPIReady() {
+              player = new YT.Player('player', {
+                width: '100%',
+                height: '100%',
+                videoId: '\(initialVideo)',
+                playerVars: {
+                  autoplay: \(autoplayValue),
+                  controls: 1,
+                  rel: 0,
+                  playsinline: 1
+                },
+                events: {
+                  onReady: function() {
+                    \(playlistJS)
+                  },
+                  onStateChange: function(event) { post('state', event.data); },
+                  onError: function(event) { post('error', event.data); }
+                }
+              });
+            }
+          </script>
+        </body>
+        </html>
+        """
+    }
+
+    private func escapeJS(_ value: String) -> String {
+        value
+            .replacingOccurrences(of: "\\", with: "\\\\")
+            .replacingOccurrences(of: "'", with: "\\'")
+            .replacingOccurrences(of: "\n", with: " ")
+            .replacingOccurrences(of: "\r", with: " ")
+    }
+}

--- a/Sources/NullPlayer/YouTubeMusic/YouTubeMusicPlayerWindowController.swift
+++ b/Sources/NullPlayer/YouTubeMusic/YouTubeMusicPlayerWindowController.swift
@@ -1,0 +1,28 @@
+import AppKit
+
+final class YouTubeMusicPlayerWindowController: NSWindowController {
+    private let playerView = YouTubeMusicPlayerView(frame: NSRect(x: 0, y: 0, width: 560, height: 315))
+
+    init() {
+        let window = NSWindow(
+            contentRect: NSRect(x: 160, y: 160, width: 560, height: 315),
+            styleMask: [.titled, .closable, .miniaturizable, .resizable],
+            backing: .buffered,
+            defer: false
+        )
+        window.title = "YouTube Music"
+        window.minSize = NSSize(width: 360, height: 220)
+        window.contentView = playerView
+        super.init(window: window)
+    }
+
+    required init?(coder: NSCoder) {
+        fatalError("init(coder:) has not been implemented")
+    }
+
+    func load(rawSource: String, autoplay: Bool = true) {
+        showWindow(nil)
+        window?.makeKeyAndOrderFront(nil)
+        YouTubeMusicController.shared.load(rawSource: rawSource, autoplay: autoplay)
+    }
+}

--- a/Sources/NullPlayer/YouTubeMusic/YouTubeMusicTrack.swift
+++ b/Sources/NullPlayer/YouTubeMusic/YouTubeMusicTrack.swift
@@ -1,0 +1,121 @@
+import Foundation
+
+enum YouTubeMusicSourceKind: String, Codable, Sendable {
+    case video
+    case playlist
+    case search
+}
+
+struct YouTubeMusicTrack: Identifiable, Equatable, Codable, Sendable {
+    let id: UUID
+    let title: String
+    let artist: String?
+    let sourceURL: URL
+    let videoID: String?
+    let playlistID: String?
+    let kind: YouTubeMusicSourceKind
+
+    init(
+        id: UUID = UUID(),
+        title: String,
+        artist: String? = nil,
+        sourceURL: URL,
+        videoID: String? = nil,
+        playlistID: String? = nil,
+        kind: YouTubeMusicSourceKind
+    ) {
+        self.id = id
+        self.title = title
+        self.artist = artist
+        self.sourceURL = sourceURL
+        self.videoID = videoID
+        self.playlistID = playlistID
+        self.kind = kind
+    }
+
+    var displayTitle: String {
+        if let artist, !artist.isEmpty {
+            return "\(artist) - \(title)"
+        }
+        return title
+    }
+}
+
+enum YouTubeMusicURLParser {
+    static func makeTrack(from rawValue: String) -> YouTubeMusicTrack? {
+        let trimmed = rawValue.trimmingCharacters(in: .whitespacesAndNewlines)
+        guard !trimmed.isEmpty else { return nil }
+
+        if let url = URL(string: trimmed), let host = url.host?.lowercased(), isYouTubeHost(host) {
+            let ids = extractIDs(from: url)
+            let title = ids.videoID.map { "YouTube \($0)" }
+                ?? ids.playlistID.map { "YouTube Playlist \($0)" }
+                ?? url.lastPathComponent
+
+            return YouTubeMusicTrack(
+                title: title,
+                sourceURL: url,
+                videoID: ids.videoID,
+                playlistID: ids.playlistID,
+                kind: ids.playlistID == nil ? .video : .playlist
+            )
+        }
+
+        if let encoded = trimmed.addingPercentEncoding(withAllowedCharacters: .urlQueryAllowed),
+           let url = URL(string: "https://music.youtube.com/search?q=\(encoded)") {
+            return YouTubeMusicTrack(
+                title: trimmed,
+                sourceURL: url,
+                videoID: nil,
+                playlistID: nil,
+                kind: .search
+            )
+        }
+
+        return nil
+    }
+
+    static func embedURL(for track: YouTubeMusicTrack) -> URL? {
+        var components = URLComponents()
+        components.scheme = "https"
+        components.host = "www.youtube.com"
+
+        if let videoID = track.videoID {
+            components.path = "/embed/\(videoID)"
+        } else {
+            components.path = "/embed"
+        }
+
+        var items = [
+            URLQueryItem(name: "enablejsapi", value: "1"),
+            URLQueryItem(name: "playsinline", value: "1"),
+            URLQueryItem(name: "autoplay", value: "1"),
+            URLQueryItem(name: "rel", value: "0")
+        ]
+
+        if let playlistID = track.playlistID {
+            items.append(URLQueryItem(name: "listType", value: "playlist"))
+            items.append(URLQueryItem(name: "list", value: playlistID))
+        }
+
+        components.queryItems = items
+        return components.url
+    }
+
+    private static func isYouTubeHost(_ host: String) -> Bool {
+        host == "youtube.com"
+            || host == "www.youtube.com"
+            || host == "music.youtube.com"
+            || host == "youtu.be"
+            || host.hasSuffix(".youtube.com")
+    }
+
+    private static func extractIDs(from url: URL) -> (videoID: String?, playlistID: String?) {
+        let components = URLComponents(url: url, resolvingAgainstBaseURL: false)
+        let query = components?.queryItems ?? []
+        let videoID = query.first(where: { $0.name == "v" })?.value
+            ?? (url.host?.lowercased() == "youtu.be" ? url.pathComponents.dropFirst().first : nil)
+        let playlistID = query.first(where: { $0.name == "list" })?.value
+        return (videoID, playlistID)
+    }
+}


### PR DESCRIPTION
## Summary

Adds an embedded YouTube / YouTube Music player window to NullPlayer.

## Changes

- Adds a YouTube Music window backed by `WKWebView` and the YouTube iframe API.
- Parses YouTube, YouTube Music, playlist, short-link, and search input into playable sources.
- Adds context/menu-bar actions to open and toggle the YouTube Music player.
- Routes playback controls to YouTube Music while it is active, including play, pause, stop, next, previous, and +/- 5 second seeks.
- Stops YouTube playback when local playlist playback starts, and stops local audio before launching a YouTube source.

## Validation

- Installed Swift 6.3.1 via Swiftly and verified `swift --version` outside the sandbox.
- Ran `swift build`; dependency resolution and binary artifact fetching worked after adding a user-local `unzip` shim, but full Linux validation is blocked by existing upstream `FFmpegKit` plugin code that references macOS-only `NSBundleExecutableArchitectureX86_64` before project sources compile.

## Notes

This repo targets macOS/AppKit, so final compile/runtime validation should be done on a macOS runner or developer machine.
