### PR TITLE
Add beat-synced EKG visualization mode

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,24 @@
 # Changelog
 
+## 0.21.0
+
+### New Features
+
+- **Output device analytics** — play events now record which audio output device (or cast target) was active. A new Output Devices breakdown chart appears in the Data tab with the same filter-and-chip interaction as Source and Genre. Cast sessions record the Chromecast, Sonos, or DLNA device name instead of the local CoreAudio output.
+- **EKG visualization mode** — the main window and spectrum window now include a BPM-synced EKG mode in both classic and modern UI paths. The persistent Metal trace preserves already-drawn history while the scan head renders new beats, peak height follows raw PCM amplitude, and EKG Style menus offer Clinical, Cyan, Amber, Neon, Crimson, and Ice palettes.
+- **Classic library Data tab** — the classic library browser now has a Data tab with the same play-history analytics available in the modern UI, including time-range filtering and source/genre breakdowns.
+- **Media-specific Data tab charts** — the Data tab overview now shows separate Top Movies and Top TV Shows sections alongside Top Artists. TV episode events are grouped by show name. Internet radio listen sessions appear in a dedicated Internet Radio section ranked by station plays and total listen time.
+- **Internet radio play history** — internet radio sessions are now recorded in play history with pause-aware duration tracking, 30-minute checkpoints for long sessions, and app-quit flushing.
+
+### Improvements
+
+- **Modern marquee art padding balanced** — album artwork in the modern main window marquee now has equal padding on both sides.
+
+### Bug Fixes
+
+- **Dock icon size fixed** — the app icon is now correctly sized in the Dock, matching the visual weight of neighboring icons. The symbol cutout renders correctly on dark backgrounds.
+- **Output device color overflow fixed** — the hash function used to assign colors to output devices no longer traps on `Int.min` overflow.
+
 ## 0.20.0
 
 ### New Features

--- a/Package.swift
+++ b/Package.swift
@@ -81,6 +81,7 @@ let package = Package(
                 .copy("Visualization/ElectricityShaders.metal"),
                 .copy("Visualization/MatrixShaders.metal"),
                 .copy("Visualization/SnowShaders.metal"),
+                .copy("Visualization/EKGShaders.metal"),
                 .copy("ModernSkin/BloomShader.metal")
             ],
             linkerSettings: [

--- a/Sources/NullPlayer/App/ContextMenuBuilder.swift
+++ b/Sources/NullPlayer/App/ContextMenuBuilder.swift
@@ -1097,6 +1097,27 @@ class ContextMenuBuilder {
             visMenu.addItem(matrixIntensityItem)
         }
 
+        // EKG Style submenu (only when EKG mode active)
+        if currentMode == .ekg {
+            let ekgStyleItem = NSMenuItem(title: "EKG Style", action: nil, keyEquivalent: "")
+            let ekgStyleMenu = NSMenu()
+            ekgStyleMenu.autoenablesItems = false
+
+            let currentStyle = UserDefaults.standard.string(forKey: "mainWindowEKGStyle")
+                .flatMap { EKGStyle(rawValue: $0) } ?? .clinical
+
+            for style in EKGStyle.allCases {
+                let item = NSMenuItem(title: style.displayName, action: #selector(MenuActions.setMainVisEKGStyle(_:)), keyEquivalent: "")
+                item.target = MenuActions.shared
+                item.representedObject = style
+                item.state = (currentStyle == style) ? .on : .off
+                ekgStyleMenu.addItem(item)
+            }
+
+            ekgStyleItem.submenu = ekgStyleMenu
+            visMenu.addItem(ekgStyleItem)
+        }
+
         // vis_classic profile controls (only when vis_classic mode active)
         if currentMode == .visClassicExact {
             let profilesMenuItem = NSMenuItem(title: "Profiles", action: nil, keyEquivalent: "")
@@ -1346,6 +1367,27 @@ class ContextMenuBuilder {
             
             matrixIntensityItem.submenu = matrixIntensityMenu
             spectrumWindowMenu.addItem(matrixIntensityItem)
+        }
+
+        // EKG Style submenu (only when EKG mode active)
+        if currentQuality == .ekg {
+            let ekgStyleItem = NSMenuItem(title: "EKG Style", action: nil, keyEquivalent: "")
+            let ekgStyleMenu = NSMenu()
+            ekgStyleMenu.autoenablesItems = false
+
+            let currentStyle = UserDefaults.standard.string(forKey: "ekgStyle")
+                .flatMap { EKGStyle(rawValue: $0) } ?? .clinical
+
+            for style in EKGStyle.allCases {
+                let item = NSMenuItem(title: style.displayName, action: #selector(MenuActions.setSpectrumEKGStyle(_:)), keyEquivalent: "")
+                item.target = MenuActions.shared
+                item.representedObject = style
+                item.state = (currentStyle == style) ? .on : .off
+                ekgStyleMenu.addItem(item)
+            }
+
+            ekgStyleItem.submenu = ekgStyleMenu
+            spectrumWindowMenu.addItem(ekgStyleItem)
         }
 
         // vis_classic profile controls (only when vis_classic mode active)
@@ -3931,6 +3973,12 @@ class MenuActions: NSObject {
         UserDefaults.standard.set(intensity.rawValue, forKey: "matrixIntensity")
         NotificationCenter.default.post(name: NSNotification.Name("SpectrumSettingsChanged"), object: nil)
     }
+
+    @objc func setSpectrumEKGStyle(_ sender: NSMenuItem) {
+        guard let style = sender.representedObject as? EKGStyle else { return }
+        UserDefaults.standard.set(style.rawValue, forKey: "ekgStyle")
+        NotificationCenter.default.post(name: NSNotification.Name("SpectrumSettingsChanged"), object: nil)
+    }
     
     @objc func setMainVisFlameIntensity(_ sender: NSMenuItem) {
         guard let intensity = sender.representedObject as? FlameIntensity else { return }
@@ -3953,6 +4001,12 @@ class MenuActions: NSObject {
     @objc func setMainVisMatrixIntensity(_ sender: NSMenuItem) {
         guard let intensity = sender.representedObject as? MatrixIntensity else { return }
         UserDefaults.standard.set(intensity.rawValue, forKey: "mainWindowMatrixIntensity")
+        NotificationCenter.default.post(name: NSNotification.Name("MainWindowVisChanged"), object: nil)
+    }
+
+    @objc func setMainVisEKGStyle(_ sender: NSMenuItem) {
+        guard let style = sender.representedObject as? EKGStyle else { return }
+        UserDefaults.standard.set(style.rawValue, forKey: "mainWindowEKGStyle")
         NotificationCenter.default.post(name: NSNotification.Name("MainWindowVisChanged"), object: nil)
     }
     

--- a/Sources/NullPlayer/Audio/AudioEngine.swift
+++ b/Sources/NullPlayer/Audio/AudioEngine.swift
@@ -1206,12 +1206,10 @@ class AudioEngine {
             }
         }
         
-        // Feed BPM detector with raw mono samples (before windowing) — modern UI only
-        if isModernUIEnabled {
-            fftSamples.withUnsafeBufferPointer { ptr in
-                if let base = ptr.baseAddress {
-                    bpmDetector.process(samples: base, count: fftSize, sampleRate: buffer.format.sampleRate)
-                }
+        // Feed BPM detector with raw mono samples before windowing.
+        fftSamples.withUnsafeBufferPointer { ptr in
+            if let base = ptr.baseAddress {
+                bpmDetector.process(samples: base, count: fftSize, sampleRate: buffer.format.sampleRate)
             }
         }
         

--- a/Sources/NullPlayer/Audio/StreamingAudioPlayer.swift
+++ b/Sources/NullPlayer/Audio/StreamingAudioPlayer.swift
@@ -451,12 +451,10 @@ class StreamingAudioPlayer {
         guard shouldUpdate else { return }
         lastSpectrumUpdateTime = now
         
-        // Feed BPM detector with raw mono samples (before windowing) — modern UI only
-        if isModernUIEnabled {
-            fftSamples.withUnsafeBufferPointer { ptr in
-                if let base = ptr.baseAddress {
-                    bpmDetector.process(samples: base, count: fftSize, sampleRate: buffer.format.sampleRate)
-                }
+        // Feed BPM detector with raw mono samples before windowing.
+        fftSamples.withUnsafeBufferPointer { ptr in
+            if let base = ptr.baseAddress {
+                bpmDetector.process(samples: base, count: fftSize, sampleRate: buffer.format.sampleRate)
             }
         }
         

--- a/Sources/NullPlayer/Visualization/EKGShaders.metal
+++ b/Sources/NullPlayer/Visualization/EKGShaders.metal
@@ -1,0 +1,270 @@
+// =============================================================================
+// EKG SHADERS - Beat-Synced Electrocardiogram Visualizer
+// =============================================================================
+// Persistent ECG monitor. BPM controls the cardiac clock, raw PCM amplitude
+// controls newly drawn peak height, and the already-drawn trace is preserved in
+// a ping-pong texture so historical line segments do not refresh or rescale.
+// This mode intentionally ignores frequency energy.
+// =============================================================================
+
+#include <metal_stdlib>
+using namespace metal;
+
+struct EKGParams {
+    float2 viewportSize;
+    float time;
+    float bpm;
+    float beatPhase;
+    float amplitudeLevel;
+    float noiseLevel;
+    float scrollDelta;
+    float brightnessBoost;
+    int colorScheme;
+    float2 padding;
+};
+
+constant float EKG_SCREEN_SECONDS = 5.6;
+constant float EKG_SCAN_HEAD_X = 0.965;
+
+float3 ekg_style_color(int scheme, int role) {
+    switch (scheme) {
+        case 1: // Cyan
+            if (role == 0) return float3(0.080, 0.930, 0.980);
+            if (role == 1) return float3(0.650, 1.000, 1.000);
+            if (role == 2) return float3(0.010, 0.165, 0.175);
+            if (role == 3) return float3(0.015, 0.300, 0.320);
+            return float3(0.002, 0.022, 0.026);
+        case 2: // Amber
+            if (role == 0) return float3(1.000, 0.650, 0.120);
+            if (role == 1) return float3(1.000, 0.930, 0.530);
+            if (role == 2) return float3(0.170, 0.105, 0.018);
+            if (role == 3) return float3(0.330, 0.190, 0.030);
+            return float3(0.030, 0.017, 0.003);
+        case 3: // Neon
+            if (role == 0) return float3(0.980, 0.140, 0.760);
+            if (role == 1) return float3(0.420, 1.000, 0.980);
+            if (role == 2) return float3(0.150, 0.030, 0.130);
+            if (role == 3) return float3(0.280, 0.060, 0.270);
+            return float3(0.026, 0.003, 0.024);
+        case 4: // Crimson
+            if (role == 0) return float3(1.000, 0.145, 0.120);
+            if (role == 1) return float3(1.000, 0.760, 0.560);
+            if (role == 2) return float3(0.170, 0.030, 0.025);
+            if (role == 3) return float3(0.330, 0.060, 0.050);
+            return float3(0.030, 0.004, 0.003);
+        case 5: // Ice
+            if (role == 0) return float3(0.620, 0.940, 1.000);
+            if (role == 1) return float3(0.930, 1.000, 1.000);
+            if (role == 2) return float3(0.070, 0.130, 0.170);
+            if (role == 3) return float3(0.120, 0.250, 0.330);
+            return float3(0.009, 0.018, 0.026);
+        default: // Clinical
+            if (role == 0) return float3(0.105, 0.900, 0.400);
+            if (role == 1) return float3(0.780, 1.000, 0.720);
+            if (role == 2) return float3(0.005, 0.115, 0.075);
+            if (role == 3) return float3(0.020, 0.240, 0.145);
+            return float3(0.002, 0.026, 0.019);
+    }
+}
+
+float ekg_hash(float2 p) {
+    p = fract(p * float2(123.34, 456.21));
+    p += dot(p, p + 45.32);
+    return fract(p.x * p.y);
+}
+
+float ekg_noise(float2 p) {
+    float2 i = floor(p);
+    float2 f = fract(p);
+    f = f * f * (3.0 - 2.0 * f);
+    return mix(
+        mix(ekg_hash(i), ekg_hash(i + float2(1.0, 0.0)), f.x),
+        mix(ekg_hash(i + float2(0.0, 1.0)), ekg_hash(i + float2(1.0, 1.0)), f.x),
+        f.y
+    );
+}
+
+float ekg_gaussian(float p, float center, float width) {
+    float d = (p - center) / width;
+    return exp(-d * d);
+}
+
+float ekg_wave_for_beat(float t, float beatTime, float beatIndex) {
+    float dt = t - beatTime;
+    float seed = ekg_hash(float2(beatIndex, 19.73));
+    float qrsAmp = mix(0.97, 1.04, seed);
+    float pAmp = mix(0.92, 1.06, ekg_hash(float2(beatIndex, 43.17)));
+    float tAmp = mix(0.93, 1.07, ekg_hash(float2(beatIndex, 71.41)));
+
+    float pWave = 0.080 * ekg_gaussian(dt, -0.180, 0.046) * pAmp;
+    float qWave = -0.135 * ekg_gaussian(dt, -0.026, 0.010) * qrsAmp;
+    float rWave = 1.000 * ekg_gaussian(dt, 0.000, 0.011) * qrsAmp;
+    float sWave = -0.300 * ekg_gaussian(dt, 0.028, 0.014) * qrsAmp;
+    float stSeg = 0.016 * smoothstep(0.052, 0.082, dt) * (1.0 - smoothstep(0.150, 0.205, dt));
+    float tWave = 0.190 * ekg_gaussian(dt, 0.290, 0.086) * tAmp;
+    float uWave = 0.025 * ekg_gaussian(dt, 0.505, 0.050);
+
+    return pWave + qWave + rWave + sWave + stSeg + tWave + uWave;
+}
+
+float ekg_waveform_at_time(float t, constant EKGParams& params) {
+    float bpm = clamp(params.bpm, 40.0, 100.0);
+    float interval = 60.0 / bpm;
+    float beatCursor = floor(t / interval);
+    float loudness = mix(0.70, 1.42, smoothstep(0.02, 0.92, params.amplitudeLevel));
+    float wave = 0.0;
+
+    for (int i = -1; i <= 1; i++) {
+        float beatIndex = beatCursor + float(i);
+        wave += ekg_wave_for_beat(t, beatIndex * interval, beatIndex);
+    }
+
+    float nerve = (ekg_noise(float2(t * 19.0, params.time * 2.0)) - 0.5) * params.noiseLevel * 0.020;
+    return wave * loudness + nerve;
+}
+
+float ekg_trace_y_for_time(float sampleTime, constant EKGParams& params) {
+    float bpmNorm = clamp((params.bpm - 40.0) / 60.0, 0.0, 1.0);
+    float tempoBreath = sin(sampleTime * 0.115 * 6.2831853);
+
+    float baseline = 0.365;
+    baseline += tempoBreath * 0.009;
+    baseline += sin(sampleTime * 0.050 * 6.2831853) * 0.008;
+    baseline += sin(sampleTime * 0.33 * 6.2831853) * 0.003;
+
+    float amp = 0.305 + bpmNorm * 0.015;
+    return clamp(baseline + ekg_waveform_at_time(sampleTime, params) * amp, 0.055, 0.945);
+}
+
+float ekg_sample_time_for_x(float x, constant EKGParams& params) {
+    float history = clamp(EKG_SCAN_HEAD_X - x, 0.0, EKG_SCAN_HEAD_X) / EKG_SCAN_HEAD_X;
+    return params.time - history * EKG_SCREEN_SECONDS;
+}
+
+float distance_segment(float2 p, float2 a, float2 b) {
+    float2 pa = p - a;
+    float2 ba = b - a;
+    float h = clamp(dot(pa, ba) / max(dot(ba, ba), 0.000001), 0.0, 1.0);
+    return length(pa - ba * h);
+}
+
+float ekg_grid_line(float v, float width) {
+    float d = min(fract(v), 1.0 - fract(v));
+    return 1.0 - smoothstep(width, width * 1.9, d);
+}
+
+vertex float4 ekg_vertex(uint vertexID [[vertex_id]]) {
+    float2 positions[6] = {
+        float2(-1.0, -1.0), float2(1.0, -1.0), float2(-1.0, 1.0),
+        float2(-1.0, 1.0),  float2(1.0, -1.0), float2(1.0, 1.0)
+    };
+    return float4(positions[vertexID], 0.0, 1.0);
+}
+
+fragment float4 ekg_update_fragment(
+    float4 position [[position]],
+    constant EKGParams& params [[buffer(0)]],
+    texture2d<float> previousTrace [[texture(0)]]
+) {
+    constexpr sampler s(mag_filter::linear, min_filter::linear, address::clamp_to_zero);
+    float2 screenUV = position.xy / params.viewportSize;
+    float2 uv = float2(screenUV.x, 1.0 - screenUV.y);
+
+    float4 previous = previousTrace.sample(s, float2(screenUV.x + params.scrollDelta, screenUV.y));
+    previous *= 0.997;
+
+    float minDim = min(params.viewportSize.x, params.viewportSize.y);
+    float aspect = params.viewportSize.x / max(params.viewportSize.y, 1.0);
+    float2 p = float2(uv.x * aspect, uv.y);
+    float pixelX = 1.0 / max(params.viewportSize.x, 1.0);
+
+    float drawBand = max(params.scrollDelta * 3.5, pixelX * 5.0);
+    float inHeadBand = smoothstep(EKG_SCAN_HEAD_X - drawBand, EKG_SCAN_HEAD_X - drawBand * 0.35, uv.x);
+    inHeadBand *= 1.0 - smoothstep(EKG_SCAN_HEAD_X, EKG_SCAN_HEAD_X + pixelX * 2.0, uv.x);
+
+    float minD = 10.0;
+    for (int i = -6; i <= 2; i++) {
+        float x0 = clamp(uv.x + float(i) * pixelX * 1.70, EKG_SCAN_HEAD_X - drawBand * 1.35, EKG_SCAN_HEAD_X);
+        float x1 = clamp(x0 + pixelX * 2.25, EKG_SCAN_HEAD_X - drawBand * 1.35, EKG_SCAN_HEAD_X);
+        float t0 = ekg_sample_time_for_x(x0, params);
+        float t1 = ekg_sample_time_for_x(x1, params);
+        float y0 = ekg_trace_y_for_time(t0, params);
+        float y1 = ekg_trace_y_for_time(t1, params);
+        minD = min(minD, distance_segment(p, float2(x0 * aspect, y0), float2(x1 * aspect, y1)));
+    }
+
+    float phaseDistance = min(params.beatPhase, 1.0 - params.beatPhase);
+    float qrsFlash = exp(-pow(phaseDistance / 0.055, 2.0));
+    float livePulse = clamp(qrsFlash * 1.10, 0.0, 1.25);
+    float lineWidth = (1.05 + livePulse * 0.62) / max(minDim, 1.0);
+    float aa = 1.35 / max(minDim, 1.0);
+    float line = (1.0 - smoothstep(lineWidth, lineWidth + aa, minD)) * inHeadBand;
+    float nearGlow = exp(-minD * minDim * 0.50) * (0.42 + livePulse * 0.55) * inHeadBand;
+    float farGlow = exp(-minD * minDim * 0.105) * (0.13 + livePulse * 0.18) * inHeadBand;
+
+    float3 baseTrace = ekg_style_color(params.colorScheme, 0);
+    float3 hotTrace = ekg_style_color(params.colorScheme, 1);
+    float3 traceCore = mix(baseTrace, hotTrace, livePulse * 0.48);
+    float3 current = traceCore * line * (1.22 + livePulse * 0.80);
+    current += baseTrace * nearGlow * 0.95;
+    current += baseTrace * farGlow * 0.48;
+
+    return max(previous, float4(current, max(line, nearGlow * 0.42)));
+}
+
+fragment float4 ekg_composite_fragment(
+    float4 position [[position]],
+    constant EKGParams& params [[buffer(0)]],
+    texture2d<float> traceTexture [[texture(0)]]
+) {
+    constexpr sampler s(mag_filter::linear, min_filter::linear, address::clamp_to_zero);
+    float2 screenUV = position.xy / params.viewportSize;
+    float2 uv = float2(screenUV.x, 1.0 - screenUV.y);
+    float2 centered = uv - 0.5;
+
+    float scanline = 0.965 + 0.035 * sin(position.y * 3.14159265);
+    float vignette = 1.0 - dot(centered, centered) * 0.88;
+    float3 backgroundColor = ekg_style_color(params.colorScheme, 4);
+    float3 minorColor = ekg_style_color(params.colorScheme, 2);
+    float3 majorColor = ekg_style_color(params.colorScheme, 3);
+    float3 traceColor = ekg_style_color(params.colorScheme, 0);
+    float3 hotTrace = ekg_style_color(params.colorScheme, 1);
+
+    float3 color = backgroundColor * scanline;
+    color *= clamp(vignette, 0.36, 1.0);
+
+    float majorX = ekg_grid_line(uv.x * 10.0, 0.010);
+    float majorY = ekg_grid_line(uv.y * 8.0, 0.010);
+    float minorX = ekg_grid_line(uv.x * 50.0, 0.008);
+    float minorY = ekg_grid_line(uv.y * 40.0, 0.008);
+    float minorGrid = max(minorX, minorY);
+    float majorGrid = max(majorX, majorY);
+    color += minorColor * minorGrid * 0.34;
+    color += majorColor * majorGrid * 0.42;
+
+    float slowNoise = ekg_noise(uv * float2(70.0, 38.0) + float2(params.time * 0.35, -params.time * 0.25));
+    color += (slowNoise - 0.5) * params.noiseLevel * minorColor * 0.38;
+
+    float4 trace = traceTexture.sample(s, screenUV);
+    color += trace.rgb;
+
+    float minDim = min(params.viewportSize.x, params.viewportSize.y);
+    float phaseDistance = min(params.beatPhase, 1.0 - params.beatPhase);
+    float qrsFlash = exp(-pow(phaseDistance / 0.055, 2.0));
+    float livePulse = clamp(qrsFlash * 1.10, 0.0, 1.25);
+
+    float scanX = EKG_SCAN_HEAD_X;
+    float beam = 1.0 - smoothstep(0.0, 0.024 + livePulse * 0.018, abs(uv.x - scanX));
+    float headY = ekg_trace_y_for_time(params.time, params);
+    float headD = length((uv - float2(scanX, headY)) * float2(params.viewportSize.x / max(params.viewportSize.y, 1.0), 1.0));
+    float head = exp(-headD * minDim * 0.052);
+    color += traceColor * beam * 0.24;
+    color += hotTrace * head * (0.62 + livePulse * 0.74);
+
+    float floorReflection = (1.0 - smoothstep(0.03, 0.36, uv.y)) * trace.a * 0.16;
+    color += traceColor * floorReflection * 0.55;
+
+    float exposure = 0.98 + params.brightnessBoost * 0.24 + livePulse * 0.08;
+    color = 1.0 - exp(-color * exposure);
+    return float4(saturate(color), 1.0);
+}

--- a/Sources/NullPlayer/Visualization/SpectrumAnalyzerView.swift
+++ b/Sources/NullPlayer/Visualization/SpectrumAnalyzerView.swift
@@ -36,6 +36,7 @@ enum SpectrumQualityMode: String, CaseIterable {
     case electricity = "Lightning" // GPU lightning storm driven by peak frequencies
     case matrix = "Matrix"           // Falling digital rain driven by spectrum
     case snow = "Snow"               // Audio-reactive snowfall driven by spectrum density
+    case ekg = "EKG"                 // Beat-synced electrocardiogram monitor driven by BPM and waveform amplitude
     case visClassicExact = "vis_classic" // Exact-port vis_classic analyzer core (CPU frame path)
     
     var displayName: String { rawValue }
@@ -50,6 +51,7 @@ enum SpectrumQualityMode: String, CaseIterable {
         case .electricity: return "ElectricityShaders"
         case .matrix: return "MatrixShaders"
         case .snow: return "SnowShaders"
+        case .ekg: return "EKGShaders"
         case .visClassicExact: return "SpectrumShaders" // Always bundled; keeps mode enabled in menus
         }
     }
@@ -213,6 +215,28 @@ enum MatrixIntensity: String, CaseIterable {
     }
 }
 
+/// Color/style presets for EKG mode
+enum EKGStyle: String, CaseIterable {
+    case clinical = "Clinical"
+    case cyan = "Cyan"
+    case amber = "Amber"
+    case neon = "Neon"
+    case crimson = "Crimson"
+    case ice = "Ice"
+
+    var displayName: String { rawValue }
+    var colorScheme: Int32 {
+        switch self {
+        case .clinical: return 0
+        case .cyan: return 1
+        case .amber: return 2
+        case .neon: return 3
+        case .crimson: return 4
+        case .ice: return 5
+        }
+    }
+}
+
 /// Parameters for Matrix Metal shaders (must match Metal MatrixParams struct)
 struct MatrixParams {
     var viewportSize: SIMD2<Float>  // 8 bytes (offset 0)
@@ -242,6 +266,20 @@ struct SnowParams {
     var windPhase: Float             // 4 bytes (offset 36)
     var density: Float               // 4 bytes (offset 40)
     var brightnessBoost: Float = 1.0 // 4 bytes (offset 44) → total 48
+}
+
+/// Parameters for EKG Metal shaders (must match Metal EKGParams struct)
+struct EKGParams {
+    var viewportSize: SIMD2<Float>  // 8 bytes (offset 0)
+    var time: Float                  // 4 bytes (offset 8)
+    var bpm: Float                   // 4 bytes (offset 12)
+    var beatPhase: Float             // 4 bytes (offset 16)
+    var amplitudeLevel: Float        // 4 bytes (offset 20)
+    var noiseLevel: Float            // 4 bytes (offset 24)
+    var scrollDelta: Float           // 4 bytes (offset 28)
+    var brightnessBoost: Float = 1.0 // 4 bytes (offset 32)
+    var colorScheme: Int32 = 0       // 4 bytes (offset 36)
+    var _padding: SIMD2<Float> = .zero // 8 bytes (offset 40), total 48
 }
 
 /// Decay mode controlling how quickly bars fall
@@ -318,8 +356,13 @@ struct UltraParams {
 
 // MARK: - Spectrum Analyzer View
 
+private let spectrumAnalyzerEKGSharedClockStart = CACurrentMediaTime()
+
 /// Metal-based spectrum analyzer visualization view
 class SpectrumAnalyzerView: NSView {
+    nonisolated(unsafe) private static var ekgSharedBPM: Float = 0
+    nonisolated(unsafe) private static var ekgSharedAmplitudeTarget: Float = 0.5
+
     private let waveformConsumerID = "visClassicWaveform.\(UUID().uuidString)"
 
     private var visClassicPreferenceScope: VisClassicBridge.PreferenceScope {
@@ -347,6 +390,7 @@ class SpectrumAnalyzerView: NSView {
         case .electricity: return electricityRenderPipeline != nil
         case .matrix: return matrixRenderPipeline != nil
         case .snow: return snowRenderPipeline != nil
+        case .ekg: return ekgUpdatePipeline != nil && ekgRenderPipeline != nil
         case .visClassicExact: return true
         }
     }
@@ -500,6 +544,20 @@ class SpectrumAnalyzerView: NSView {
             dataLock.withLock { renderFlameIntensity = intensity }
         }
     }
+
+    /// Current EKG color/style preset (only used when qualityMode == .ekg)
+    var ekgStyle: EKGStyle = .clinical {
+        didSet {
+            if !isEmbedded {
+                UserDefaults.standard.set(ekgStyle.rawValue, forKey: "ekgStyle")
+            }
+            let style = ekgStyle
+            dataLock.withLock {
+                renderEKGStyle = style
+                ekgTraceNeedsClear = true
+            }
+        }
+    }
     
     // MARK: - Metal Resources
     
@@ -542,6 +600,16 @@ class SpectrumAnalyzerView: NSView {
     // Snow mode resources
     private var snowRenderPipeline: MTLRenderPipelineState?
     private var snowParamsBuffer: MTLBuffer?
+
+    // EKG mode resources
+    private var ekgUpdatePipeline: MTLRenderPipelineState?
+    private var ekgRenderPipeline: MTLRenderPipelineState?
+    private var ekgParamsBuffer: MTLBuffer?
+    private var ekgTraceTextureA: MTLTexture?
+    private var ekgTraceTextureB: MTLTexture?
+    private var ekgTraceLastDrawableSize: CGSize = .zero
+    private var ekgTraceSourceIsA = true
+    nonisolated(unsafe) private var ekgTraceNeedsClear = true
 
     // vis_classic exact mode resources (CPU-rendered frame uploaded to a Metal texture)
     private var visClassicBridge: VisClassicBridge?
@@ -654,6 +722,15 @@ class SpectrumAnalyzerView: NSView {
     nonisolated(unsafe) private var snowWindPhase: Float = 0
     nonisolated(unsafe) private var snowDensity: Float = 0.2
 
+    // EKG mode state
+    nonisolated(unsafe) private var ekgBeatPhase: Float = 0
+    nonisolated(unsafe) private var ekgAmplitudeLevel: Float = 0.5
+    nonisolated(unsafe) private var ekgTargetAmplitudeLevel: Float = 0.5
+    nonisolated(unsafe) private var ekgNoiseLevel: Float = 0.04
+    nonisolated(unsafe) private var ekgCurrentBPM: Float = 0
+    nonisolated(unsafe) private var ekgLastRenderTime: Float = 0
+    nonisolated(unsafe) private var renderEKGStyle: EKGStyle = .clinical
+
     // vis_classic waveform state (latest 576-sample stereo frame)
     nonisolated(unsafe) private var visClassicWaveLeft: [UInt8] = Array(repeating: 128, count: 576)
     nonisolated(unsafe) private var visClassicWaveRight: [UInt8] = Array(repeating: 128, count: 576)
@@ -736,6 +813,12 @@ class SpectrumAnalyzerView: NSView {
             matrixIntensity = intensity
         }
         renderMatrixIntensity = matrixIntensity
+
+        if let saved = UserDefaults.standard.string(forKey: "ekgStyle"),
+           let style = EKGStyle(rawValue: saved) {
+            ekgStyle = style
+        }
+        renderEKGStyle = ekgStyle
         
         // Initialize display spectrum and sync to render-safe variables
         // Use max size to avoid any resizing during mode switches
@@ -803,6 +886,14 @@ class SpectrumAnalyzerView: NSView {
         // Observe playback state changes to ensure display link restarts when playback begins
         NotificationCenter.default.addObserver(self, selector: #selector(handlePlaybackStateChange),
                                                name: .audioPlaybackStateChanged, object: nil)
+
+        // Observe BPM detection updates for EKG mode's cardiac timing.
+        NotificationCenter.default.addObserver(self, selector: #selector(handleBPMUpdate(_:)),
+                                               name: .bpmUpdated, object: nil)
+
+        // Observe raw PCM amplitude for EKG peak height. This intentionally avoids frequency-band energy.
+        NotificationCenter.default.addObserver(self, selector: #selector(handlePCMAmplitudeUpdate(_:)),
+                                               name: .audioPCMDataUpdated, object: nil)
 
         // Observe 576-sample stereo waveform updates for vis_classic exact mode
         NotificationCenter.default.addObserver(self, selector: #selector(handleWaveform576Update(_:)),
@@ -901,6 +992,10 @@ class SpectrumAnalyzerView: NSView {
             if let savedMatIntensity = UserDefaults.standard.string(forKey: "matrixIntensity"),
                let matIntensity = MatrixIntensity(rawValue: savedMatIntensity) {
                 matrixIntensity = matIntensity
+            }
+            if let savedEKGStyle = UserDefaults.standard.string(forKey: "ekgStyle"),
+               let style = EKGStyle(rawValue: savedEKGStyle) {
+                ekgStyle = style
             }
         }
         
@@ -1012,6 +1107,45 @@ class SpectrumAnalyzerView: NSView {
             renderBlackFrame()
         }
     }
+
+    @objc private func handleBPMUpdate(_ notification: Notification) {
+        guard let bpm = notification.userInfo?["bpm"] as? Int else { return }
+        let foldedBPM = bpm > 0 ? Self.foldEKGBPM(Float(bpm)) : 0
+        Self.ekgSharedBPM = foldedBPM
+        dataLock.withLock {
+            ekgCurrentBPM = foldedBPM
+        }
+    }
+
+    private static func foldEKGBPM(_ bpm: Float) -> Float {
+        var folded = bpm
+        while folded > 100.0 {
+            folded *= 0.5
+        }
+        while folded > 0.0 && folded < 40.0 {
+            folded *= 2.0
+        }
+        return min(max(folded, 40.0), 100.0)
+    }
+
+    @objc private func handlePCMAmplitudeUpdate(_ notification: Notification) {
+        guard let pcm = notification.userInfo?["pcm"] as? [Float], !pcm.isEmpty else { return }
+
+        var sumSquares: Float = 0
+        var peak: Float = 0
+        for sample in pcm {
+            let magnitude = abs(sample)
+            peak = max(peak, magnitude)
+            sumSquares += sample * sample
+        }
+
+        let rms = sqrt(sumSquares / Float(pcm.count))
+        let level = min(max(pow(min(max(rms * 7.0 + peak * 0.45, 0.0), 1.0), 0.58), 0.0), 1.0)
+        Self.ekgSharedAmplitudeTarget = level
+        dataLock.withLock {
+            ekgTargetAmplitudeLevel = level
+        }
+    }
     
     // MARK: - Metal Setup
     
@@ -1054,6 +1188,7 @@ class SpectrumAnalyzerView: NSView {
         setupElectricityPipelines()
         setupMatrixPipelines()
         setupSnowPipelines()
+        setupEKGPipelines()
         
         // Create buffers
         setupBuffers()
@@ -1085,7 +1220,7 @@ class SpectrumAnalyzerView: NSView {
         case .electricity:
             // Lightning is fragment-heavy at fullscreen sizes.
             return 1.0
-        case .cosmic, .matrix, .snow:
+        case .cosmic, .matrix, .snow, .ekg:
             // Slight cap keeps these smooth while preserving detail.
             return min(baseScale, 1.25)
         default:
@@ -1193,6 +1328,8 @@ class SpectrumAnalyzerView: NSView {
                 pipelineState = matrixRenderPipeline
             case .snow:
                 pipelineState = snowRenderPipeline
+            case .ekg:
+                pipelineState = ekgRenderPipeline
             case .visClassicExact:
                 pipelineState = nil
             }
@@ -1270,6 +1407,9 @@ class SpectrumAnalyzerView: NSView {
         
         // Snow mode buffers
         snowParamsBuffer = device.makeBuffer(length: MemoryLayout<SnowParams>.stride, options: .storageModeShared)
+
+        // EKG mode buffers
+        ekgParamsBuffer = device.makeBuffer(length: MemoryLayout<EKGParams>.stride, options: .storageModeShared)
     }
     
     /// Set up flame compute and render pipelines
@@ -1418,6 +1558,37 @@ class SpectrumAnalyzerView: NSView {
             NSLog("SpectrumAnalyzerView: Snow pipeline created")
         } catch {
             NSLog("SpectrumAnalyzerView: Snow shader error: \(error)")
+        }
+    }
+
+    /// Set up EKG mode render pipeline
+    private func setupEKGPipelines() {
+        guard let device = device else { return }
+        guard let url = BundleHelper.url(forResource: "EKGShaders", withExtension: "metal"),
+              let src = try? String(contentsOf: url, encoding: .utf8) else {
+            NSLog("SpectrumAnalyzerView: EKGShaders.metal not found")
+            return
+        }
+        do {
+            let lib = try device.makeLibrary(source: src, options: nil)
+            if let vf = lib.makeFunction(name: "ekg_vertex"),
+               let updateFF = lib.makeFunction(name: "ekg_update_fragment"),
+               let compositeFF = lib.makeFunction(name: "ekg_composite_fragment") {
+                let updateDescriptor = MTLRenderPipelineDescriptor()
+                updateDescriptor.vertexFunction = vf
+                updateDescriptor.fragmentFunction = updateFF
+                updateDescriptor.colorAttachments[0].pixelFormat = .rgba16Float
+                ekgUpdatePipeline = try device.makeRenderPipelineState(descriptor: updateDescriptor)
+
+                let compositeDescriptor = MTLRenderPipelineDescriptor()
+                compositeDescriptor.vertexFunction = vf
+                compositeDescriptor.fragmentFunction = compositeFF
+                compositeDescriptor.colorAttachments[0].pixelFormat = .bgra8Unorm
+                ekgRenderPipeline = try device.makeRenderPipelineState(descriptor: compositeDescriptor)
+            }
+            NSLog("SpectrumAnalyzerView: EKG pipeline created")
+        } catch {
+            NSLog("SpectrumAnalyzerView: EKG shader error: \(error)")
         }
     }
 
@@ -1656,6 +1827,10 @@ class SpectrumAnalyzerView: NSView {
             renderSnow(drawable: drawable)
             return
         }
+        if currentMode == .ekg {
+            renderEKG(drawable: drawable)
+            return
+        }
         if currentMode == .visClassicExact {
             renderVisClassicExact(drawable: drawable)
             return
@@ -1679,6 +1854,8 @@ class SpectrumAnalyzerView: NSView {
             activePipeline = nil  // Handled by renderMatrix() above
         case .snow:
             activePipeline = nil  // Handled by renderSnow() above
+        case .ekg:
+            activePipeline = nil  // Handled by renderEKG() above
         case .visClassicExact:
             activePipeline = nil  // Handled by renderVisClassicExact() above
         }
@@ -1780,6 +1957,8 @@ class SpectrumAnalyzerView: NSView {
             break  // Handled by renderMatrix() above
         case .snow:
             break  // Handled by renderSnow() above
+        case .ekg:
+            break  // Handled by renderEKG() above
         case .visClassicExact:
             break  // Handled by renderVisClassicExact() above
         }
@@ -2380,6 +2559,146 @@ class SpectrumAnalyzerView: NSView {
         cb.commit()
     }
 
+    /// Render EKG mode: BPM-clocked ECG trace with no frequency-energy input
+    private func renderEKG(drawable: CAMetalDrawable) {
+        guard let cb = commandQueue?.makeCommandBuffer(),
+              let updatePL = ekgUpdatePipeline,
+              let renderPL = ekgRenderPipeline else {
+            inFlightSemaphore.signal(); return
+        }
+
+        let state = dataLock.withLock { () -> (
+            time: Float,
+            bpm: Float,
+            beatPhase: Float,
+            amplitude: Float,
+            scrollDelta: Float,
+            noise: Float,
+            style: EKGStyle
+        ) in
+            let localTime = Float(CACurrentMediaTime() - spectrumAnalyzerEKGSharedClockStart)
+            animationTime = localTime
+            let frameDelta = ekgLastRenderTime > 0 ? min(max(localTime - ekgLastRenderTime, 1.0 / 120.0), 1.0 / 20.0) : 1.0 / 60.0
+            ekgLastRenderTime = localTime
+
+            ekgCurrentBPM = Self.ekgSharedBPM
+            ekgTargetAmplitudeLevel = Self.ekgSharedAmplitudeTarget
+
+            let detectedBPM = ekgCurrentBPM > 0 ? ekgCurrentBPM : 80.0
+            let tempoHz = detectedBPM / 60.0
+            let beatClock = localTime * tempoHz
+            ekgBeatPhase = beatClock - floor(beatClock)
+
+            let phaseDistance = min(ekgBeatPhase, 1.0 - ekgBeatPhase)
+            let qrsPulse = exp(-pow(phaseDistance / 0.075, 2.0))
+            let targetNoise = 0.025 + qrsPulse * 0.025
+            ekgNoiseLevel += (targetNoise - ekgNoiseLevel) * 0.12
+            let amplitudeRate: Float = ekgTargetAmplitudeLevel > ekgAmplitudeLevel ? 0.28 : 0.075
+            ekgAmplitudeLevel += (ekgTargetAmplitudeLevel - ekgAmplitudeLevel) * amplitudeRate
+
+            return (
+                time: localTime,
+                bpm: detectedBPM,
+                beatPhase: ekgBeatPhase,
+                amplitude: ekgAmplitudeLevel,
+                scrollDelta: frameDelta / 5.6 * 0.965,
+                noise: ekgNoiseLevel,
+                style: renderEKGStyle
+            )
+        }
+
+        let viewport = drawableViewportSize(drawable)
+        guard let (sourceTrace, destinationTrace) = ensureEKGTraceTextures(
+            width: drawable.texture.width,
+            height: drawable.texture.height
+        ) else {
+            inFlightSemaphore.signal(); return
+        }
+
+        if let buf = ekgParamsBuffer {
+            let p = buf.contents().bindMemory(to: EKGParams.self, capacity: 1)
+            p.pointee = EKGParams(
+                viewportSize: viewport,
+                time: state.time,
+                bpm: state.bpm,
+                beatPhase: state.beatPhase,
+                amplitudeLevel: state.amplitude,
+                noiseLevel: state.noise,
+                scrollDelta: state.scrollDelta,
+                brightnessBoost: brightnessBoost,
+                colorScheme: state.style.colorScheme
+            )
+        }
+
+        if ekgTraceNeedsClear {
+            let clearPass = MTLRenderPassDescriptor()
+            clearPass.colorAttachments[0].texture = sourceTrace
+            clearPass.colorAttachments[0].loadAction = .clear
+            clearPass.colorAttachments[0].storeAction = .store
+            clearPass.colorAttachments[0].clearColor = MTLClearColor(red: 0, green: 0, blue: 0, alpha: 0)
+            if let enc = cb.makeRenderCommandEncoder(descriptor: clearPass) {
+                enc.endEncoding()
+            }
+            ekgTraceNeedsClear = false
+        }
+
+        let updatePass = MTLRenderPassDescriptor()
+        updatePass.colorAttachments[0].texture = destinationTrace
+        updatePass.colorAttachments[0].loadAction = .clear
+        updatePass.colorAttachments[0].storeAction = .store
+        updatePass.colorAttachments[0].clearColor = MTLClearColor(red: 0, green: 0, blue: 0, alpha: 0)
+
+        if let enc = cb.makeRenderCommandEncoder(descriptor: updatePass) {
+            enc.setRenderPipelineState(updatePL)
+            enc.setFragmentBuffer(ekgParamsBuffer, offset: 0, index: 0)
+            enc.setFragmentTexture(sourceTrace, index: 0)
+            enc.drawPrimitives(type: .triangle, vertexStart: 0, vertexCount: 6)
+            enc.endEncoding()
+        }
+
+        let rpd = MTLRenderPassDescriptor()
+        rpd.colorAttachments[0].texture = drawable.texture
+        rpd.colorAttachments[0].loadAction = .clear
+        rpd.colorAttachments[0].storeAction = .store
+        rpd.colorAttachments[0].clearColor = MTLClearColor(red: 0.0, green: 0.015, blue: 0.012, alpha: 1)
+
+        if let enc = cb.makeRenderCommandEncoder(descriptor: rpd) {
+            enc.setRenderPipelineState(renderPL)
+            enc.setFragmentBuffer(ekgParamsBuffer, offset: 0, index: 0)
+            enc.setFragmentTexture(destinationTrace, index: 0)
+            enc.drawPrimitives(type: .triangle, vertexStart: 0, vertexCount: 6)
+            enc.endEncoding()
+        }
+
+        ekgTraceSourceIsA.toggle()
+        cb.addCompletedHandler { [weak self] _ in self?.inFlightSemaphore.signal() }
+        cb.present(drawable)
+        cb.commit()
+    }
+
+    private func ensureEKGTraceTextures(width: Int, height: Int) -> (MTLTexture, MTLTexture)? {
+        guard let device = device, width > 0, height > 0 else { return nil }
+        let size = CGSize(width: width, height: height)
+        if ekgTraceTextureA == nil || ekgTraceTextureB == nil || ekgTraceLastDrawableSize != size {
+            let descriptor = MTLTextureDescriptor.texture2DDescriptor(
+                pixelFormat: .rgba16Float,
+                width: width,
+                height: height,
+                mipmapped: false
+            )
+            descriptor.usage = [.renderTarget, .shaderRead]
+            descriptor.storageMode = .private
+            ekgTraceTextureA = device.makeTexture(descriptor: descriptor)
+            ekgTraceTextureB = device.makeTexture(descriptor: descriptor)
+            ekgTraceLastDrawableSize = size
+            ekgTraceSourceIsA = true
+            ekgTraceNeedsClear = true
+        }
+
+        guard let a = ekgTraceTextureA, let b = ekgTraceTextureB else { return nil }
+        return ekgTraceSourceIsA ? (a, b) : (b, a)
+    }
+
     /// Render vis_classic exact mode: CPU frame generation in C++ core, then blit to drawable.
     private func renderVisClassicExact(drawable: CAMetalDrawable) {
         guard let device = device,
@@ -2612,6 +2931,8 @@ class SpectrumAnalyzerView: NSView {
             break  // Matrix handles its own state in renderMatrix()
         case .snow:
             break  // Snow handles its own state in renderSnow()
+        case .ekg:
+            break  // EKG handles its own state in renderEKG()
         case .visClassicExact:
             break  // vis_classic exact mode renders from CPU frame output
         }
@@ -3004,6 +3325,8 @@ class SpectrumAnalyzerView: NSView {
             break  // Matrix updates its own buffers in renderMatrix()
         case .snow:
             break  // Snow updates its own buffers in renderSnow()
+        case .ekg:
+            break  // EKG updates its own buffers in renderEKG()
         case .visClassicExact:
             break  // vis_classic exact mode does not use shader parameter buffers
         }
@@ -3100,6 +3423,13 @@ class SpectrumAnalyzerView: NSView {
 
             visClassicWaveLeft = Array(repeating: 128, count: 576)
             visClassicWaveRight = Array(repeating: 128, count: 576)
+
+            ekgBeatPhase = 0
+            ekgAmplitudeLevel = 0.5
+            ekgTargetAmplitudeLevel = 0.5
+            ekgNoiseLevel = 0.04
+            ekgLastRenderTime = 0
+            ekgTraceNeedsClear = true
         }
         NSLog("SpectrumAnalyzerView: State reset")
     }

--- a/Sources/NullPlayer/Visualization/SpectrumAnalyzerView.swift
+++ b/Sources/NullPlayer/Visualization/SpectrumAnalyzerView.swift
@@ -357,6 +357,8 @@ struct UltraParams {
 // MARK: - Spectrum Analyzer View
 
 private let spectrumAnalyzerEKGSharedClockStart = CACurrentMediaTime()
+private let EKG_SCREEN_SECONDS: Float = 5.6   // seconds of trace history visible on screen (matches Metal constant)
+private let EKG_SCAN_HEAD_X: Float = 0.965    // normalized x position of the scan head (matches Metal constant)
 
 /// Metal-based spectrum analyzer visualization view
 class SpectrumAnalyzerView: NSView {
@@ -818,7 +820,6 @@ class SpectrumAnalyzerView: NSView {
            let style = EKGStyle(rawValue: saved) {
             ekgStyle = style
         }
-        renderEKGStyle = ekgStyle
         
         // Initialize display spectrum and sync to render-safe variables
         // Use max size to avoid any resizing during mode switches
@@ -2601,7 +2602,7 @@ class SpectrumAnalyzerView: NSView {
                 bpm: detectedBPM,
                 beatPhase: ekgBeatPhase,
                 amplitude: ekgAmplitudeLevel,
-                scrollDelta: frameDelta / 5.6 * 0.965,
+                scrollDelta: frameDelta / EKG_SCREEN_SECONDS * EKG_SCAN_HEAD_X,
                 noise: ekgNoiseLevel,
                 style: renderEKGStyle
             )

--- a/Sources/NullPlayer/Windows/MainWindow/MainWindowView.swift
+++ b/Sources/NullPlayer/Windows/MainWindow/MainWindowView.swift
@@ -11,6 +11,7 @@ enum MainWindowVisMode: String, CaseIterable {
     case electricity = "Lightning"   // GPU lightning storm (Metal overlay)
     case matrix = "Matrix"           // Falling digital rain (Metal overlay)
     case snow = "Snow"               // Audio-reactive snowfall (Metal overlay)
+    case ekg = "EKG"                 // BPM-synced ECG monitor (Metal overlay)
     
     var displayName: String { rawValue }
     
@@ -29,6 +30,7 @@ enum MainWindowVisMode: String, CaseIterable {
         case .electricity: return .electricity
         case .matrix: return .matrix
         case .snow: return .snow
+        case .ekg: return .ekg
         }
     }
 }
@@ -373,6 +375,10 @@ class MainWindowView: NSView {
            let intensity = MatrixIntensity(rawValue: savedIntensity) {
             overlay.matrixIntensity = intensity
         }
+        if let savedStyle = UserDefaults.standard.string(forKey: "mainWindowEKGStyle"),
+           let style = EKGStyle(rawValue: savedStyle) {
+            overlay.ekgStyle = style
+        }
         if let savedDecay = UserDefaults.standard.string(forKey: "mainWindowDecayMode"),
            let mode = SpectrumDecayMode(rawValue: savedDecay) {
             overlay.decayMode = mode
@@ -517,6 +523,11 @@ class MainWindowView: NSView {
             if let savedIntensity = UserDefaults.standard.string(forKey: "mainWindowMatrixIntensity"),
                let intensity = MatrixIntensity(rawValue: savedIntensity) {
                 overlay.matrixIntensity = intensity
+            }
+            // EKG settings
+            if let savedStyle = UserDefaults.standard.string(forKey: "mainWindowEKGStyle"),
+               let style = EKGStyle(rawValue: savedStyle) {
+                overlay.ekgStyle = style
             }
             // Decay/responsiveness
             if let savedDecay = UserDefaults.standard.string(forKey: "mainWindowDecayMode"),

--- a/Sources/NullPlayer/Windows/ModernMainWindow/ModernMainWindowView.swift
+++ b/Sources/NullPlayer/Windows/ModernMainWindow/ModernMainWindowView.swift
@@ -1260,6 +1260,8 @@ class ModernMainWindowView: NSView {
                    let scheme = MatrixColorScheme(rawValue: savedScheme) { overlay.matrixColorScheme = scheme }
                 if let savedIntensity = UserDefaults.standard.string(forKey: "mainWindowMatrixIntensity"),
                    let intensity = MatrixIntensity(rawValue: savedIntensity) { overlay.matrixIntensity = intensity }
+                if let savedStyle = UserDefaults.standard.string(forKey: "mainWindowEKGStyle"),
+                   let style = EKGStyle(rawValue: savedStyle) { overlay.ekgStyle = style }
                 if let savedDecay = UserDefaults.standard.string(forKey: "mainWindowDecayMode"),
                    let mode = SpectrumDecayMode(rawValue: savedDecay) { overlay.decayMode = mode }
 
@@ -1334,6 +1336,8 @@ class ModernMainWindowView: NSView {
                let scheme = MatrixColorScheme(rawValue: savedScheme) { overlay.matrixColorScheme = scheme }
             if let savedIntensity = UserDefaults.standard.string(forKey: "mainWindowMatrixIntensity"),
                let intensity = MatrixIntensity(rawValue: savedIntensity) { overlay.matrixIntensity = intensity }
+            if let savedStyle = UserDefaults.standard.string(forKey: "mainWindowEKGStyle"),
+               let style = EKGStyle(rawValue: savedStyle) { overlay.ekgStyle = style }
             if let savedDecay = UserDefaults.standard.string(forKey: "mainWindowDecayMode"),
                let mode = SpectrumDecayMode(rawValue: savedDecay) { overlay.decayMode = mode }
             if mainVisMode == .visClassicExact {

--- a/Sources/NullPlayer/Windows/ModernSpectrum/ModernSpectrumView.swift
+++ b/Sources/NullPlayer/Windows/ModernSpectrum/ModernSpectrumView.swift
@@ -527,6 +527,8 @@ class ModernSpectrumView: NSView {
                 cycleLightningStyle(forward: false)
             } else if spectrumAnalyzerView?.qualityMode == .matrix {
                 cycleMatrixColor(forward: false)
+            } else if spectrumAnalyzerView?.qualityMode == .ekg {
+                cycleEKGStyle(forward: false)
             } else if spectrumAnalyzerView?.qualityMode == .visClassicExact {
                 _ = spectrumAnalyzerView?.loadPreviousVisClassicProfile()
             } else { super.keyDown(with: event) }
@@ -537,6 +539,8 @@ class ModernSpectrumView: NSView {
                 cycleLightningStyle(forward: true)
             } else if spectrumAnalyzerView?.qualityMode == .matrix {
                 cycleMatrixColor(forward: true)
+            } else if spectrumAnalyzerView?.qualityMode == .ekg {
+                cycleEKGStyle(forward: true)
             } else if spectrumAnalyzerView?.qualityMode == .visClassicExact {
                 _ = spectrumAnalyzerView?.loadNextVisClassicProfile()
             } else { super.keyDown(with: event) }
@@ -580,6 +584,13 @@ class ModernSpectrumView: NSView {
         guard let idx = schemes.firstIndex(of: spectrumAnalyzerView?.matrixColorScheme ?? .classic) else { return }
         let newIdx = forward ? (idx + 1) % schemes.count : (idx - 1 + schemes.count) % schemes.count
         spectrumAnalyzerView?.matrixColorScheme = schemes[newIdx]
+    }
+
+    private func cycleEKGStyle(forward: Bool) {
+        let styles = EKGStyle.allCases
+        guard let idx = styles.firstIndex(of: spectrumAnalyzerView?.ekgStyle ?? .clinical) else { return }
+        let newIdx = forward ? (idx + 1) % styles.count : (idx - 1 + styles.count) % styles.count
+        spectrumAnalyzerView?.ekgStyle = styles[newIdx]
     }
     
     // MARK: - Context Menu
@@ -706,6 +717,22 @@ class ModernSpectrumView: NSView {
             menu.addItem(matrixIntensityMenuItem)
         }
 
+        // EKG Style submenu (only when EKG mode active)
+        if spectrumAnalyzerView?.qualityMode == .ekg {
+            let ekgMenu = NSMenu()
+            let curStyle = spectrumAnalyzerView?.ekgStyle ?? .clinical
+            for style in EKGStyle.allCases {
+                let item = NSMenuItem(title: style.displayName, action: #selector(setEKGStyle(_:)), keyEquivalent: "")
+                item.target = self
+                item.representedObject = style
+                item.state = (curStyle == style) ? .on : .off
+                ekgMenu.addItem(item)
+            }
+            let ekgMenuItem = NSMenuItem(title: "EKG Style", action: nil, keyEquivalent: "")
+            ekgMenuItem.submenu = ekgMenu
+            menu.addItem(ekgMenuItem)
+        }
+
         // vis_classic profile controls (only when vis_classic mode is active)
         if spectrumAnalyzerView?.qualityMode == .visClassicExact {
             let profilesMenu = NSMenu()
@@ -826,6 +853,11 @@ class ModernSpectrumView: NSView {
     @objc private func setMatrixIntensity(_ sender: NSMenuItem) {
         guard let intensity = sender.representedObject as? MatrixIntensity else { return }
         spectrumAnalyzerView?.matrixIntensity = intensity
+    }
+
+    @objc private func setEKGStyle(_ sender: NSMenuItem) {
+        guard let style = sender.representedObject as? EKGStyle else { return }
+        spectrumAnalyzerView?.ekgStyle = style
     }
 
     @objc private func setVisClassicProfile(_ sender: NSMenuItem) {

--- a/Sources/NullPlayer/Windows/Spectrum/SpectrumView.swift
+++ b/Sources/NullPlayer/Windows/Spectrum/SpectrumView.swift
@@ -484,6 +484,8 @@ class SpectrumView: NSView {
                 cycleLightningStyle(forward: false)
             } else if spectrumAnalyzerView?.qualityMode == .matrix {
                 cycleMatrixColor(forward: false)
+            } else if spectrumAnalyzerView?.qualityMode == .ekg {
+                cycleEKGStyle(forward: false)
             } else if spectrumAnalyzerView?.qualityMode == .visClassicExact {
                 _ = spectrumAnalyzerView?.loadPreviousVisClassicProfile()
             } else { super.keyDown(with: event) }
@@ -494,6 +496,8 @@ class SpectrumView: NSView {
                 cycleLightningStyle(forward: true)
             } else if spectrumAnalyzerView?.qualityMode == .matrix {
                 cycleMatrixColor(forward: true)
+            } else if spectrumAnalyzerView?.qualityMode == .ekg {
+                cycleEKGStyle(forward: true)
             } else if spectrumAnalyzerView?.qualityMode == .visClassicExact {
                 _ = spectrumAnalyzerView?.loadNextVisClassicProfile()
             } else { super.keyDown(with: event) }
@@ -535,6 +539,13 @@ class SpectrumView: NSView {
         guard let idx = schemes.firstIndex(of: spectrumAnalyzerView?.matrixColorScheme ?? .classic) else { return }
         let newIdx = forward ? (idx + 1) % schemes.count : (idx - 1 + schemes.count) % schemes.count
         spectrumAnalyzerView?.matrixColorScheme = schemes[newIdx]
+    }
+
+    private func cycleEKGStyle(forward: Bool) {
+        let styles = EKGStyle.allCases
+        guard let idx = styles.firstIndex(of: spectrumAnalyzerView?.ekgStyle ?? .clinical) else { return }
+        let newIdx = forward ? (idx + 1) % styles.count : (idx - 1 + styles.count) % styles.count
+        spectrumAnalyzerView?.ekgStyle = styles[newIdx]
     }
     
     // MARK: - Context Menu
@@ -661,6 +672,21 @@ class SpectrumView: NSView {
             menu.addItem(matrixIntensityMenuItem)
         }
 
+        // EKG Style submenu (only when EKG mode active)
+        if spectrumAnalyzerView?.qualityMode == .ekg {
+            let ekgMenu = NSMenu()
+            let curStyle = spectrumAnalyzerView?.ekgStyle ?? .clinical
+            for style in EKGStyle.allCases {
+                let item = NSMenuItem(title: style.displayName, action: #selector(setEKGStyle(_:)), keyEquivalent: "")
+                item.target = self; item.representedObject = style
+                item.state = (curStyle == style) ? .on : .off
+                ekgMenu.addItem(item)
+            }
+            let ekgMenuItem = NSMenuItem(title: "EKG Style", action: nil, keyEquivalent: "")
+            ekgMenuItem.submenu = ekgMenu
+            menu.addItem(ekgMenuItem)
+        }
+
         // vis_classic profile controls (only when vis_classic mode is active)
         if spectrumAnalyzerView?.qualityMode == .visClassicExact {
             let profilesMenu = NSMenu()
@@ -779,6 +805,11 @@ class SpectrumView: NSView {
     @objc private func setMatrixIntensity(_ sender: NSMenuItem) {
         guard let intensity = sender.representedObject as? MatrixIntensity else { return }
         spectrumAnalyzerView?.matrixIntensity = intensity
+    }
+
+    @objc private func setEKGStyle(_ sender: NSMenuItem) {
+        guard let style = sender.representedObject as? EKGStyle else { return }
+        spectrumAnalyzerView?.ekgStyle = style
     }
 
     @objc private func setVisClassicProfile(_ sender: NSMenuItem) {

--- a/skills/local-library/SKILL.md
+++ b/skills/local-library/SKILL.md
@@ -12,7 +12,7 @@ Reference for local media library: scanning, persistence, NAS responsiveness, an
 | File discovery | `Utilities/LocalFileDiscovery.swift` |
 | Audio engine (NAS paths) | `Audio/AudioEngine.swift` |
 | Waveform (cue-sheet) | `Waveform/BaseWaveformView.swift` |
-| Play history (Data tab) | `Windows/ModernStats/PlayHistoryStore.swift`, `Windows/ModernStats/PlayHistoryAgent.swift` |
+| Play history (Data tab) | `Windows/ModernStats/PlayHistoryStore.swift`, `Windows/ModernStats/PlayHistoryAgent.swift`, `Windows/ModernStats/StatsContentView.swift` |
 
 ## Database Schema
 
@@ -30,6 +30,7 @@ Reference for local media library: scanning, persistence, NAS responsiveness, an
 - v3 → v4: migration adds extended metadata columns (`composer`, `comment`, `grouping`, `bpm`, `musical_key`, `isrc`, `copyright`, `musicbrainz_recording_id`, `musicbrainz_release_id`, `discogs_*`, `artwork_url`) via `ALTER TABLE … ADD COLUMN`.
 - v4 → v5: migration adds `play_events` table and indexes (see Tables below).
 - v5 → v6: migration adds `content_type` column to `play_events` (TEXT, nullable); backfills `'radio'` for source=radio rows, `'music'` for everything else.
+- v6 → v7: migration adds `output_device` column to `play_events` (TEXT, nullable). Records the active CoreAudio output device name, or the cast target name (Chromecast/Sonos/DLNA device) when a cast session is active. NULL for legacy rows. Supplied via `CastManager.currentPlaybackDeviceName` at call sites in `AudioEngine` and `VideoPlayerWindowController`.
 
 ### Tables
 
@@ -99,10 +100,11 @@ PK: `(track_url, artist_name, role)`. Indexes: `idx_track_artists_name`, `idx_tr
 | `source` | TEXT | `'local'`, `'plex'`, `'subsonic'`, `'jellyfin'`, `'emby'`, or `'radio'` |
 | `skipped` | INTEGER | 0/1, NOT NULL, default 0 |
 | `content_type` | TEXT? | Added v6. Values: `'music'`, `'movie'`, `'tv'`, `'radio'`, `'video'`. NULL treated as `'music'` in queries. Derived from `Track.playHistoryContentType`; video playback records from `VideoPlayerWindowController` set this explicitly via `beginPlaybackAnalyticsSession(contentType:)`. |
+| `output_device` | TEXT? | Added v7. Name of active audio output device (CoreAudio) or cast target device. NULL for legacy rows. |
 Indexes: `idx_play_events_played_at`, `idx_play_events_track_id`, `idx_play_events_source_time`.
-Queried by `PlayHistoryStore` (in `Windows/ModernStats/`) to power the Data tab in the Library Browser.
+Queried by `PlayHistoryStore` (in `Windows/ModernStats/`) to power the Data tab in both the modern Library Browser and the classic `PlexBrowserView`.
 
-**`insertPlayEvent` signature** (in `MediaLibraryStore`): takes `contentType: String = "music"` as a trailing parameter — defaults to music so all existing callers work unchanged. Pass `track.playHistoryContentType` at call sites that know the content type. `VideoPlayerWindowController` passes the content type explicitly.
+**`insertPlayEvent` signature** (in `MediaLibraryStore`): takes `contentType: String = "music"` and `outputDevice: String? = nil` as trailing parameters — both default so all existing callers work unchanged. Pass `track.playHistoryContentType` and `CastManager.currentPlaybackDeviceName` at call sites. Internet radio sessions pass `outputDevice` from `CastManager.currentPlaybackDeviceName` at the time the event is recorded.
 
 ### Key API Methods (MediaLibraryStore)
 
@@ -183,6 +185,33 @@ Reference pattern: `watchFolderSummaries()` in `MediaLibrary.swift`.
 
 ### Fast-track scan signatures
 `makeFastTrack` does **not** persist a scan signature. The signature (`scan_file_size`, `scan_mod_date`) is written only after metadata enrichment completes. This is intentional: if enrichment is interrupted, the file will be re-enriched on next scan.
+
+## Data Tab (Play History Analytics)
+
+Both `ModernLibraryBrowserView` and `PlexBrowserView` (classic) embed a Data tab backed by `PlayHistoryAgent` + `StatsContentView`.
+
+In `PlexBrowserView`, the tab is the `.history` case (displayed as "Data"). It is implemented via an `NSHostingView<StatsContentView>` created in `makeHistoryHostingView()` and reused across tab switches. The agent is a private `let historyAgent = PlayHistoryAgent()` instance on the view. Skin text color is forwarded on tab selection and on skin reload.
+
+**Charts in the Data tab overview:**
+- Play Time summary (day/week/month/year/all-time)
+- Top Artists (music only — excludes radio)
+- Top Movies / Top TV Shows (content-type specific)
+- Genre breakdown (excludes radio)
+- Sources breakdown (excludes radio; shows note directing to Internet Radio section)
+- Output Devices breakdown (filterable; NULL/empty device rows excluded)
+- Content Types donut
+- Internet Radio section (total listen time + Top Stations by play count/duration)
+- Plays Over Time time series
+
+**Output Devices chart** (`OutputDeviceChartView`): groups `play_events` by `COALESCE(NULLIF(trim(output_device), ''), 'Unknown')`, filtering out NULL/empty rows. Color assignment uses a deterministic hash of the device name mapped into a 12-color palette. Cast sessions record the Chromecast/Sonos/DLNA device name via `CastManager.currentPlaybackDeviceName`.
+
+**`PlayHistoryStore` query isolation:**
+- `fetchTopArtists` — music only (`content_type = 'music'`)
+- `fetchTopMovies` — movie only
+- `fetchTopTVShows` — tv only; extracts show name from `event_artist` first, falls back to parsing `"Show Name - S01E02"` title pattern
+- `fetchTopRadioStations` / `fetchRadioListenSeconds` — radio only; use `whereClause(forRadio:)` which only applies time range, output device, and skip filters
+- `fetchTopDimension(.artist/.source/.album/.genre)` — all exclude radio via `content_type <> 'radio'`
+- `fetchGenreBreakdown` — excludes radio
 
 ## Testing
 

--- a/skills/radio-streaming/SKILL.md
+++ b/skills/radio-streaming/SKILL.md
@@ -186,6 +186,93 @@ Key behavior:
 
 ---
 
+## 3. Internet Radio Play History
+
+Internet radio listen sessions are recorded in the shared `play_events` table (see local-library skill for schema). This is distinct from the per-source radio history databases used for playlist deduplication.
+
+### Session Tracking (AudioEngine)
+
+`AudioEngine` maintains an `activeRadioSession: RadioSession?` private struct:
+
+```swift
+private struct RadioSession {
+    let track: Track
+    let stationURL: URL
+    var startedAt: Date
+    var pausedAccumulator: TimeInterval    // total paused seconds
+    var lastPauseStartedAt: Date?          // non-nil while paused
+}
+```
+
+State transitions are driven by `handleRadioSessionPlaybackStateChange(from:to:)` called from the `state` property observer:
+
+| Transition | Action |
+|-----------|--------|
+| → `.playing` | `startOrResumeActiveRadioSessionIfNeeded()` |
+| `.playing` → `.paused` | `pauseActiveRadioSessionIfNeeded()` — records pause start |
+| → `.stopped` | `flushActiveRadioSession()` — writes event and nils session |
+
+**Station switches**: if the playing track's URL differs from `activeRadioSession.stationURL`, the old session is flushed and a new one starts.
+
+**Non-radio tracks**: if the track's `playHistorySource != .radio`, any active session is flushed immediately.
+
+### Audibility Guard (`isRadioPlaybackAudibleNow`)
+
+Sessions are only started/resumed when audio is actually being delivered. The guard checks:
+- For audio casts: `CastManager.shared.activeSession.playbackStartDate != nil`
+- For local streaming: `!isStreamingPlayback || streamingPlaybackConfirmed`
+
+`streamingPlaybackConfirmed` is set to `true` when `StreamingAudioPlayerDelegate` fires `.playing` state, and reset to `false` when streaming starts loading a new track or enters stopped/error state. This prevents recording time during buffering.
+
+### Long-Session Checkpoints
+
+A 30-minute checkpoint fires from the timer tick path (`checkpointActiveRadioSessionIfNeeded`). When `listened >= 30 * 60` and not paused:
+1. Writes a play event for the elapsed 30 minutes
+2. Resets `startedAt` to now with zero `pausedAccumulator`
+
+This prevents a single very long session from being lost if the app crashes before the station is stopped.
+
+### App-Quit Flush
+
+`AppDelegate.applicationWillTerminate` calls `audioEngine.flushActiveRadioSessionIfAny()` before any other teardown. This ensures in-progress sessions are recorded even when the user quits while radio is playing.
+
+### Play Event Schema
+
+Radio sessions write to `play_events` with:
+
+| Column | Value |
+|--------|-------|
+| `track_id` | `nil` |
+| `track_url` | Station stream URL (absolute string) |
+| `event_title` | Station name (`track.title`) |
+| `event_artist` | `nil` |
+| `event_genre` | Station genre if set |
+| `source` | `PlayHistorySource.radio.rawValue` (`"radio"`) |
+| `content_type` | `"radio"` |
+| `duration_listened` | Actual listen seconds (elapsed minus paused) |
+| `skipped` | `false` for normal stop/switch; `true` if skipped |
+| `output_device` | Active output or cast device name |
+
+Minimum threshold: sessions shorter than **1 second** are discarded.
+
+### Data Tab — Internet Radio Section
+
+`PlayHistoryStore` exposes two radio-specific queries:
+- `fetchTopRadioStations(filter:)` — groups by station URL (uses URL as id, title as display name), returns top 50 by play count
+- `fetchRadioListenSeconds(filter:)` — total `SUM(duration_listened)` for radio events
+
+Both use `whereClause(forRadio:)` which respects only time range, output device, and skip filters (artist/album/genre/source/content type don't apply to radio).
+
+`PlayHistoryAgent` publishes `topRadioStations: [TopDimensionRow]` and `radioListenSeconds: Double`.
+
+`InternetRadioSection` in `StatsContentView.swift` renders the section only when `!rows.isEmpty || totalSeconds > 0`. It shows total formatted listen time, a "Top N stations" label, and a `TopDimensionChartView` with `showsTotalMinutes: true` (displays `"plays / duration"` per row).
+
+Radio events are **excluded** from music/video charts: `fetchTopArtists`, `fetchGenreBreakdown`, and source/album/genre dimensions in `fetchTopDimension` all add `COALESCE(pe.content_type, 'music') <> 'radio'` conditions.
+
+The source filter UI silently drops any selection of the radio source (`selectSource(_:)` in `PlayHistoryAgent` maps `PlayHistorySource.radio.rawValue` → `nil`), since radio is presented separately.
+
+---
+
 ## 2. Library Radio
 
 Library Radio generates smart playlists from server/local sources with play-history deduplication.

--- a/skills/user-guide/SKILL.md
+++ b/skills/user-guide/SKILL.md
@@ -25,7 +25,18 @@ A faithful recreation of Winamp 2.x for macOS with Plex/Jellyfin/Subsonic integr
 | **Library Browser** | Browse Plex/Jellyfin/Subsonic/Emby and local media | Logo button or context menu |
 | **ProjectM** | Real-time audio visualizations | Menu button or context menu |
 
-In modern UI, **Windows > Play History** opens the **Data** tab inside the Library Browser instead of a separate window. The Data tab shows play-time summaries, top artists, a time-series chart, genre breakdown, source breakdown, a **Content Types** donut chart (Music / Movies / TV Shows / Radio / Video), and a recent events list. All charts are interactive filters — clicking a segment narrows all other charts to that slice. The **Now Playing…** context menu item shows rich track info (album artist, year, track number, genre, play count, rating, file path, etc.) fetched live from the server for Plex/Subsonic/Jellyfin/Emby tracks.
+In modern UI, **Windows > Play History** opens the **Data** tab inside the Library Browser instead of a separate window. The Data tab is also available in the classic library browser. The Data tab shows:
+- **Play Time** summary (day/week/month/year/all-time)
+- **Top Artists** (music only)
+- **Top Movies** and **Top TV Shows** (separate sections; TV groups by show name)
+- **Genre** breakdown (music and video; excludes radio)
+- **Sources** breakdown (music and video; excludes radio — a note directs to the Internet Radio section below)
+- **Output Devices** breakdown (which speaker/cast device was active; cast sessions record Chromecast/Sonos/DLNA device name)
+- **Content Types** donut chart (Music / Movies / TV Shows / Radio / Video)
+- **Internet Radio** section — total listen time + Top Stations ranked by play count and listen duration
+- **Plays Over Time** time series
+
+All charts are interactive filters — clicking a segment narrows all other charts to that slice. The **Now Playing…** context menu item shows rich track info (album artist, year, track number, genre, play count, rating, file path, etc.) fetched live from the server for Plex/Subsonic/Jellyfin/Emby tracks.
 
 ### Top Menu Bar
 
@@ -134,6 +145,7 @@ Modern UI adds: **HT** (Hide Title Bars), **CA** (Cast), **pM** (ProjectM), **SP
 - Internet-radio-only folder organization (smart folders + custom folders)
 - 5-star station ratings (persisted per station URL)
 - Casting to Sonos
+- **Play history tracking** — listen sessions are recorded with pause-aware duration; visible in the Data tab Internet Radio section (total listen time + top stations). Sessions shorter than 1 second are discarded. Long sessions checkpoint every 30 minutes.
 - Playback Options now groups all source histories under a single **Radio History** submenu
 
 ### Local Files
@@ -156,6 +168,8 @@ Switch the Library Browser source to "Local" to manage a persistent media librar
 - Progress updates are throttled/coarse during large imports to keep UI responsive
 
 **Tabs:** Artists, Albums, Playlists (`Plists` in the UI), Movies, Shows, Search, Radio, Data
+
+The **Data tab** is present in both the modern Library Browser and the classic library browser (`PlexBrowserView`). It shows play-history analytics for all sources (see the Data tab description at the top of this section).
 
 ### Drag/Drop + Folder Import Behavior (Local/NAS)
 

--- a/skills/visualizations/SKILL.md
+++ b/skills/visualizations/SKILL.md
@@ -11,7 +11,7 @@ Related but separate from the visualization stack is the standalone waveform win
 
 ## Main Window Visualization
 
-The main window's built-in visualization area (76x16 pixels in Winamp coordinates) supports nine rendering modes.
+The main window's built-in visualization area (76x16 pixels in Winamp coordinates) supports ten rendering modes.
 
 ### Modes
 
@@ -26,6 +26,7 @@ The main window's built-in visualization area (76x16 pixels in Winamp coordinate
 | **Lightning** | GPU lightning storm with fractal bolts mapped to spectrum peaks |
 | **Matrix** | Falling digital rain with procedural glyphs mapped to spectrum bands |
 | **Snow** | Audio-reactive snowfall with flurry-to-blizzard intensity and bass-driven wind gusts |
+| **EKG** | Realistic high-resolution ECG monitor trace synchronized to detected BPM and waveform amplitude, with selectable monitor palettes |
 
 ### Switching Modes
 
@@ -253,6 +254,7 @@ Participates in docking system with Main, EQ, and Playlist:
 | **Lightning** | GPU lightning storm with fractal bolts mapped to spectrum peaks (8 color schemes) |
 | **Matrix** | Falling digital rain with procedural glyphs (5 color schemes, 2 intensity presets) |
 | **Snow** | Layered procedural snowfall with spectrum-shaped density, gusting drift, and soft atmospheric haze |
+| **EKG** | Beat-synced ECG monitor with phosphor trace, medical grid, scan glow, BPM-driven QRS pulses, PCM amplitude-driven peak height, and selectable palettes |
 
 ### Switching Modes
 
@@ -359,6 +361,32 @@ Iconic falling digital rain from The Matrix.
 
 **Technical**: Single render pass with hash-based segment patterns, multi-stream rain simulation. Phosphor glow samples 8 neighbors (glowRange capped to 1 for both Subtle and Intense). 60 FPS.
 
+### EKG Mode Details
+
+Realistic electrocardiogram monitor visualization.
+
+**Visual Elements:**
+- Procedural P-QRS-T ECG waveform with smooth antialiasing
+- Medical monitor grid with fine and major subdivisions
+- Green phosphor trace, glow, scan head, scanlines, vignette, and analog monitor noise
+- QRS timing pulses from the BPM clock
+- R-peaks are placed on a fixed seconds-wide monitor timebase, so faster BPM produces closer peak spacing
+- Peak height follows smoothed raw PCM amplitude without using frequency energy
+- Persistent ping-pong trace texture preserves already-drawn history; only the scan-head region is redrawn
+- Larger vertical scale and lower baseline use more of the monitor area
+- Selectable styles: Clinical, Cyan, Amber, Neon, Crimson, Ice
+- Subtle per-beat procedural variance keeps the trace alive without fighting amplitude response
+
+**Audio Reactivity:**
+- Detected BPM drives the cardiac clock when available, folded into a 40-100 BPM display range
+- Fast tempos are halved until they fit the EKG range; unusually slow readings are doubled
+- Smoothed raw PCM amplitude controls QRS/R-peak height
+- No spectrum or frequency-band energy is sampled in this mode
+- Defaults to 80 BPM when no confident BPM has been detected yet
+- EKG Style is available in the spectrum window context menu and the main-window Visuals menu when EKG is active
+
+**Technical**: Two-pass Metal path: an update pass scrolls/preserves the persistent trace texture and draws only the scan-head band; a composite pass renders the monitor grid, glow, and stored trace. Uses `.bpmUpdated` notifications for timing and `.audioPCMDataUpdated` for raw-amplitude scaling. 60 FPS.
+
 ### Responsiveness Modes
 
 Controls how quickly bars fall:
@@ -374,8 +402,8 @@ Controls how quickly bars fall:
 
 | Feature | Album Art | ProjectM/MilkDrop | Spectrum Analyzer |
 |---------|-----------|-------------------|-------------------|
-| **Visual Style** | Transformed artwork | Procedural graphics | Frequency bars/vis_classic/Fire/JWST/Lightning/Matrix/Snow |
-| **Effect Count** | 30 built-in | 100s of presets | 9 modes |
+| **Visual Style** | Transformed artwork | Procedural graphics | Frequency bars/vis_classic/Fire/JWST/Lightning/Matrix/Snow/EKG |
+| **Effect Count** | 30 built-in | 100s of presets | 10 modes |
 | **Customization** | Intensity adjustment | Full preset ecosystem | Mode + decay + style presets |
 | **GPU Tech** | Core Image (Metal) | OpenGL shaders | Metal shaders + compute |
 | **Audio Response** | Spectrum bands | PCM waveform + beats | 75-band spectrum / energy-driven |
@@ -403,7 +431,7 @@ Controls how quickly bars fall:
 - Monitoring audio levels
 - Classic Winamp spectrum aesthetic
 - Larger display complements main window
-- Fire/JWST/Lightning/Matrix modes for ambient visuals
+- Fire/JWST/Lightning/Matrix/EKG modes for ambient visuals
 
 ## Key Files
 
@@ -436,6 +464,7 @@ Controls how quickly bars fall:
 - `Visualization/ElectricityShaders.metal` - Lightning mode fragment shaders
 - `Visualization/MatrixShaders.metal` - Matrix mode fragment shaders
 - `Visualization/SnowShaders.metal` - Snow mode fragment shaders
+- `Visualization/EKGShaders.metal` - EKG mode fragment shaders
 - `Sources/CVisClassicCore/` - Portable C/C++ vis_classic core implementation and C API
 - `App/SpectrumWindowProviding.swift` - Protocol abstracting classic/modern
 


### PR DESCRIPTION
## Summary
- Add an EKG spectrum/main-window visualization mode backed by a persistent Metal trace texture
- Drive EKG timing from folded BPM and peak height from smoothed raw PCM amplitude, not frequency bands
- Add EKG style palettes and menu wiring for classic/modern spectrum windows and main-window visuals
- Include related visualization and skill documentation updates

## Verification
- swift build