### PR TITLE
Track output device on play events and surface in stats

### DIFF
--- a/Sources/NullPlayer/Audio/AudioEngine.swift
+++ b/Sources/NullPlayer/Audio/AudioEngine.swift
@@ -2560,7 +2560,8 @@ class AudioEngine {
                 playedAt: Date(),
                 durationListened: finishedTrack.duration ?? 0,
                 source: finishedTrack.playHistorySource.rawValue,
-                skipped: false)
+                skipped: false,
+                outputDevice: AudioOutputManager.shared.currentDeviceDisplayName)
             if let eventId, finishedTrack.genre == nil || finishedTrack.genre?.isEmpty == true {
                 Task.detached(priority: .utility) { [track = finishedTrack] in
                     await GenreDiscoveryService.shared.enrichPlayEvent(
@@ -3852,7 +3853,8 @@ class AudioEngine {
                 playedAt: Date(),
                 durationListened: finishedTrack.duration ?? 0,
                 source: finishedTrack.playHistorySource.rawValue,
-                skipped: false)
+                skipped: false,
+                outputDevice: AudioOutputManager.shared.currentDeviceDisplayName)
             if let eventId, finishedTrack.genre == nil || finishedTrack.genre?.isEmpty == true {
                 Task.detached(priority: .utility) { [track = finishedTrack] in
                     await GenreDiscoveryService.shared.enrichPlayEvent(
@@ -4426,7 +4428,8 @@ class AudioEngine {
                 playedAt: Date(),
                 durationListened: outgoingTrack.duration ?? 0,
                 source: outgoingTrack.playHistorySource.rawValue,
-                skipped: false)
+                skipped: false,
+                outputDevice: AudioOutputManager.shared.currentDeviceDisplayName)
             if let eventId, outgoingTrack.genre == nil || outgoingTrack.genre?.isEmpty == true {
                 Task.detached(priority: .utility) { [track = outgoingTrack] in
                     await GenreDiscoveryService.shared.enrichPlayEvent(
@@ -4546,7 +4549,8 @@ class AudioEngine {
                 playedAt: Date(),
                 durationListened: outgoingTrack.duration ?? 0,
                 source: outgoingTrack.playHistorySource.rawValue,
-                skipped: false)
+                skipped: false,
+                outputDevice: AudioOutputManager.shared.currentDeviceDisplayName)
             if let eventId, outgoingTrack.genre == nil || outgoingTrack.genre?.isEmpty == true {
                 Task.detached(priority: .utility) { [track = outgoingTrack] in
                     await GenreDiscoveryService.shared.enrichPlayEvent(

--- a/Sources/NullPlayer/Audio/AudioEngine.swift
+++ b/Sources/NullPlayer/Audio/AudioEngine.swift
@@ -2561,7 +2561,7 @@ class AudioEngine {
                 durationListened: finishedTrack.duration ?? 0,
                 source: finishedTrack.playHistorySource.rawValue,
                 skipped: false,
-                outputDevice: AudioOutputManager.shared.currentDeviceDisplayName)
+                outputDevice: CastManager.currentPlaybackDeviceName)
             if let eventId, finishedTrack.genre == nil || finishedTrack.genre?.isEmpty == true {
                 Task.detached(priority: .utility) { [track = finishedTrack] in
                     await GenreDiscoveryService.shared.enrichPlayEvent(
@@ -3854,7 +3854,7 @@ class AudioEngine {
                 durationListened: finishedTrack.duration ?? 0,
                 source: finishedTrack.playHistorySource.rawValue,
                 skipped: false,
-                outputDevice: AudioOutputManager.shared.currentDeviceDisplayName)
+                outputDevice: CastManager.currentPlaybackDeviceName)
             if let eventId, finishedTrack.genre == nil || finishedTrack.genre?.isEmpty == true {
                 Task.detached(priority: .utility) { [track = finishedTrack] in
                     await GenreDiscoveryService.shared.enrichPlayEvent(
@@ -4429,7 +4429,7 @@ class AudioEngine {
                 durationListened: outgoingTrack.duration ?? 0,
                 source: outgoingTrack.playHistorySource.rawValue,
                 skipped: false,
-                outputDevice: AudioOutputManager.shared.currentDeviceDisplayName)
+                outputDevice: CastManager.currentPlaybackDeviceName)
             if let eventId, outgoingTrack.genre == nil || outgoingTrack.genre?.isEmpty == true {
                 Task.detached(priority: .utility) { [track = outgoingTrack] in
                     await GenreDiscoveryService.shared.enrichPlayEvent(
@@ -4550,7 +4550,7 @@ class AudioEngine {
                 durationListened: outgoingTrack.duration ?? 0,
                 source: outgoingTrack.playHistorySource.rawValue,
                 skipped: false,
-                outputDevice: AudioOutputManager.shared.currentDeviceDisplayName)
+                outputDevice: CastManager.currentPlaybackDeviceName)
             if let eventId, outgoingTrack.genre == nil || outgoingTrack.genre?.isEmpty == true {
                 Task.detached(priority: .utility) { [track = outgoingTrack] in
                     await GenreDiscoveryService.shared.enrichPlayEvent(

--- a/Sources/NullPlayer/Audio/AudioOutputManager.swift
+++ b/Sources/NullPlayer/Audio/AudioOutputManager.swift
@@ -494,6 +494,24 @@ class AudioOutputManager {
         return status == noErr ? deviceID : nil
     }
     
+    /// Resolved display name for the currently active output device.
+    /// Falls back to the system default device's name when no explicit selection is set.
+    var currentDeviceDisplayName: String {
+        if let id = currentDeviceID,
+           let device = outputDevices.first(where: { $0.id == id }) {
+            return device.name
+        }
+        if let defaultID = getDefaultOutputDeviceID() {
+            if let device = outputDevices.first(where: { $0.id == defaultID }) {
+                return device.name
+            }
+            if let name = getDeviceName(deviceID: defaultID) {
+                return name
+            }
+        }
+        return "System Default"
+    }
+
     // MARK: - Device Selection
     
     /// Select an output device by ID

--- a/Sources/NullPlayer/Casting/CastManager.swift
+++ b/Sources/NullPlayer/Casting/CastManager.swift
@@ -253,6 +253,15 @@ class CastManager {
         NSLog("CastManager: Transfer complete")
     }
     
+    /// Resolved output device name for play-history recording: the active cast
+    /// target when casting, otherwise the local CoreAudio output.
+    static var currentPlaybackDeviceName: String {
+        if let name = CastManager.shared.activeSession?.device.name {
+            return name
+        }
+        return AudioOutputManager.shared.currentDeviceDisplayName
+    }
+
     /// Current active cast session (if any)
     var activeSession: CastSession? {
         #if DEBUG

--- a/Sources/NullPlayer/Data/Models/MediaLibraryStore.swift
+++ b/Sources/NullPlayer/Data/Models/MediaLibraryStore.swift
@@ -199,6 +199,11 @@ final class MediaLibraryStore {
         if currentVersion == 5 {
             try migrateToV6(connection)
             try connection.run("PRAGMA user_version = 6")
+            currentVersion = 6
+        }
+        if currentVersion == 6 {
+            try migrateToV7(connection)
+            try connection.run("PRAGMA user_version = 7")
         }
     }
 
@@ -261,6 +266,21 @@ final class MediaLibraryStore {
             SET content_type = CASE WHEN source = 'radio' THEN 'radio' ELSE 'music' END
             WHERE content_type IS NULL
             """)
+    }
+
+    private func migrateToV7(_ connection: Connection) throws {
+        // Add output_device column to play_events
+        let pragmaSQL = "PRAGMA table_info(play_events)"
+        var hasColumn = false
+        for row in try connection.prepare(pragmaSQL) {
+            if let existingName = row[1] as? String, existingName == "output_device" {
+                hasColumn = true
+                break
+            }
+        }
+        if !hasColumn {
+            try connection.execute("ALTER TABLE play_events ADD COLUMN output_device TEXT")
+        }
     }
 
     private func addTrackColumnIfMissing(_ connection: Connection, name: String, sqlType: String) throws {
@@ -1235,7 +1255,8 @@ final class MediaLibraryStore {
     func insertPlayEvent(trackId: String?, trackURL: String?, title: String?, artist: String?,
                          album: String?, genre: String?, playedAt: Date,
                          durationListened: Double, source: String, skipped: Bool,
-                         contentType: String = "music") -> Int64? {
+                         contentType: String = "music",
+                         outputDevice: String? = nil) -> Int64? {
         guard let db = db else { return nil }
         do {
             let bindings: [Binding?] = [
@@ -1249,13 +1270,14 @@ final class MediaLibraryStore {
                 durationListened as Binding,
                 source as Binding,
                 (skipped ? 1 : 0) as Binding,
-                contentType as Binding
+                contentType as Binding,
+                outputDevice as Binding?
             ]
             try db.run("""
                 INSERT INTO play_events
                   (track_id, track_url, event_title, event_artist, event_album, event_genre,
-                   played_at, duration_listened, source, skipped, content_type)
-                VALUES (?,?,?,?,?,?,?,?,?,?,?)
+                   played_at, duration_listened, source, skipped, content_type, output_device)
+                VALUES (?,?,?,?,?,?,?,?,?,?,?,?)
                 """, bindings)
             NotificationCenter.default.post(name: Self.playHistoryDidChangeNotification, object: nil)
             return db.lastInsertRowid

--- a/Sources/NullPlayer/Windows/ModernStats/PlayHistoryAgent.swift
+++ b/Sources/NullPlayer/Windows/ModernStats/PlayHistoryAgent.swift
@@ -1,7 +1,7 @@
 import Foundation
 import Combine
 
-enum StatsDimension { case artist, album, genre, source }
+enum StatsDimension { case artist, album, genre, source, outputDevice }
 enum StatsGranularity { case day, week, month }
 enum StatsTimeRange: Equatable, Hashable {
     case last7Days, last30Days, last90Days, last365Days, allTime
@@ -35,6 +35,7 @@ struct StatsFilterState: Equatable {
     var selectedGenre:  String? = nil
     var selectedSource: String? = nil
     var selectedContentType: String? = nil
+    var selectedOutputDevice: String? = nil
     var excludeSkipped: Bool = true
 }
 
@@ -46,6 +47,7 @@ final class PlayHistoryAgent: ObservableObject {
     @Published var genreBreakdown: [TopDimensionRow] = []
     @Published var sourceBreakdown: [TopDimensionRow] = []
     @Published var contentTypeBreakdown: [TopDimensionRow] = []
+    @Published var outputDeviceBreakdown: [TopDimensionRow] = []
     @Published var recentEvents:   [RecentEventRow]  = []
     @Published var isLoading: Bool = false
     @Published var error: String? = nil
@@ -68,6 +70,7 @@ final class PlayHistoryAgent: ObservableObject {
     private var cachedGenreBreakdown: [TopDimensionRow]?
     private var cachedSourceBreakdown: [TopDimensionRow]?
     private var cachedContentTypeBreakdown: [TopDimensionRow]?
+    private var cachedOutputDeviceBreakdown: [TopDimensionRow]?
     private var cachedRecentEvents:   [RecentEventRow]?
 
     private let store = PlayHistoryStore()
@@ -78,6 +81,7 @@ final class PlayHistoryAgent: ObservableObject {
     func selectGenre(_ name: String?)   { filter.selectedGenre  = name }
     func selectSource(_ s: String?)     { filter.selectedSource = s }
     func selectContentType(_ s: String?) { filter.selectedContentType = s }
+    func selectOutputDevice(_ s: String?) { filter.selectedOutputDevice = s }
     func clearAllFilters()              { filter = StatsFilterState() }
     func clearVisibleFilters() {
         filter = StatsFilterState(
@@ -87,6 +91,7 @@ final class PlayHistoryAgent: ObservableObject {
             selectedGenre: nil,
             selectedSource: nil,
             selectedContentType: nil,
+            selectedOutputDevice: nil,
             excludeSkipped: true
         )
     }
@@ -99,6 +104,7 @@ final class PlayHistoryAgent: ObservableObject {
         filter.selectedGenre != nil ||
         filter.selectedSource != nil ||
         filter.selectedContentType != nil ||
+        filter.selectedOutputDevice != nil ||
         filter.excludeSkipped != true
     }
 
@@ -106,6 +112,7 @@ final class PlayHistoryAgent: ObservableObject {
         cachedPlayTimeSummaries = nil; cachedTopArtists = nil
         cachedTimeSeries = nil; cachedGenreBreakdown = nil
         cachedSourceBreakdown = nil; cachedContentTypeBreakdown = nil
+        cachedOutputDeviceBreakdown = nil
         cachedRecentEvents = nil
     }
 
@@ -134,15 +141,18 @@ final class PlayHistoryAgent: ObservableObject {
                 try Task.checkCancellation()
                 let c = try store.fetchContentTypeBreakdown(filter: currentFilter)
                 try Task.checkCancellation()
+                let d = try store.fetchTopDimension(dimension: .outputDevice, filter: currentFilter)
+                try Task.checkCancellation()
                 let r = try store.fetchRecentEvents(filter: currentFilter)
-                return (p, a, s, g, o, c, r)
+                return (p, a, s, g, o, c, d, r)
             }.value
             try Task.checkCancellation()
-            (playTimeSummaries, topArtists, timeSeries, genreBreakdown, sourceBreakdown, contentTypeBreakdown, recentEvents) = result
+            (playTimeSummaries, topArtists, timeSeries, genreBreakdown, sourceBreakdown, contentTypeBreakdown, outputDeviceBreakdown, recentEvents) = result
             cachedPlayTimeSummaries = result.0; cachedTopArtists = result.1
             cachedTimeSeries = result.2; cachedGenreBreakdown = result.3
             cachedSourceBreakdown = result.4; cachedContentTypeBreakdown = result.5
-            cachedRecentEvents = result.6
+            cachedOutputDeviceBreakdown = result.6
+            cachedRecentEvents = result.7
         } catch is CancellationError {
             // Refresh was superseded by a newer request — discard results silently
         } catch {

--- a/Sources/NullPlayer/Windows/ModernStats/PlayHistoryStore.swift
+++ b/Sources/NullPlayer/Windows/ModernStats/PlayHistoryStore.swift
@@ -100,9 +100,15 @@ final class PlayHistoryStore: Sendable {
             dimensionExpr = "COALESCE(NULLIF(trim(pe.event_genre), ''), 'Unknown')"
         case .source:
             dimensionExpr = "pe.source"
+        case .outputDevice:
+            dimensionExpr = "COALESCE(NULLIF(trim(pe.output_device), ''), 'Unknown')"
         }
         let limit = dimension == .artist ? 250 : 25
-        let (whereStr, params) = whereClause(for: filter)
+        var (whereStr, params) = whereClause(for: filter)
+        if dimension == .outputDevice {
+            let extra = "NULLIF(trim(pe.output_device), '') IS NOT NULL"
+            whereStr = whereStr.isEmpty ? "WHERE \(extra)" : "\(whereStr) AND \(extra)"
+        }
         let sql = """
             SELECT \(dimensionExpr), COUNT(*), COALESCE(SUM(pe.duration_listened), 0.0) / 60.0
             \(historyFromClause)
@@ -344,6 +350,10 @@ final class PlayHistoryStore: Sendable {
         if let contentType = filter.selectedContentType {
             conditions.append("COALESCE(pe.content_type, 'music') = ?")
             params.append(contentType)
+        }
+        if let device = filter.selectedOutputDevice {
+            conditions.append("COALESCE(NULLIF(trim(pe.output_device), ''), 'Unknown') = ?")
+            params.append(device)
         }
         if filter.excludeSkipped {
             conditions.append("pe.skipped = 0")

--- a/Sources/NullPlayer/Windows/ModernStats/StatsContentView.swift
+++ b/Sources/NullPlayer/Windows/ModernStats/StatsContentView.swift
@@ -57,6 +57,9 @@ struct StatsHeaderView: View {
             if let contentType = agent.filter.selectedContentType {
                 FilterChip(label: PlayHistoryContentType.displayName(for: contentType)) { agent.selectContentType(nil) }
             }
+            if let device = agent.filter.selectedOutputDevice {
+                FilterChip(label: device) { agent.selectOutputDevice(nil) }
+            }
             if agent.isLoading {
                 ProgressView().controlSize(.small)
             }

--- a/Sources/NullPlayer/Windows/ModernStats/StatsContentView.swift
+++ b/Sources/NullPlayer/Windows/ModernStats/StatsContentView.swift
@@ -134,6 +134,15 @@ struct StatsOverviewView: View {
                 )
                 .frame(height: 220)
 
+                OutputDeviceChartView(
+                    rows: agent.outputDeviceBreakdown,
+                    selected: Binding(
+                        get: { agent.filter.selectedOutputDevice },
+                        set: { (v: String?) in agent.selectOutputDevice(v) }
+                    )
+                )
+                .frame(height: 220)
+
                 ContentTypeChartView(
                     rows: agent.contentTypeBreakdown,
                     selected: Binding(
@@ -500,6 +509,79 @@ struct SourceChartView: View {
     }
 }
 
+private let outputDevicePalette: [Color] = [
+    .blue, .orange, .green, .purple, .red, .pink, .teal, .indigo, .yellow, .mint, .cyan, .brown
+]
+
+private func outputDeviceColor(for name: String) -> Color {
+    var hasher = Hasher()
+    hasher.combine(name)
+    let h = abs(hasher.finalize())
+    return outputDevicePalette[h % outputDevicePalette.count]
+}
+
+struct OutputDeviceChartView: View {
+    let rows: [TopDimensionRow]
+    @Binding var selected: String?
+    private let chartSize: CGFloat = 156
+
+    var body: some View {
+        VStack(alignment: .leading, spacing: 4) {
+            Text("Output Devices").font(.subheadline).fontWeight(.medium)
+            if rows.isEmpty {
+                Text("No data").foregroundColor(.secondary).frame(maxWidth: .infinity, maxHeight: .infinity)
+            } else {
+                HStack(alignment: .top, spacing: 12) {
+                    Chart(rows) { row in
+                        SectorMark(
+                            angle: .value("Plays", row.playCount),
+                            innerRadius: .ratio(0.5)
+                        )
+                        .foregroundStyle(outputDeviceColor(for: row.displayName))
+                        .opacity(selected == nil || selected == row.id ? 1.0 : 0.4)
+                    }
+                    .chartLegend(.hidden)
+                    .frame(width: chartSize, height: chartSize)
+                    .onTapGesture { selected = nil }
+
+                    ScrollView(.vertical, showsIndicators: true) {
+                        VStack(spacing: 3) {
+                            ForEach(rows) { row in
+                                Button {
+                                    selected = (selected == row.id) ? nil : row.id
+                                } label: {
+                                    HStack(spacing: 6) {
+                                        Circle()
+                                            .fill(outputDeviceColor(for: row.displayName))
+                                            .frame(width: 8, height: 8)
+                                        Text(row.displayName)
+                                            .font(.caption2)
+                                            .foregroundColor(row.id == selected ? .accentColor : .primary)
+                                            .lineLimit(1)
+                                        Spacer(minLength: 0)
+                                        Text("\(row.playCount)")
+                                            .font(.caption2)
+                                            .foregroundColor(.secondary)
+                                            .monospacedDigit()
+                                    }
+                                    .contentShape(Rectangle())
+                                }
+                                .buttonStyle(.plain)
+                                .opacity(selected == nil || selected == row.id ? 1.0 : 0.5)
+                            }
+                        }
+                        .padding(.vertical, 2)
+                        .padding(.trailing, 12)
+                    }
+                    .frame(maxWidth: .infinity, maxHeight: .infinity, alignment: .topLeading)
+                }
+                .frame(maxHeight: .infinity, alignment: .top)
+            }
+        }
+        .frame(maxWidth: .infinity)
+    }
+}
+
 private let contentTypeColorScale: KeyValuePairs<String, Color> = [
     "Music": .blue,
     "Movies": .orange,
@@ -632,7 +714,7 @@ struct TimeSeriesChartView: View {
                 .chartForegroundStyleScale(sourceColorScale)
                 .chartLegend(.hidden)
                 .chartXAxis {
-                    AxisMarks(values: .stride(by: calendarUnit, count: axisStrideCount)) { value in
+                    AxisMarks(values: .automatic(desiredCount: 6)) { value in
                         AxisGridLine().foregroundStyle(skinTextColor.opacity(0.15))
                         if let date = value.as(Date.self) {
                             AxisValueLabel {

--- a/Sources/NullPlayer/Windows/ModernStats/StatsContentView.swift
+++ b/Sources/NullPlayer/Windows/ModernStats/StatsContentView.swift
@@ -519,8 +519,8 @@ private let outputDevicePalette: [Color] = [
 private func outputDeviceColor(for name: String) -> Color {
     var hasher = Hasher()
     hasher.combine(name)
-    let h = abs(hasher.finalize())
-    return outputDevicePalette[h % outputDevicePalette.count]
+    let h = UInt(bitPattern: hasher.finalize())
+    return outputDevicePalette[Int(h % UInt(outputDevicePalette.count))]
 }
 
 struct OutputDeviceChartView: View {

--- a/Sources/NullPlayer/Windows/VideoPlayer/VideoPlayerWindowController.swift
+++ b/Sources/NullPlayer/Windows/VideoPlayer/VideoPlayerWindowController.swift
@@ -525,7 +525,8 @@ class VideoPlayerWindowController: NSWindowController, NSWindowDelegate {
             durationListened: duration,
             source: source,
             skipped: false,
-            contentType: contentType)
+            contentType: contentType,
+            outputDevice: AudioOutputManager.shared.currentDeviceDisplayName)
 
         playbackStartTime = nil
         accumulatedPlaybackDuration = 0

--- a/Sources/NullPlayer/Windows/VideoPlayer/VideoPlayerWindowController.swift
+++ b/Sources/NullPlayer/Windows/VideoPlayer/VideoPlayerWindowController.swift
@@ -526,7 +526,7 @@ class VideoPlayerWindowController: NSWindowController, NSWindowDelegate {
             source: source,
             skipped: false,
             contentType: contentType,
-            outputDevice: AudioOutputManager.shared.currentDeviceDisplayName)
+            outputDevice: CastManager.currentPlaybackDeviceName)
 
         playbackStartTime = nil
         accumulatedPlaybackDuration = 0

--- a/Tests/NullPlayerAppTests/MediaLibraryStoreMigrationTests.swift
+++ b/Tests/NullPlayerAppTests/MediaLibraryStoreMigrationTests.swift
@@ -40,7 +40,7 @@ final class MediaLibraryStoreMigrationTests: XCTestCase {
         store.open(at: dbURL)
         let db = try XCTUnwrap(store.testDB)
 
-        XCTAssertEqual(try db.scalar("PRAGMA user_version") as? Int64, 6)
+        XCTAssertEqual(try db.scalar("PRAGMA user_version") as? Int64, 7)
         XCTAssertTrue(try table("play_events", hasColumn: "content_type", in: db))
 
         let rows = try db.prepare("SELECT source, content_type FROM play_events ORDER BY id").map {
@@ -69,7 +69,7 @@ final class MediaLibraryStoreMigrationTests: XCTestCase {
         store.open(at: dbURL)
         let db = try XCTUnwrap(store.testDB)
 
-        XCTAssertEqual(try db.scalar("PRAGMA user_version") as? Int64, 6)
+        XCTAssertEqual(try db.scalar("PRAGMA user_version") as? Int64, 7)
 
         let rows = try db.prepare("SELECT source, content_type FROM play_events ORDER BY id").map {
             (($0[0] as? String) ?? "", ($0[1] as? String) ?? "")

--- a/Tests/NullPlayerAppTests/MediaLibraryStoreMigrationTests.swift
+++ b/Tests/NullPlayerAppTests/MediaLibraryStoreMigrationTests.swift
@@ -82,6 +82,30 @@ final class MediaLibraryStoreMigrationTests: XCTestCase {
         XCTAssertEqual(rows[1].1, "movie")
     }
 
+    func testV6ToV7MigrationAddsOutputDeviceColumn() throws {
+        let dbURL = tempDirectoryURL.appendingPathComponent("library-v6.sqlite")
+
+        do {
+            let seedConnection = try Connection(dbURL.path)
+            try seedConnection.execute("""
+                CREATE TABLE play_events (
+                    id INTEGER PRIMARY KEY AUTOINCREMENT,
+                    source TEXT NOT NULL,
+                    content_type TEXT
+                );
+                """)
+            try seedConnection.run("PRAGMA user_version = 6")
+            try seedConnection.run("INSERT INTO play_events (source, content_type) VALUES (?, ?)",
+                                   ["local" as Binding, "music" as Binding])
+        }
+
+        store.open(at: dbURL)
+        let db = try XCTUnwrap(store.testDB)
+
+        XCTAssertEqual(try db.scalar("PRAGMA user_version") as? Int64, 7)
+        XCTAssertTrue(try table("play_events", hasColumn: "output_device", in: db))
+    }
+
     private func seedLegacyPlayEventsTable(at dbURL: URL, withContentTypeColumn: Bool) throws {
         let db = try Connection(dbURL.path)
 


### PR DESCRIPTION
## Summary
- Schema v7 migration adds `output_device` to `play_events`; all 5 `insertPlayEvent` call sites pass the active device name (resolved via `AudioOutputManager.currentDeviceDisplayName`, falling back to the system default device's actual name)
- New Output Devices breakdown chart on the data page, filterable like Source/Genre; NULL/legacy rows are excluded so only real device entries appear
- Plays Over Time x-axis switched to `.automatic(desiredCount: 6)` to stop date labels from overlapping at the default window width

## Test plan
- [x] `swift test` passes (58 tests, including updated v6→v7 user_version assertions)
- [x] `swift build` clean
- [ ] Play a local file, end of track, open Stats — Output Devices section shows current device with ~track-duration
- [ ] Switch system output device, play another track — two distinct entries appear
- [ ] Click a device row — page filters; click again to deselect; Clear Filters resets it
- [ ] Pre-migration plays do not appear in the chart
- [ ] Plays Over Time x-axis labels no longer overlap at default width across Day/Week/Month

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Audio playback output device is now tracked and recorded in analytics
  * "Output Devices" chart added to the statistics overview, allowing you to view and filter playback history by output device

* **Chores**
  * Database schema updated to support device tracking functionality

<!-- end of auto-generated comment: release notes by coderabbit.ai -->