### PR TITLE
Apply media breakdown stats to modern Data page

### DIFF
--- a/Sources/NullPlayer/App/AppDelegate.swift
+++ b/Sources/NullPlayer/App/AppDelegate.swift
@@ -144,7 +144,7 @@ class AppDelegate: NSObject, NSApplicationDelegate {
     }
     
     func applicationWillTerminate(_ notification: Notification) {
-        windowManager.audioEngine.flushActiveRadioSessionIfAny()
+        windowManager.audioEngine.flushActiveRadioSession()
 
         // Stop any active casting (video or audio)
         // Use sync version to avoid deadlock - async stopCasting() uses MainActor.run

--- a/Sources/NullPlayer/App/AppDelegate.swift
+++ b/Sources/NullPlayer/App/AppDelegate.swift
@@ -144,6 +144,8 @@ class AppDelegate: NSObject, NSApplicationDelegate {
     }
     
     func applicationWillTerminate(_ notification: Notification) {
+        windowManager.audioEngine.flushActiveRadioSessionIfAny()
+
         // Stop any active casting (video or audio)
         // Use sync version to avoid deadlock - async stopCasting() uses MainActor.run
         // which can't execute while main thread is blocked waiting for completion

--- a/Sources/NullPlayer/Audio/AudioEngine.swift
+++ b/Sources/NullPlayer/Audio/AudioEngine.swift
@@ -83,6 +83,14 @@ class AudioEngine {
         let pendingRepeatOrder: [Int]?
     }
 
+    private struct RadioSession {
+        let track: Track
+        let stationURL: URL
+        var startedAt: Date
+        var pausedAccumulator: TimeInterval
+        var lastPauseStartedAt: Date?
+    }
+
     static func freezeLocalPlaybackClockForSleep(
         currentTime: TimeInterval,
         playbackStartDate: Date,
@@ -142,6 +150,7 @@ class AudioEngine {
     /// This routes audio through AVAudioEngine so EQ affects streaming audio
     private var streamingPlayer: StreamingAudioPlayer?
     private var isStreamingPlayback: Bool = false
+    private var streamingPlaybackConfirmed: Bool = false
     private var isLoadingNewStreamingTrack: Bool = false
     
     /// Guard against concurrent loadTrack() calls which can cause both local and streaming players to be active
@@ -188,6 +197,7 @@ class AudioEngine {
                 object: self,
                 userInfo: ["state": state]
             )
+            handleRadioSessionPlaybackStateChange(from: oldValue, to: state)
         }
     }
     
@@ -366,6 +376,9 @@ class AudioEngine {
     
     /// Timer for time updates
     private var timeUpdateTimer: Timer?
+
+    private let radioSessionCheckpointInterval: TimeInterval = 30 * 60
+    private var activeRadioSession: RadioSession?
     
     /// Spectrum analyzer data (75 bands for classic skin-style visualization)
     private(set) var spectrumData: [Float] = Array(repeating: 0, count: 75)
@@ -2459,6 +2472,7 @@ class AudioEngine {
             let trackDuration = self.duration
             self.lastReportedTime = current
             self.delegate?.audioEngineDidUpdateTime(current: current, duration: trackDuration)
+            self.checkpointActiveRadioSessionIfNeeded()
             
             // Update Plex playback position (for scrobble threshold detection)
             PlexPlaybackReporter.shared.updatePosition(current)
@@ -2525,6 +2539,129 @@ class AudioEngine {
         // Add to common modes so it runs during menu tracking and other modal states
         RunLoop.main.add(timer, forMode: .common)
         timeUpdateTimer = timer
+    }
+
+    func flushActiveRadioSessionIfAny() {
+        flushActiveRadioSession()
+    }
+
+    private func handleRadioSessionPlaybackStateChange(from oldState: PlaybackState, to newState: PlaybackState) {
+        switch newState {
+        case .playing:
+            startOrResumeActiveRadioSessionIfNeeded()
+        case .paused:
+            if oldState == .playing {
+                pauseActiveRadioSessionIfNeeded()
+            }
+        case .stopped:
+            flushActiveRadioSession()
+        }
+    }
+
+    private func startOrResumeActiveRadioSessionIfNeeded() {
+        guard let track = currentTrack, track.playHistorySource == .radio else {
+            flushActiveRadioSession()
+            return
+        }
+        guard isRadioPlaybackAudibleNow else {
+            pauseActiveRadioSessionIfNeeded()
+            return
+        }
+
+        let now = Date()
+        if let existing = activeRadioSession {
+            guard existing.stationURL == track.url else {
+                flushActiveRadioSession()
+                activeRadioSession = RadioSession(
+                    track: track,
+                    stationURL: track.url,
+                    startedAt: now,
+                    pausedAccumulator: 0,
+                    lastPauseStartedAt: nil
+                )
+                return
+            }
+
+            if let pauseStartedAt = existing.lastPauseStartedAt {
+                activeRadioSession?.pausedAccumulator += now.timeIntervalSince(pauseStartedAt)
+                activeRadioSession?.lastPauseStartedAt = nil
+            }
+            return
+        }
+
+        activeRadioSession = RadioSession(
+            track: track,
+            stationURL: track.url,
+            startedAt: now,
+            pausedAccumulator: 0,
+            lastPauseStartedAt: nil
+        )
+    }
+
+    private func pauseActiveRadioSessionIfNeeded() {
+        guard activeRadioSession != nil,
+              activeRadioSession?.lastPauseStartedAt == nil else { return }
+        activeRadioSession?.lastPauseStartedAt = Date()
+    }
+
+    private var isRadioPlaybackAudibleNow: Bool {
+        if let session = CastManager.shared.activeSession,
+           CastManager.shared.currentCast == .audio {
+            return session.playbackStartDate != nil
+        }
+        return !isStreamingPlayback || streamingPlaybackConfirmed
+    }
+
+    private func checkpointActiveRadioSessionIfNeeded() {
+        guard state == .playing,
+              let session = activeRadioSession,
+              session.lastPauseStartedAt == nil else { return }
+
+        let now = Date()
+        let listened = max(0, now.timeIntervalSince(session.startedAt) - session.pausedAccumulator)
+        guard listened >= radioSessionCheckpointInterval else { return }
+
+        recordRadioPlayEvent(for: session, listened: listened, playedAt: now, skipped: false)
+        activeRadioSession = RadioSession(
+            track: session.track,
+            stationURL: session.stationURL,
+            startedAt: now,
+            pausedAccumulator: 0,
+            lastPauseStartedAt: nil
+        )
+    }
+
+    private func flushActiveRadioSession(skipped: Bool = false) {
+        guard var session = activeRadioSession else { return }
+
+        let now = Date()
+        if let pauseStartedAt = session.lastPauseStartedAt {
+            session.pausedAccumulator += now.timeIntervalSince(pauseStartedAt)
+            session.lastPauseStartedAt = nil
+        }
+
+        let listened = max(0, now.timeIntervalSince(session.startedAt) - session.pausedAccumulator)
+        activeRadioSession = nil
+        guard listened >= 1.0 else { return }
+
+        recordRadioPlayEvent(for: session, listened: listened, playedAt: now, skipped: skipped)
+    }
+
+    private func recordRadioPlayEvent(for session: RadioSession, listened: TimeInterval, playedAt: Date, skipped: Bool) {
+        _ = MediaLibraryStore.shared.insertPlayEvent(
+            trackId: nil,
+            trackURL: session.stationURL.absoluteString,
+            title: session.track.title,
+            artist: nil,
+            album: nil,
+            genre: session.track.genre,
+            playedAt: playedAt,
+            durationListened: listened,
+            source: PlayHistorySource.radio.rawValue,
+            skipped: skipped,
+            contentType: "radio",
+            outputDevice: CastManager.currentPlaybackDeviceName
+        )
     }
     
     /// Handle cast track completion - advance to next track
@@ -3688,6 +3825,7 @@ class AudioEngine {
         mixerNode.removeTap(onBus: 0)  // Critical: remove local spectrum tap
         audioFile = nil
         isStreamingPlayback = true
+        streamingPlaybackConfirmed = false
         
         // Reset spectrum analyzer state when switching sources
         NotificationCenter.default.post(name: NSNotification.Name("ResetSpectrumState"), object: nil)
@@ -5250,6 +5388,7 @@ extension AudioEngine: StreamingAudioPlayerDelegate {
         // Map AudioStreaming state to our PlaybackState
         switch state {
         case .playing:
+            streamingPlaybackConfirmed = true
             self.state = .playing
             playbackStartDate = Date()
             suspendedLocalPlaybackClockForSleep = false
@@ -5262,6 +5401,11 @@ extension AudioEngine: StreamingAudioPlayerDelegate {
         case .paused:
             self.state = .paused
         case .stopped:
+            guard !isLoadingNewStreamingTrack else {
+                NSLog("AudioEngine: Ignoring streaming stopped state during track switch")
+                return
+            }
+            streamingPlaybackConfirmed = false
             self.state = .stopped
             isSeekingStreaming = false
             // Cancel any pending reset work item
@@ -5269,6 +5413,7 @@ extension AudioEngine: StreamingAudioPlayerDelegate {
             streamingSeekResetWorkItem = nil
         case .error:
             NSLog("AudioEngine: Streaming player entered error state")
+            streamingPlaybackConfirmed = false
             self.state = .stopped
             isSeekingStreaming = false
             // Cancel any pending seeks and reset work items

--- a/Sources/NullPlayer/Audio/AudioEngine.swift
+++ b/Sources/NullPlayer/Audio/AudioEngine.swift
@@ -2541,10 +2541,6 @@ class AudioEngine {
         timeUpdateTimer = timer
     }
 
-    func flushActiveRadioSessionIfAny() {
-        flushActiveRadioSession()
-    }
-
     private func handleRadioSessionPlaybackStateChange(from oldState: PlaybackState, to newState: PlaybackState) {
         switch newState {
         case .playing:
@@ -2631,7 +2627,7 @@ class AudioEngine {
         )
     }
 
-    private func flushActiveRadioSession(skipped: Bool = false) {
+    func flushActiveRadioSession(skipped: Bool = false) {
         guard var session = activeRadioSession else { return }
 
         let now = Date()

--- a/Sources/NullPlayer/Audio/AudioEngine.swift
+++ b/Sources/NullPlayer/Audio/AudioEngine.swift
@@ -5399,6 +5399,7 @@ extension AudioEngine: StreamingAudioPlayerDelegate {
                 RadioManager.shared.streamDidConnect()
             }
         case .paused:
+            streamingPlaybackConfirmed = false
             self.state = .paused
         case .stopped:
             guard !isLoadingNewStreamingTrack else {

--- a/Sources/NullPlayer/Windows/ModernStats/PlayHistoryAgent.swift
+++ b/Sources/NullPlayer/Windows/ModernStats/PlayHistoryAgent.swift
@@ -1,9 +1,9 @@
 import Foundation
 import Combine
 
-enum StatsDimension { case artist, album, genre, source, outputDevice }
-enum StatsGranularity { case day, week, month }
-enum StatsTimeRange: Equatable, Hashable {
+enum StatsDimension: Sendable { case artist, album, genre, source, outputDevice }
+enum StatsGranularity: Sendable { case day, week, month }
+enum StatsTimeRange: Equatable, Hashable, Sendable {
     case last7Days, last30Days, last90Days, last365Days, allTime
     case custom(Date, Date)
     static func == (lhs: Self, rhs: Self) -> Bool {
@@ -28,7 +28,7 @@ enum StatsTimeRange: Equatable, Hashable {
     }
 }
 
-struct StatsFilterState: Equatable {
+struct StatsFilterState: Equatable, Sendable {
     var timeRange: StatsTimeRange = .last30Days
     var selectedArtist: String? = nil
     var selectedAlbum:  String? = nil
@@ -138,7 +138,7 @@ final class PlayHistoryAgent: ObservableObject {
         isLoading = true
         error = nil
         do {
-            let result = try await Task(priority: .userInitiated) { [store, currentFilter, currentGranularity] in
+            let result = try await Task.detached(priority: .userInitiated) { [store, currentFilter, currentGranularity] in
                 try Task.checkCancellation()
                 let p = try store.fetchPlayTimeSummaries(filter: currentFilter)
                 try Task.checkCancellation()

--- a/Sources/NullPlayer/Windows/ModernStats/PlayHistoryAgent.swift
+++ b/Sources/NullPlayer/Windows/ModernStats/PlayHistoryAgent.swift
@@ -43,6 +43,8 @@ struct StatsFilterState: Equatable {
 final class PlayHistoryAgent: ObservableObject {
     @Published var playTimeSummaries: [PlayTimeSummaryRow] = []
     @Published var topArtists:     [TopDimensionRow] = []
+    @Published var topMovies:      [TopDimensionRow] = []
+    @Published var topTVShows:     [TopDimensionRow] = []
     @Published var timeSeries:     [TimeSeriesRow]   = []
     @Published var genreBreakdown: [TopDimensionRow] = []
     @Published var sourceBreakdown: [TopDimensionRow] = []
@@ -66,6 +68,8 @@ final class PlayHistoryAgent: ObservableObject {
     private var backfillTask: Task<Void, Never>?
     private var cachedPlayTimeSummaries: [PlayTimeSummaryRow]?
     private var cachedTopArtists:     [TopDimensionRow]?
+    private var cachedTopMovies:      [TopDimensionRow]?
+    private var cachedTopTVShows:     [TopDimensionRow]?
     private var cachedTimeSeries:     [TimeSeriesRow]?
     private var cachedGenreBreakdown: [TopDimensionRow]?
     private var cachedSourceBreakdown: [TopDimensionRow]?
@@ -110,6 +114,7 @@ final class PlayHistoryAgent: ObservableObject {
 
     private func invalidateCache() {
         cachedPlayTimeSummaries = nil; cachedTopArtists = nil
+        cachedTopMovies = nil; cachedTopTVShows = nil
         cachedTimeSeries = nil; cachedGenreBreakdown = nil
         cachedSourceBreakdown = nil; cachedContentTypeBreakdown = nil
         cachedOutputDeviceBreakdown = nil
@@ -131,7 +136,11 @@ final class PlayHistoryAgent: ObservableObject {
                 try Task.checkCancellation()
                 let p = try store.fetchPlayTimeSummaries(filter: currentFilter)
                 try Task.checkCancellation()
-                let a = try store.fetchTopDimension(dimension: .artist, filter: currentFilter)
+                let a = try store.fetchTopArtists(filter: currentFilter)
+                try Task.checkCancellation()
+                let m = try store.fetchTopMovies(filter: currentFilter)
+                try Task.checkCancellation()
+                let tv = try store.fetchTopTVShows(filter: currentFilter)
                 try Task.checkCancellation()
                 let s = try store.fetchTimeSeries(filter: currentFilter, granularity: currentGranularity)
                 try Task.checkCancellation()
@@ -144,15 +153,16 @@ final class PlayHistoryAgent: ObservableObject {
                 let d = try store.fetchTopDimension(dimension: .outputDevice, filter: currentFilter)
                 try Task.checkCancellation()
                 let r = try store.fetchRecentEvents(filter: currentFilter)
-                return (p, a, s, g, o, c, d, r)
+                return (p, a, m, tv, s, g, o, c, d, r)
             }.value
             try Task.checkCancellation()
-            (playTimeSummaries, topArtists, timeSeries, genreBreakdown, sourceBreakdown, contentTypeBreakdown, outputDeviceBreakdown, recentEvents) = result
+            (playTimeSummaries, topArtists, topMovies, topTVShows, timeSeries, genreBreakdown, sourceBreakdown, contentTypeBreakdown, outputDeviceBreakdown, recentEvents) = result
             cachedPlayTimeSummaries = result.0; cachedTopArtists = result.1
-            cachedTimeSeries = result.2; cachedGenreBreakdown = result.3
-            cachedSourceBreakdown = result.4; cachedContentTypeBreakdown = result.5
-            cachedOutputDeviceBreakdown = result.6
-            cachedRecentEvents = result.7
+            cachedTopMovies = result.2; cachedTopTVShows = result.3
+            cachedTimeSeries = result.4; cachedGenreBreakdown = result.5
+            cachedSourceBreakdown = result.6; cachedContentTypeBreakdown = result.7
+            cachedOutputDeviceBreakdown = result.8
+            cachedRecentEvents = result.9
         } catch is CancellationError {
             // Refresh was superseded by a newer request — discard results silently
         } catch {

--- a/Sources/NullPlayer/Windows/ModernStats/PlayHistoryAgent.swift
+++ b/Sources/NullPlayer/Windows/ModernStats/PlayHistoryAgent.swift
@@ -45,6 +45,8 @@ final class PlayHistoryAgent: ObservableObject {
     @Published var topArtists:     [TopDimensionRow] = []
     @Published var topMovies:      [TopDimensionRow] = []
     @Published var topTVShows:     [TopDimensionRow] = []
+    @Published var topRadioStations: [TopDimensionRow] = []
+    @Published var radioListenSeconds: Double = 0
     @Published var timeSeries:     [TimeSeriesRow]   = []
     @Published var genreBreakdown: [TopDimensionRow] = []
     @Published var sourceBreakdown: [TopDimensionRow] = []
@@ -70,6 +72,8 @@ final class PlayHistoryAgent: ObservableObject {
     private var cachedTopArtists:     [TopDimensionRow]?
     private var cachedTopMovies:      [TopDimensionRow]?
     private var cachedTopTVShows:     [TopDimensionRow]?
+    private var cachedTopRadioStations: [TopDimensionRow]?
+    private var cachedRadioListenSeconds: Double?
     private var cachedTimeSeries:     [TimeSeriesRow]?
     private var cachedGenreBreakdown: [TopDimensionRow]?
     private var cachedSourceBreakdown: [TopDimensionRow]?
@@ -83,7 +87,8 @@ final class PlayHistoryAgent: ObservableObject {
     func selectArtist(_ name: String?)  { filter.selectedArtist = name }
     func selectAlbum(_ name: String?)   { filter.selectedAlbum  = name }
     func selectGenre(_ name: String?)   { filter.selectedGenre  = name }
-    func selectSource(_ s: String?)     { filter.selectedSource = s }
+    // Internet radio is presented in its own section; music/video source filtering ignores it.
+    func selectSource(_ s: String?)     { filter.selectedSource = s == PlayHistorySource.radio.rawValue ? nil : s }
     func selectContentType(_ s: String?) { filter.selectedContentType = s }
     func selectOutputDevice(_ s: String?) { filter.selectedOutputDevice = s }
     func clearAllFilters()              { filter = StatsFilterState() }
@@ -115,6 +120,7 @@ final class PlayHistoryAgent: ObservableObject {
     private func invalidateCache() {
         cachedPlayTimeSummaries = nil; cachedTopArtists = nil
         cachedTopMovies = nil; cachedTopTVShows = nil
+        cachedTopRadioStations = nil; cachedRadioListenSeconds = nil
         cachedTimeSeries = nil; cachedGenreBreakdown = nil
         cachedSourceBreakdown = nil; cachedContentTypeBreakdown = nil
         cachedOutputDeviceBreakdown = nil
@@ -142,6 +148,10 @@ final class PlayHistoryAgent: ObservableObject {
                 try Task.checkCancellation()
                 let tv = try store.fetchTopTVShows(filter: currentFilter)
                 try Task.checkCancellation()
+                let radioStations = try store.fetchTopRadioStations(filter: currentFilter)
+                try Task.checkCancellation()
+                let radioSeconds = try store.fetchRadioListenSeconds(filter: currentFilter)
+                try Task.checkCancellation()
                 let s = try store.fetchTimeSeries(filter: currentFilter, granularity: currentGranularity)
                 try Task.checkCancellation()
                 let g = try store.fetchGenreBreakdown(filter: currentFilter)
@@ -153,16 +163,17 @@ final class PlayHistoryAgent: ObservableObject {
                 let d = try store.fetchTopDimension(dimension: .outputDevice, filter: currentFilter)
                 try Task.checkCancellation()
                 let r = try store.fetchRecentEvents(filter: currentFilter)
-                return (p, a, m, tv, s, g, o, c, d, r)
+                return (p, a, m, tv, radioStations, radioSeconds, s, g, o, c, d, r)
             }.value
             try Task.checkCancellation()
-            (playTimeSummaries, topArtists, topMovies, topTVShows, timeSeries, genreBreakdown, sourceBreakdown, contentTypeBreakdown, outputDeviceBreakdown, recentEvents) = result
+            (playTimeSummaries, topArtists, topMovies, topTVShows, topRadioStations, radioListenSeconds, timeSeries, genreBreakdown, sourceBreakdown, contentTypeBreakdown, outputDeviceBreakdown, recentEvents) = result
             cachedPlayTimeSummaries = result.0; cachedTopArtists = result.1
             cachedTopMovies = result.2; cachedTopTVShows = result.3
-            cachedTimeSeries = result.4; cachedGenreBreakdown = result.5
-            cachedSourceBreakdown = result.6; cachedContentTypeBreakdown = result.7
-            cachedOutputDeviceBreakdown = result.8
-            cachedRecentEvents = result.9
+            cachedTopRadioStations = result.4; cachedRadioListenSeconds = result.5
+            cachedTimeSeries = result.6; cachedGenreBreakdown = result.7
+            cachedSourceBreakdown = result.8; cachedContentTypeBreakdown = result.9
+            cachedOutputDeviceBreakdown = result.10
+            cachedRecentEvents = result.11
         } catch is CancellationError {
             // Refresh was superseded by a newer request — discard results silently
         } catch {

--- a/Sources/NullPlayer/Windows/ModernStats/PlayHistoryAgent.swift
+++ b/Sources/NullPlayer/Windows/ModernStats/PlayHistoryAgent.swift
@@ -39,6 +39,21 @@ struct StatsFilterState: Equatable, Sendable {
     var excludeSkipped: Bool = true
 }
 
+private struct StatsRefreshResult {
+    var playTimeSummaries: [PlayTimeSummaryRow]
+    var topArtists: [TopDimensionRow]
+    var topMovies: [TopDimensionRow]
+    var topTVShows: [TopDimensionRow]
+    var topRadioStations: [TopDimensionRow]
+    var radioListenSeconds: Double
+    var timeSeries: [TimeSeriesRow]
+    var genreBreakdown: [TopDimensionRow]
+    var sourceBreakdown: [TopDimensionRow]
+    var contentTypeBreakdown: [TopDimensionRow]
+    var outputDeviceBreakdown: [TopDimensionRow]
+    var recentEvents: [RecentEventRow]
+}
+
 @MainActor
 final class PlayHistoryAgent: ObservableObject {
     @Published var playTimeSummaries: [PlayTimeSummaryRow] = []
@@ -140,40 +155,69 @@ final class PlayHistoryAgent: ObservableObject {
         do {
             let result = try await Task.detached(priority: .userInitiated) { [store, currentFilter, currentGranularity] in
                 try Task.checkCancellation()
-                let p = try store.fetchPlayTimeSummaries(filter: currentFilter)
+                let playTimeSummaries = try store.fetchPlayTimeSummaries(filter: currentFilter)
                 try Task.checkCancellation()
-                let a = try store.fetchTopArtists(filter: currentFilter)
+                let topArtists = try store.fetchTopArtists(filter: currentFilter)
                 try Task.checkCancellation()
-                let m = try store.fetchTopMovies(filter: currentFilter)
+                let topMovies = try store.fetchTopMovies(filter: currentFilter)
                 try Task.checkCancellation()
-                let tv = try store.fetchTopTVShows(filter: currentFilter)
+                let topTVShows = try store.fetchTopTVShows(filter: currentFilter)
                 try Task.checkCancellation()
-                let radioStations = try store.fetchTopRadioStations(filter: currentFilter)
+                let topRadioStations = try store.fetchTopRadioStations(filter: currentFilter)
                 try Task.checkCancellation()
-                let radioSeconds = try store.fetchRadioListenSeconds(filter: currentFilter)
+                let radioListenSeconds = try store.fetchRadioListenSeconds(filter: currentFilter)
                 try Task.checkCancellation()
-                let s = try store.fetchTimeSeries(filter: currentFilter, granularity: currentGranularity)
+                let timeSeries = try store.fetchTimeSeries(filter: currentFilter, granularity: currentGranularity)
                 try Task.checkCancellation()
-                let g = try store.fetchGenreBreakdown(filter: currentFilter)
+                let genreBreakdown = try store.fetchGenreBreakdown(filter: currentFilter)
                 try Task.checkCancellation()
-                let o = try store.fetchTopDimension(dimension: .source, filter: currentFilter)
+                let sourceBreakdown = try store.fetchTopDimension(dimension: .source, filter: currentFilter)
                 try Task.checkCancellation()
-                let c = try store.fetchContentTypeBreakdown(filter: currentFilter)
+                let contentTypeBreakdown = try store.fetchContentTypeBreakdown(filter: currentFilter)
                 try Task.checkCancellation()
-                let d = try store.fetchTopDimension(dimension: .outputDevice, filter: currentFilter)
+                let outputDeviceBreakdown = try store.fetchTopDimension(dimension: .outputDevice, filter: currentFilter)
                 try Task.checkCancellation()
-                let r = try store.fetchRecentEvents(filter: currentFilter)
-                return (p, a, m, tv, radioStations, radioSeconds, s, g, o, c, d, r)
+                let recentEvents = try store.fetchRecentEvents(filter: currentFilter)
+                return StatsRefreshResult(
+                    playTimeSummaries: playTimeSummaries,
+                    topArtists: topArtists,
+                    topMovies: topMovies,
+                    topTVShows: topTVShows,
+                    topRadioStations: topRadioStations,
+                    radioListenSeconds: radioListenSeconds,
+                    timeSeries: timeSeries,
+                    genreBreakdown: genreBreakdown,
+                    sourceBreakdown: sourceBreakdown,
+                    contentTypeBreakdown: contentTypeBreakdown,
+                    outputDeviceBreakdown: outputDeviceBreakdown,
+                    recentEvents: recentEvents
+                )
             }.value
             try Task.checkCancellation()
-            (playTimeSummaries, topArtists, topMovies, topTVShows, topRadioStations, radioListenSeconds, timeSeries, genreBreakdown, sourceBreakdown, contentTypeBreakdown, outputDeviceBreakdown, recentEvents) = result
-            cachedPlayTimeSummaries = result.0; cachedTopArtists = result.1
-            cachedTopMovies = result.2; cachedTopTVShows = result.3
-            cachedTopRadioStations = result.4; cachedRadioListenSeconds = result.5
-            cachedTimeSeries = result.6; cachedGenreBreakdown = result.7
-            cachedSourceBreakdown = result.8; cachedContentTypeBreakdown = result.9
-            cachedOutputDeviceBreakdown = result.10
-            cachedRecentEvents = result.11
+            playTimeSummaries = result.playTimeSummaries
+            topArtists = result.topArtists
+            topMovies = result.topMovies
+            topTVShows = result.topTVShows
+            topRadioStations = result.topRadioStations
+            radioListenSeconds = result.radioListenSeconds
+            timeSeries = result.timeSeries
+            genreBreakdown = result.genreBreakdown
+            sourceBreakdown = result.sourceBreakdown
+            contentTypeBreakdown = result.contentTypeBreakdown
+            outputDeviceBreakdown = result.outputDeviceBreakdown
+            recentEvents = result.recentEvents
+            cachedPlayTimeSummaries = result.playTimeSummaries
+            cachedTopArtists = result.topArtists
+            cachedTopMovies = result.topMovies
+            cachedTopTVShows = result.topTVShows
+            cachedTopRadioStations = result.topRadioStations
+            cachedRadioListenSeconds = result.radioListenSeconds
+            cachedTimeSeries = result.timeSeries
+            cachedGenreBreakdown = result.genreBreakdown
+            cachedSourceBreakdown = result.sourceBreakdown
+            cachedContentTypeBreakdown = result.contentTypeBreakdown
+            cachedOutputDeviceBreakdown = result.outputDeviceBreakdown
+            cachedRecentEvents = result.recentEvents
         } catch is CancellationError {
             // Refresh was superseded by a newer request — discard results silently
         } catch {

--- a/Sources/NullPlayer/Windows/ModernStats/PlayHistoryStore.swift
+++ b/Sources/NullPlayer/Windows/ModernStats/PlayHistoryStore.swift
@@ -145,14 +145,13 @@ final class PlayHistoryStore: Sendable {
         let limit = dimension == .artist ? 250 : 25
         var (whereStr, params) = whereClause(for: filter)
         switch dimension {
-        case .source, .album, .genre:
+        case .source, .album, .genre, .artist:
             addCondition("COALESCE(pe.content_type, 'music') <> 'radio'", to: &whereStr)
-        case .artist, .outputDevice:
+        case .outputDevice:
             break
         }
         if dimension == .outputDevice {
-            let extra = "NULLIF(trim(pe.output_device), '') IS NOT NULL"
-            whereStr = whereStr.isEmpty ? "WHERE \(extra)" : "\(whereStr) AND \(extra)"
+            addCondition("NULLIF(trim(pe.output_device), '') IS NOT NULL", to: &whereStr)
         }
         let sql = """
             SELECT \(dimensionExpr), COUNT(*), COALESCE(SUM(pe.duration_listened), 0.0) / 60.0
@@ -477,43 +476,12 @@ final class PlayHistoryStore: Sendable {
     }
 
     private func whereClause(forRadio filter: StatsFilterState) -> (String, [Binding?]) {
-        var conditions: [String] = []
-        var params: [Binding?] = []
-
-        let now = Date().timeIntervalSince1970
-        switch filter.timeRange {
-        case .last7Days:
-            conditions.append("pe.played_at >= ?")
-            params.append(now - 7 * 86400)
-        case .last30Days:
-            conditions.append("pe.played_at >= ?")
-            params.append(now - 30 * 86400)
-        case .last90Days:
-            conditions.append("pe.played_at >= ?")
-            params.append(now - 90 * 86400)
-        case .last365Days:
-            conditions.append("pe.played_at >= ?")
-            params.append(now - 365 * 86400)
-        case .allTime:
-            break
-        case .custom(let start, let end):
-            conditions.append("pe.played_at >= ?")
-            params.append(start.timeIntervalSince1970)
-            conditions.append("pe.played_at <= ?")
-            params.append(end.timeIntervalSince1970)
-        }
-
-        if let device = filter.selectedOutputDevice {
-            conditions.append("COALESCE(NULLIF(trim(pe.output_device), ''), 'Unknown') = ?")
-            params.append(device)
-        }
-        if filter.excludeSkipped {
-            conditions.append("pe.skipped = 0")
-        }
-
-        if conditions.isEmpty {
-            return ("", params)
-        }
-        return ("WHERE " + conditions.joined(separator: " AND "), params)
+        // Radio stats only respect time range, output device, and skip filter —
+        // artist/album/genre/source/contentType dimensions don't apply to radio.
+        var stripped = StatsFilterState()
+        stripped.timeRange = filter.timeRange
+        stripped.selectedOutputDevice = filter.selectedOutputDevice
+        stripped.excludeSkipped = filter.excludeSkipped
+        return whereClause(for: stripped)
     }
 }

--- a/Sources/NullPlayer/Windows/ModernStats/PlayHistoryStore.swift
+++ b/Sources/NullPlayer/Windows/ModernStats/PlayHistoryStore.swift
@@ -144,6 +144,12 @@ final class PlayHistoryStore: Sendable {
         }
         let limit = dimension == .artist ? 250 : 25
         var (whereStr, params) = whereClause(for: filter)
+        switch dimension {
+        case .source, .album, .genre:
+            addCondition("COALESCE(pe.content_type, 'music') <> 'radio'", to: &whereStr)
+        case .artist, .outputDevice:
+            break
+        }
         if dimension == .outputDevice {
             let extra = "NULLIF(trim(pe.output_device), '') IS NOT NULL"
             whereStr = whereStr.isEmpty ? "WHERE \(extra)" : "\(whereStr) AND \(extra)"
@@ -184,6 +190,48 @@ final class PlayHistoryStore: Sendable {
             let mins = row[2] as? Double ?? 0
             return TopDimensionRow(id: name, displayName: name, playCount: count, totalMinutes: mins)
         }
+    }
+
+    func fetchTopRadioStations(filter: StatsFilterState) throws -> [TopDimensionRow] {
+        var (whereStr, params) = whereClause(forRadio: filter)
+        addCondition("COALESCE(pe.content_type, 'music') = 'radio'", to: &whereStr)
+
+        let groupExpr = "COALESCE(NULLIF(pe.track_url, ''), pe.event_title)"
+        let displayExpr = "COALESCE(NULLIF(trim(pe.event_title), ''), 'Unknown Station')"
+        let sql = """
+            SELECT \(groupExpr) AS gk,
+                   MAX(\(displayExpr)) AS name,
+                   COUNT(*),
+                   COALESCE(SUM(pe.duration_listened), 0.0) / 60.0
+            \(historyFromClause)
+            \(whereStr)
+            GROUP BY gk
+            ORDER BY 3 DESC
+            LIMIT 50
+            """
+        guard let db = MediaLibraryStore.shared.analyticsConnection else { return [] }
+        let stmt = try db.prepare(sql, params)
+        return stmt.map { row in
+            let key = row[0] as? String ?? "Unknown Station"
+            let name = row[1] as? String ?? "Unknown Station"
+            let count = Int(row[2] as? Int64 ?? 0)
+            let mins = row[3] as? Double ?? 0
+            return TopDimensionRow(id: key, displayName: name, playCount: count, totalMinutes: mins)
+        }
+    }
+
+    func fetchRadioListenSeconds(filter: StatsFilterState) throws -> Double {
+        var (whereStr, params) = whereClause(forRadio: filter)
+        addCondition("COALESCE(pe.content_type, 'music') = 'radio'", to: &whereStr)
+
+        let sql = """
+            SELECT COALESCE(SUM(pe.duration_listened), 0.0)
+            \(historyFromClause)
+            \(whereStr)
+            """
+        guard let db = MediaLibraryStore.shared.analyticsConnection else { return 0 }
+        let stmt = try db.prepare(sql, params)
+        return stmt.makeIterator().next()?[0] as? Double ?? 0
     }
 
     func fetchTimeSeries(filter: StatsFilterState, granularity: StatsGranularity) throws -> [TimeSeriesRow] {
@@ -240,7 +288,8 @@ final class PlayHistoryStore: Sendable {
     }
 
     func fetchGenreBreakdown(filter: StatsFilterState) throws -> [TopDimensionRow] {
-        let (whereStr, params) = whereClause(for: filter)
+        var (whereStr, params) = whereClause(for: filter)
+        addCondition("COALESCE(pe.content_type, 'music') <> 'radio'", to: &whereStr)
         let sql = """
             SELECT COALESCE(NULLIF(trim(pe.event_genre), ''), 'Unknown'), COUNT(*), COALESCE(SUM(pe.duration_listened), 0.0) / 60.0
             \(historyFromClause)
@@ -413,6 +462,47 @@ final class PlayHistoryStore: Sendable {
             conditions.append("COALESCE(pe.content_type, 'music') = ?")
             params.append(contentType)
         }
+        if let device = filter.selectedOutputDevice {
+            conditions.append("COALESCE(NULLIF(trim(pe.output_device), ''), 'Unknown') = ?")
+            params.append(device)
+        }
+        if filter.excludeSkipped {
+            conditions.append("pe.skipped = 0")
+        }
+
+        if conditions.isEmpty {
+            return ("", params)
+        }
+        return ("WHERE " + conditions.joined(separator: " AND "), params)
+    }
+
+    private func whereClause(forRadio filter: StatsFilterState) -> (String, [Binding?]) {
+        var conditions: [String] = []
+        var params: [Binding?] = []
+
+        let now = Date().timeIntervalSince1970
+        switch filter.timeRange {
+        case .last7Days:
+            conditions.append("pe.played_at >= ?")
+            params.append(now - 7 * 86400)
+        case .last30Days:
+            conditions.append("pe.played_at >= ?")
+            params.append(now - 30 * 86400)
+        case .last90Days:
+            conditions.append("pe.played_at >= ?")
+            params.append(now - 90 * 86400)
+        case .last365Days:
+            conditions.append("pe.played_at >= ?")
+            params.append(now - 365 * 86400)
+        case .allTime:
+            break
+        case .custom(let start, let end):
+            conditions.append("pe.played_at >= ?")
+            params.append(start.timeIntervalSince1970)
+            conditions.append("pe.played_at <= ?")
+            params.append(end.timeIntervalSince1970)
+        }
+
         if let device = filter.selectedOutputDevice {
             conditions.append("COALESCE(NULLIF(trim(pe.output_device), ''), 'Unknown') = ?")
             params.append(device)

--- a/Sources/NullPlayer/Windows/ModernStats/PlayHistoryStore.swift
+++ b/Sources/NullPlayer/Windows/ModernStats/PlayHistoryStore.swift
@@ -89,6 +89,45 @@ final class PlayHistoryStore: Sendable {
         """
     }
 
+    private var resolvedTVShowExpression: String {
+        """
+        COALESCE(
+            NULLIF(trim(pe.event_artist), ''),
+            NULLIF(trim(
+                CASE
+                    WHEN instr(pe.event_title, ' - S') > 0
+                    THEN substr(pe.event_title, 1, instr(pe.event_title, ' - S') - 1)
+                    ELSE pe.event_title
+                END
+            ), ''),
+            'Unknown'
+        )
+        """
+    }
+
+    func fetchTopArtists(filter: StatsFilterState) throws -> [TopDimensionRow] {
+        var (whereStr, params) = whereClause(for: filter)
+        addCondition("COALESCE(pe.content_type, 'music') = 'music'", to: &whereStr)
+        return try fetchTopRows(expression: resolvedArtistExpression, whereStr: whereStr, params: params, limit: 250)
+    }
+
+    func fetchTopMovies(filter: StatsFilterState) throws -> [TopDimensionRow] {
+        var (whereStr, params) = whereClause(for: filter)
+        addCondition("COALESCE(pe.content_type, 'music') = 'movie'", to: &whereStr)
+        return try fetchTopRows(
+            expression: "COALESCE(NULLIF(trim(pe.event_title), ''), 'Unknown')",
+            whereStr: whereStr,
+            params: params,
+            limit: 25
+        )
+    }
+
+    func fetchTopTVShows(filter: StatsFilterState) throws -> [TopDimensionRow] {
+        var (whereStr, params) = whereClause(for: filter)
+        addCondition("COALESCE(pe.content_type, 'music') = 'tv'", to: &whereStr)
+        return try fetchTopRows(expression: resolvedTVShowExpression, whereStr: whereStr, params: params, limit: 25)
+    }
+
     func fetchTopDimension(dimension: StatsDimension, filter: StatsFilterState) throws -> [TopDimensionRow] {
         let dimensionExpr: String
         switch dimension {
@@ -125,6 +164,25 @@ final class PlayHistoryStore: Sendable {
             let mins = row[2] as? Double ?? 0
             let displayName = dimension == .source ? PlayHistorySource.displayName(for: name) : name
             return TopDimensionRow(id: name, displayName: displayName, playCount: count, totalMinutes: mins)
+        }
+    }
+
+    private func fetchTopRows(expression: String, whereStr: String, params: [Binding?], limit: Int) throws -> [TopDimensionRow] {
+        let sql = """
+            SELECT \(expression), COUNT(*), COALESCE(SUM(pe.duration_listened), 0.0) / 60.0
+            \(historyFromClause)
+            \(whereStr)
+            GROUP BY 1
+            ORDER BY 2 DESC
+            LIMIT \(limit)
+            """
+        guard let db = MediaLibraryStore.shared.analyticsConnection else { return [] }
+        let stmt = try db.prepare(sql, params)
+        return stmt.map { row in
+            let name = row[0] as? String ?? "Unknown"
+            let count = Int(row[1] as? Int64 ?? 0)
+            let mins = row[2] as? Double ?? 0
+            return TopDimensionRow(id: name, displayName: name, playCount: count, totalMinutes: mins)
         }
     }
 
@@ -303,6 +361,10 @@ final class PlayHistoryStore: Sendable {
     }
 
     // MARK: - WHERE clause builder
+
+    private func addCondition(_ condition: String, to whereStr: inout String) {
+        whereStr = whereStr.isEmpty ? "WHERE \(condition)" : "\(whereStr) AND \(condition)"
+    }
 
     private func whereClause(for filter: StatsFilterState) -> (String, [Binding?]) {
         var conditions: [String] = []

--- a/Sources/NullPlayer/Windows/ModernStats/StatsContentView.swift
+++ b/Sources/NullPlayer/Windows/ModernStats/StatsContentView.swift
@@ -173,6 +173,12 @@ struct StatsOverviewView: View {
                 )
                 .frame(height: 220)
 
+                InternetRadioSection(
+                    rows: agent.topRadioStations,
+                    totalSeconds: agent.radioListenSeconds,
+                    skinTextColor: skinTextColor
+                )
+
                 TimeSeriesChartView(agent: agent, skinTextColor: skinTextColor)
                     .frame(height: 220)
             }
@@ -307,22 +313,7 @@ struct PlayTimeSummarySection: View {
     }
 
     private func formatPlayTime(_ duration: Double) -> String {
-        let totalSeconds = max(0, Int(duration.rounded()))
-        if totalSeconds == 0 { return "0m" }
-        let days = totalSeconds / 86_400
-        let hours = (totalSeconds % 86_400) / 3_600
-        let minutes = (totalSeconds % 3_600) / 60
-
-        if days > 0 {
-            return hours > 0 ? "\(days)d \(hours)h" : "\(days)d"
-        }
-        if hours > 0 {
-            return minutes > 0 ? "\(hours)h \(minutes)m" : "\(hours)h"
-        }
-        if minutes > 0 {
-            return "\(minutes)m"
-        }
-        return "<1m"
+        formatStatsPlayTime(duration)
     }
 
     private func shortLabel(for title: String) -> String {
@@ -333,11 +324,74 @@ struct PlayTimeSummarySection: View {
     }
 }
 
+private func formatStatsPlayTime(_ duration: Double) -> String {
+    let totalSeconds = max(0, Int(duration.rounded()))
+    if totalSeconds == 0 { return "0m" }
+    let days = totalSeconds / 86_400
+    let hours = (totalSeconds % 86_400) / 3_600
+    let minutes = (totalSeconds % 3_600) / 60
+
+    if days > 0 {
+        return hours > 0 ? "\(days)d \(hours)h" : "\(days)d"
+    }
+    if hours > 0 {
+        return minutes > 0 ? "\(hours)h \(minutes)m" : "\(hours)h"
+    }
+    if minutes > 0 {
+        return "\(minutes)m"
+    }
+    return "<1m"
+}
+
+struct InternetRadioSection: View {
+    let rows: [TopDimensionRow]
+    let totalSeconds: Double
+    var skinTextColor: Color = .primary
+
+    private var stationCountLabel: String {
+        rows.count == 1 ? "1 station" : "\(rows.count) stations"
+    }
+
+    var body: some View {
+        if !rows.isEmpty || totalSeconds > 0 {
+            VStack(alignment: .leading, spacing: 8) {
+                HStack {
+                    Text("Internet Radio")
+                        .font(.subheadline)
+                        .fontWeight(.medium)
+                    Spacer()
+                }
+
+                VStack(alignment: .leading, spacing: 3) {
+                    Text(formatStatsPlayTime(totalSeconds))
+                        .font(.title3)
+                        .fontWeight(.semibold)
+                        .foregroundColor(skinTextColor)
+                    Text("\(stationCountLabel) - Listen time tracked from this version onward.")
+                        .font(.caption)
+                        .foregroundColor(.secondary)
+                }
+
+                TopDimensionChartView(
+                    title: "Top Stations",
+                    rows: rows,
+                    skinTextColor: skinTextColor,
+                    selected: .constant(nil),
+                    showsTotalMinutes: true
+                )
+                .frame(height: 180)
+            }
+            .frame(maxWidth: .infinity, alignment: .leading)
+        }
+    }
+}
+
 struct TopDimensionChartView: View {
     let title: String
     let rows: [TopDimensionRow]
     var skinTextColor: Color = .primary
     @Binding var selected: String?
+    var showsTotalMinutes: Bool = false
     private let labelColumnWidth: CGFloat = 150
 
     var body: some View {
@@ -364,10 +418,10 @@ struct TopDimensionChartView: View {
                                             .frame(width: max(2, geo.size.width * fraction), height: 10)
                                             .frame(maxHeight: .infinity, alignment: .center)
                                     }
-                                    Text("\(row.playCount)")
+                                    Text(rowValueText(for: row))
                                         .font(.caption2)
                                         .foregroundColor(skinTextColor.opacity(0.7))
-                                        .frame(width: 24, alignment: .leading)
+                                        .frame(width: showsTotalMinutes ? 76 : 24, alignment: .leading)
                                 }
                                 .frame(height: 18)
                             }
@@ -379,6 +433,11 @@ struct TopDimensionChartView: View {
             }
         }
         .frame(maxWidth: .infinity)
+    }
+
+    private func rowValueText(for row: TopDimensionRow) -> String {
+        guard showsTotalMinutes else { return "\(row.playCount)" }
+        return "\(row.playCount) / \(formatStatsPlayTime(row.totalMinutes * 60))"
     }
 }
 
@@ -524,6 +583,9 @@ struct SourceChartView: View {
                     .frame(maxWidth: .infinity, maxHeight: .infinity, alignment: .topLeading)
                 }
                 .frame(maxHeight: .infinity, alignment: .top)
+                Text("Music and video sources only - see Internet Radio below.")
+                    .font(.caption2)
+                    .foregroundColor(.secondary)
             }
         }
         .frame(maxWidth: .infinity)

--- a/Sources/NullPlayer/Windows/ModernStats/StatsContentView.swift
+++ b/Sources/NullPlayer/Windows/ModernStats/StatsContentView.swift
@@ -122,7 +122,8 @@ struct StatsOverviewView: View {
                     title: "Top Movies",
                     rows: agent.topMovies,
                     skinTextColor: skinTextColor,
-                    selected: .constant(nil)
+                    selected: .constant(nil),
+                    allowsSelection: false
                 )
                 .frame(height: 180)
 
@@ -130,7 +131,8 @@ struct StatsOverviewView: View {
                     title: "Top TV Shows",
                     rows: agent.topTVShows,
                     skinTextColor: skinTextColor,
-                    selected: .constant(nil)
+                    selected: .constant(nil),
+                    allowsSelection: false
                 )
                 .frame(height: 180)
 
@@ -375,6 +377,7 @@ struct InternetRadioSection: View {
                     rows: rows,
                     skinTextColor: skinTextColor,
                     selected: .constant(nil),
+                    allowsSelection: false,
                     showsTotalMinutes: true
                 )
                 .frame(height: 180)
@@ -389,6 +392,7 @@ struct TopDimensionChartView: View {
     let rows: [TopDimensionRow]
     var skinTextColor: Color = .primary
     @Binding var selected: String?
+    var allowsSelection: Bool = true
     var showsTotalMinutes: Bool = false
     private let labelColumnWidth: CGFloat = 150
 
@@ -402,28 +406,16 @@ struct TopDimensionChartView: View {
                 ScrollView(.vertical, showsIndicators: true) {
                     VStack(spacing: 3) {
                         ForEach(rows) { row in
-                            Button { selected = (selected == row.id) ? nil : row.id } label: {
-                                HStack(spacing: 6) {
-                                    Text(row.displayName)
-                                        .font(.caption2)
-                                        .foregroundColor(row.id == selected ? Color.accentColor : skinTextColor)
-                                        .lineLimit(1)
-                                        .frame(width: labelColumnWidth, alignment: .trailing)
-                                    GeometryReader { geo in
-                                        let fraction = CGFloat(row.playCount) / CGFloat(maxCount)
-                                        Capsule()
-                                            .fill(row.id == selected ? Color.accentColor : Color.accentColor.opacity(0.55))
-                                            .frame(width: max(2, geo.size.width * fraction), height: 10)
-                                            .frame(maxHeight: .infinity, alignment: .center)
-                                    }
-                                    Text(rowValueText(for: row))
-                                        .font(.caption2)
-                                        .foregroundColor(skinTextColor.opacity(0.7))
-                                        .frame(width: showsTotalMinutes ? 76 : 24, alignment: .leading)
+                            if allowsSelection {
+                                Button {
+                                    selected = (selected == row.id) ? nil : row.id
+                                } label: {
+                                    rowContent(row, maxCount: maxCount)
                                 }
-                                .frame(height: 18)
+                                .buttonStyle(.plain)
+                            } else {
+                                rowContent(row, maxCount: maxCount)
                             }
-                            .buttonStyle(.plain)
                         }
                     }
                     .padding(.vertical, 2)
@@ -436,6 +428,28 @@ struct TopDimensionChartView: View {
     private func rowValueText(for row: TopDimensionRow) -> String {
         guard showsTotalMinutes else { return "\(row.playCount)" }
         return "\(row.playCount) / \(formatStatsPlayTime(row.totalMinutes * 60))"
+    }
+
+    private func rowContent(_ row: TopDimensionRow, maxCount: Int) -> some View {
+        HStack(spacing: 6) {
+            Text(row.displayName)
+                .font(.caption2)
+                .foregroundColor(row.id == selected ? Color.accentColor : skinTextColor)
+                .lineLimit(1)
+                .frame(width: labelColumnWidth, alignment: .trailing)
+            GeometryReader { geo in
+                let fraction = CGFloat(row.playCount) / CGFloat(maxCount)
+                Capsule()
+                    .fill(row.id == selected ? Color.accentColor : Color.accentColor.opacity(0.55))
+                    .frame(width: max(2, geo.size.width * fraction), height: 10)
+                    .frame(maxHeight: .infinity, alignment: .center)
+            }
+            Text(rowValueText(for: row))
+                .font(.caption2)
+                .foregroundColor(skinTextColor.opacity(0.7))
+                .frame(width: showsTotalMinutes ? 76 : 24, alignment: .leading)
+        }
+        .frame(height: 18)
     }
 }
 
@@ -581,7 +595,7 @@ struct SourceChartView: View {
                     .frame(maxWidth: .infinity, maxHeight: .infinity, alignment: .topLeading)
                 }
                 .frame(maxHeight: .infinity, alignment: .top)
-                Text("Music and video sources only - see Internet Radio below.")
+                Text("Music and video sources only. Internet Radio appears in a separate section when available.")
                     .font(.caption2)
                     .foregroundColor(.secondary)
             }

--- a/Sources/NullPlayer/Windows/ModernStats/StatsContentView.swift
+++ b/Sources/NullPlayer/Windows/ModernStats/StatsContentView.swift
@@ -136,6 +136,12 @@ struct StatsOverviewView: View {
                 )
                 .frame(height: 180)
 
+                InternetRadioSection(
+                    rows: agent.topRadioStations,
+                    totalSeconds: agent.radioListenSeconds,
+                    skinTextColor: skinTextColor
+                )
+
                 GenreChartView(
                     rows: agent.genreBreakdown,
                     selected: Binding(
@@ -172,12 +178,6 @@ struct StatsOverviewView: View {
                     )
                 )
                 .frame(height: 220)
-
-                InternetRadioSection(
-                    rows: agent.topRadioStations,
-                    totalSeconds: agent.radioListenSeconds,
-                    skinTextColor: skinTextColor
-                )
 
                 TimeSeriesChartView(agent: agent, skinTextColor: skinTextColor)
                     .frame(height: 220)

--- a/Sources/NullPlayer/Windows/ModernStats/StatsContentView.swift
+++ b/Sources/NullPlayer/Windows/ModernStats/StatsContentView.swift
@@ -349,7 +349,11 @@ struct InternetRadioSection: View {
     var skinTextColor: Color = .primary
 
     private var stationCountLabel: String {
-        rows.count == 1 ? "Top 1 station" : "Top \(rows.count) stations"
+        switch rows.count {
+        case 0:  return "No stations recorded yet"
+        case 1:  return "Top 1 station"
+        default: return "Top \(rows.count) stations"
+        }
     }
 
     var body: some View {
@@ -431,16 +435,17 @@ struct TopDimensionChartView: View {
     }
 
     private func rowContent(_ row: TopDimensionRow, maxCount: Int) -> some View {
-        HStack(spacing: 6) {
+        let isSelected = allowsSelection && row.id == selected
+        return HStack(spacing: 6) {
             Text(row.displayName)
                 .font(.caption2)
-                .foregroundColor(row.id == selected ? Color.accentColor : skinTextColor)
+                .foregroundColor(isSelected ? Color.accentColor : skinTextColor)
                 .lineLimit(1)
                 .frame(width: labelColumnWidth, alignment: .trailing)
             GeometryReader { geo in
                 let fraction = CGFloat(row.playCount) / CGFloat(maxCount)
                 Capsule()
-                    .fill(row.id == selected ? Color.accentColor : Color.accentColor.opacity(0.55))
+                    .fill(isSelected ? Color.accentColor : Color.accentColor.opacity(0.55))
                     .frame(width: max(2, geo.size.width * fraction), height: 10)
                     .frame(maxHeight: .infinity, alignment: .center)
             }

--- a/Sources/NullPlayer/Windows/ModernStats/StatsContentView.swift
+++ b/Sources/NullPlayer/Windows/ModernStats/StatsContentView.swift
@@ -101,8 +101,6 @@ struct FilterChip: View {
 struct StatsOverviewView: View {
     @ObservedObject var agent: PlayHistoryAgent
     var skinTextColor: Color = .primary
-    @State private var selectedMovie: String?
-    @State private var selectedTVShow: String?
 
     var body: some View {
         ScrollView(.vertical) {
@@ -124,7 +122,7 @@ struct StatsOverviewView: View {
                     title: "Top Movies",
                     rows: agent.topMovies,
                     skinTextColor: skinTextColor,
-                    selected: $selectedMovie
+                    selected: .constant(nil)
                 )
                 .frame(height: 180)
 
@@ -132,7 +130,7 @@ struct StatsOverviewView: View {
                     title: "Top TV Shows",
                     rows: agent.topTVShows,
                     skinTextColor: skinTextColor,
-                    selected: $selectedTVShow
+                    selected: .constant(nil)
                 )
                 .frame(height: 180)
 
@@ -349,7 +347,7 @@ struct InternetRadioSection: View {
     var skinTextColor: Color = .primary
 
     private var stationCountLabel: String {
-        rows.count == 1 ? "1 station" : "\(rows.count) stations"
+        rows.count == 1 ? "Top 1 station" : "Top \(rows.count) stations"
     }
 
     var body: some View {

--- a/Sources/NullPlayer/Windows/ModernStats/StatsContentView.swift
+++ b/Sources/NullPlayer/Windows/ModernStats/StatsContentView.swift
@@ -101,6 +101,8 @@ struct FilterChip: View {
 struct StatsOverviewView: View {
     @ObservedObject var agent: PlayHistoryAgent
     var skinTextColor: Color = .primary
+    @State private var selectedMovie: String?
+    @State private var selectedTVShow: String?
 
     var body: some View {
         ScrollView(.vertical) {
@@ -117,6 +119,22 @@ struct StatsOverviewView: View {
                     )
                 )
                 .frame(height: 220)
+
+                TopDimensionChartView(
+                    title: "Top Movies",
+                    rows: agent.topMovies,
+                    skinTextColor: skinTextColor,
+                    selected: $selectedMovie
+                )
+                .frame(height: 180)
+
+                TopDimensionChartView(
+                    title: "Top TV Shows",
+                    rows: agent.topTVShows,
+                    skinTextColor: skinTextColor,
+                    selected: $selectedTVShow
+                )
+                .frame(height: 180)
 
                 GenreChartView(
                     rows: agent.genreBreakdown,

--- a/Sources/NullPlayer/Windows/ProjectM/ProjectMWindowController.swift
+++ b/Sources/NullPlayer/Windows/ProjectM/ProjectMWindowController.swift
@@ -312,6 +312,7 @@ class ProjectMWindowController: NSWindowController, ProjectMWindowProviding {
 extension ProjectMWindowController: NSWindowDelegate {
     func windowDidMove(_ notification: Notification) {
         guard let window = window else { return }
+        if isCustomFullscreen { return }
         let newOrigin = WindowManager.shared.windowWillMove(window, to: window.frame.origin)
         WindowManager.shared.applySnappedPosition(window, to: newOrigin)
     }
@@ -335,7 +336,9 @@ extension ProjectMWindowController: NSWindowDelegate {
     func windowDidBecomeKey(_ notification: Notification) {
         projectMView.needsDisplay = true
         // Bring all app windows to front when this window gets focus
-        WindowManager.shared.bringAllWindowsToFront(keepingWindowOnTop: window)
+        if !isCustomFullscreen {
+            WindowManager.shared.bringAllWindowsToFront(keepingWindowOnTop: window)
+        }
     }
     
     func windowDidResignKey(_ notification: Notification) {


### PR DESCRIPTION
## Summary
- add media-specific Top Movies and Top TV Shows sections to the shared Data page stats view
- add an Internet Radio stats section backed by station listen-time aggregation
- track active internet radio listening sessions so radio data appears in play history

## Verification
- swift build