### PR TITLE
Fix classic ProjectM fullscreen snapping

### DIFF
--- a/Sources/NullPlayer/Windows/ProjectM/ProjectMWindowController.swift
+++ b/Sources/NullPlayer/Windows/ProjectM/ProjectMWindowController.swift
@@ -312,6 +312,7 @@ class ProjectMWindowController: NSWindowController, ProjectMWindowProviding {
 extension ProjectMWindowController: NSWindowDelegate {
     func windowDidMove(_ notification: Notification) {
         guard let window = window else { return }
+        if isCustomFullscreen { return }
         let newOrigin = WindowManager.shared.windowWillMove(window, to: window.frame.origin)
         WindowManager.shared.applySnappedPosition(window, to: newOrigin)
     }
@@ -335,7 +336,9 @@ extension ProjectMWindowController: NSWindowDelegate {
     func windowDidBecomeKey(_ notification: Notification) {
         projectMView.needsDisplay = true
         // Bring all app windows to front when this window gets focus
-        WindowManager.shared.bringAllWindowsToFront(keepingWindowOnTop: window)
+        if !isCustomFullscreen {
+            WindowManager.shared.bringAllWindowsToFront(keepingWindowOnTop: window)
+        }
     }
     
     func windowDidResignKey(_ notification: Notification) {


### PR DESCRIPTION
## Summary
- Skip classic ProjectM window snapping while the visualizer is in custom fullscreen
- Avoid bringing other classic windows forward over the fullscreen visualizer

## Verification
- swift build
- swift test

Fixes #189