### PR TITLE
Move radio stats below top TV shows

### DIFF
--- a/Sources/NullPlayer/Windows/ModernStats/StatsContentView.swift
+++ b/Sources/NullPlayer/Windows/ModernStats/StatsContentView.swift
@@ -136,6 +136,12 @@ struct StatsOverviewView: View {
                 )
                 .frame(height: 180)
 
+                InternetRadioSection(
+                    rows: agent.topRadioStations,
+                    totalSeconds: agent.radioListenSeconds,
+                    skinTextColor: skinTextColor
+                )
+
                 GenreChartView(
                     rows: agent.genreBreakdown,
                     selected: Binding(
@@ -172,12 +178,6 @@ struct StatsOverviewView: View {
                     )
                 )
                 .frame(height: 220)
-
-                InternetRadioSection(
-                    rows: agent.topRadioStations,
-                    totalSeconds: agent.radioListenSeconds,
-                    skinTextColor: skinTextColor
-                )
 
                 TimeSeriesChartView(agent: agent, skinTextColor: skinTextColor)
                     .frame(height: 220)


### PR DESCRIPTION
## Summary
- Move the Internet Radio section directly below Top TV Shows in the shared Data tab overview
- Applies to both modern and classic library browsers through the shared StatsContentView

## Verification
- swift build
- swift test