### PR TITLE
Treat internet radio as non-local for cast logging and Sonos discovery

### DIFF
--- a/Sources/NullPlayer/App/AppStateManager.swift
+++ b/Sources/NullPlayer/App/AppStateManager.swift
@@ -814,7 +814,8 @@ class AppStateManager {
                     title: savedTrack.radioStationName ?? savedTrack.title,
                     artist: savedTrack.artist,
                     album: savedTrack.album,
-                    duration: savedTrack.duration
+                    duration: savedTrack.duration,
+                    isRadioOrigin: true
                 )
                 allTracks.append(track)
             } else if let urlString = savedTrack.localURL, let url = URL(string: urlString) {

--- a/Sources/NullPlayer/Audio/AudioEngine.swift
+++ b/Sources/NullPlayer/Audio/AudioEngine.swift
@@ -2079,7 +2079,7 @@ class AudioEngine {
         // Use isAudioCastRoutingActive so the .loaded phase is included.
         if isAudioCastRoutingActive {
             let track = playlist[currentIndex]
-            let isLocalFile = track.url.scheme != "http" && track.url.scheme != "https"
+            let isLocalFile = !track.isRadioStream && track.url.isFileURL
 
             // For local files, defer UI update until cast completes (prevents UI jumping during rapid clicks)
             // For streaming, update immediately since there's no async delay
@@ -2142,7 +2142,7 @@ class AudioEngine {
         // Use isAudioCastRoutingActive so the .loaded phase is included.
         if isAudioCastRoutingActive {
             let track = playlist[currentIndex]
-            let isLocalFile = track.url.scheme != "http" && track.url.scheme != "https"
+            let isLocalFile = !track.isRadioStream && track.url.isFileURL
 
             // For local files, defer UI update until cast completes (prevents UI jumping during rapid clicks)
             // For streaming, update immediately since there's no async delay
@@ -2222,7 +2222,7 @@ class AudioEngine {
         // Use isAudioCastRoutingActive so the .loaded phase is included.
         if isAudioCastRoutingActive {
             let track = playlist[currentIndex]
-            let isLocalFile = track.url.scheme != "http" && track.url.scheme != "https"
+            let isLocalFile = !track.isRadioStream && track.url.isFileURL
 
             // For local files, defer UI update until cast completes (prevents UI jumping during rapid clicks)
             // For streaming, update immediately since there's no async delay
@@ -2916,7 +2916,7 @@ class AudioEngine {
             }
             // Cast the same or new random track
             let track = playlist[currentIndex]
-            let isLocalFile = track.url.scheme != "http" && track.url.scheme != "https"
+            let isLocalFile = !track.isRadioStream && track.url.isFileURL
             
             // For local files, defer UI update until cast completes
             if !isLocalFile {
@@ -2964,7 +2964,7 @@ class AudioEngine {
                     return
                 }
                 let track = playlist[currentIndex]
-                let isLocalFile = track.url.scheme != "http" && track.url.scheme != "https"
+                let isLocalFile = !track.isRadioStream && track.url.isFileURL
                 
                 // For local files, defer UI update until cast completes
                 if !isLocalFile {
@@ -3008,7 +3008,7 @@ class AudioEngine {
                     return
                 }
                 let track = playlist[currentIndex]
-                let isLocalFile = track.url.scheme != "http" && track.url.scheme != "https"
+                let isLocalFile = !track.isRadioStream && track.url.isFileURL
                 
                 // For local files, defer UI update until cast completes
                 if !isLocalFile {
@@ -3203,7 +3203,7 @@ class AudioEngine {
                 // When casting, don't set up local playback - just set the track metadata
                 // and cast to the active device
                 let track = playlist[currentIndex]
-                let isLocalFile = track.url.scheme != "http" && track.url.scheme != "https"
+                let isLocalFile = !track.isRadioStream && track.url.isFileURL
                 
                 // For local files, defer UI update until cast completes (prevents UI jumping during rapid clicks)
                 // For streaming, update immediately since there's no async delay
@@ -3489,7 +3489,7 @@ class AudioEngine {
             if wasCasting {
                 // When casting, don't set up local playback - just update track metadata and cast
                 let track = playlist[currentIndex]
-                let isLocalFile = track.url.scheme != "http" && track.url.scheme != "https"
+                let isLocalFile = !track.isRadioStream && track.url.isFileURL
                 
                 // For local files, defer UI update until cast completes (prevents UI jumping during rapid clicks)
                 // For streaming, update immediately since there's no async delay
@@ -3563,7 +3563,7 @@ class AudioEngine {
         if wasCasting {
             // When casting, don't set up local playback - just update track metadata and cast
             let track = playlist[currentIndex]
-            let isLocalFile = track.url.scheme != "http" && track.url.scheme != "https"
+            let isLocalFile = !track.isRadioStream && track.url.isFileURL
             
             // For local files, defer UI update until cast completes (prevents UI jumping during rapid clicks)
             // For streaming, update immediately since there's no async delay
@@ -5397,7 +5397,7 @@ class AudioEngine {
         
         if wasCasting {
             // When casting, don't set up local playback - just update track metadata and cast
-            let isLocalFile = track.url.scheme != "http" && track.url.scheme != "https"
+            let isLocalFile = !track.isRadioStream && track.url.isFileURL
             
             // For local files, defer UI update until cast completes (prevents UI jumping during rapid clicks)
             // For streaming, update immediately since there's no async delay

--- a/Sources/NullPlayer/Casting/CastManager.swift
+++ b/Sources/NullPlayer/Casting/CastManager.swift
@@ -616,7 +616,10 @@ class CastManager {
                 // Avoid discovery restart bursts during local playback, which can
                 // compete with high-throughput SMB/NAS reads on weaker WiFi links.
                 let engine = self.resolvedAudioEngine
-                if engine.state == .playing && !engine.isCastingActive {
+                let suppressForLocalRead = engine.state == .playing
+                    && !engine.isCastingActive
+                    && !RadioManager.shared.isActive
+                if suppressForLocalRead {
                     NSLog("CastManager: Skipping discovery refresh - local audio is playing")
                     return
                 }

--- a/Sources/NullPlayer/Data/Models/RadioStation.swift
+++ b/Sources/NullPlayer/Data/Models/RadioStation.swift
@@ -35,7 +35,8 @@ struct RadioStation: Identifiable, Codable, Equatable, Hashable {
             jellyfinServerId: nil,
             artworkThumb: iconURL?.absoluteString,
             mediaType: .audio,
-            genre: genre
+            genre: genre,
+            isRadioOrigin: true
         )
     }
 }

--- a/Sources/NullPlayer/Data/Models/Track.swift
+++ b/Sources/NullPlayer/Data/Models/Track.swift
@@ -317,6 +317,15 @@ struct Track: Identifiable, Equatable {
         url.absoluteString == "about:blank"
     }
 
+    /// True when this track is an internet radio stream (no streaming-service identity, non-file URL).
+    var isRadioStream: Bool {
+        plexRatingKey == nil &&
+        subsonicId == nil &&
+        jellyfinId == nil &&
+        embyId == nil &&
+        !url.isFileURL
+    }
+
     /// True when this track has enough persisted service identity to be refreshed by ID.
     var isResolvableStreamingServiceTrack: Bool {
         if plexRatingKey != nil { return true }

--- a/Sources/NullPlayer/Data/Models/Track.swift
+++ b/Sources/NullPlayer/Data/Models/Track.swift
@@ -82,7 +82,12 @@ struct Track: Identifiable, Equatable {
     
     /// MIME content type hint for casting (e.g. "audio/flac"). When nil, detected from URL extension.
     let contentType: String?
-    
+
+    /// True when this track originated from an internet radio context. Persists across
+    /// transient `file://` URLs (e.g., recordings or temp-cached streams) so cast/local
+    /// classification stays correct even when the playback URL is local.
+    let isRadioOrigin: Bool
+
     init(url: URL) {
         self.id = UUID()
         self.url = url
@@ -215,6 +220,7 @@ struct Track: Identifiable, Equatable {
         self.genre = extractedGenre
         self.playHistoryContentTypeOverride = nil
         self.contentType = nil  // Local files use URL extension detection
+        self.isRadioOrigin = false
     }
 
     /// Fast path for bulk imports: avoid AVFoundation metadata parsing up-front.
@@ -241,8 +247,9 @@ struct Track: Identifiable, Equatable {
         self.genre = nil
         self.playHistoryContentTypeOverride = nil
         self.contentType = nil
+        self.isRadioOrigin = false
     }
-    
+
     init(id: UUID = UUID(),
          url: URL,
          title: String,
@@ -264,7 +271,8 @@ struct Track: Identifiable, Equatable {
          mediaType: MediaType = .audio,
          genre: String? = nil,
          playHistoryContentTypeOverride: String? = nil,
-         contentType: String? = nil) {
+         contentType: String? = nil,
+         isRadioOrigin: Bool = false) {
         self.id = id
         self.url = url
         self.title = title
@@ -287,6 +295,7 @@ struct Track: Identifiable, Equatable {
         self.genre = genre
         self.playHistoryContentTypeOverride = playHistoryContentTypeOverride
         self.contentType = contentType
+        self.isRadioOrigin = isRadioOrigin
     }
     
     /// Display title (artist - title or just title)
@@ -317,13 +326,18 @@ struct Track: Identifiable, Equatable {
         url.absoluteString == "about:blank"
     }
 
-    /// True when this track is an internet radio stream (no streaming-service identity, non-file URL).
+    /// True when this track is an internet radio stream. Honors the explicit
+    /// `isRadioOrigin` flag (set at radio track creation) so radio tracks are
+    /// correctly classified even when their playback URL is `file://` (e.g.,
+    /// recordings or temp-cached streams). Falls back to the legacy heuristic
+    /// for tracks constructed without the flag.
     var isRadioStream: Bool {
-        plexRatingKey == nil &&
-        subsonicId == nil &&
-        jellyfinId == nil &&
-        embyId == nil &&
-        !url.isFileURL
+        if isRadioOrigin { return true }
+        return plexRatingKey == nil &&
+            subsonicId == nil &&
+            jellyfinId == nil &&
+            embyId == nil &&
+            !url.isFileURL
     }
 
     /// True when this track has enough persisted service identity to be refreshed by ID.
@@ -357,6 +371,7 @@ struct Track: Identifiable, Equatable {
         if subsonicId != nil { return .subsonic }
         if jellyfinId != nil { return .jellyfin }
         if embyId != nil { return .emby }
+        if isRadioOrigin { return .radio }
         if !url.isFileURL { return .radio }
         return .local
     }


### PR DESCRIPTION
## Summary
- Adds `Track.isRadioStream` and uses `!isRadioStream && url.isFileURL` for the 10 cast-path `isLocalFile` checks in `AudioEngine`, so radio tracks with non-http URLs (file: temp resolved from `.pls`, `mms://`, `rtsp://`) no longer fall into the local-file cast branch and the `(local=%d)` log lines are accurate.
- Exempts radio playback from `CastManager`'s 60s discovery-refresh suppressor, so Sonos M-SEARCH boosts keep firing while radio is playing — Sonos rooms now show up without first switching to another source.

## Test plan
- [ ] `./scripts/kill_build_run.sh`
- [ ] With Sonos active, start an internet radio station; confirm cast-path logs report `(local=0)` for the radio URL across prev/next/playNow.
- [ ] Cold launch, immediately start radio, wait ~75s, open **Output Devices**: Sonos rooms appear without source switch. Logs should show periodic `Refreshing devices...` and no `Skipping discovery refresh` while only radio is playing.
- [ ] Local file playback (no radio, no cast) still triggers `Skipping discovery refresh`.
- [ ] Cast a Plex track → log shows `(local=0)`; cast a true local file → `(local=1)`.
- [ ] `swift test` passes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Enhanced radio stream detection and casting behavior to more accurately distinguish between local files and internet radio streams, improving cast routing and UI updates during playback transitions.
  * Optimized cast device discovery refresh logic with additional condition checks to reduce unnecessary refresh operations during local audio playback.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->