### PR TITLE
Fix transparent main window background after occlusion

### DIFF
--- a/Sources/NullPlayer/Windows/MainWindow/MainWindowView.swift
+++ b/Sources/NullPlayer/Windows/MainWindow/MainWindowView.swift
@@ -1384,6 +1384,9 @@ class MainWindowView: NSView {
         }
         // Resume Metal overlay rendering
         if mainVisMode.usesMetal { metalOverlay?.startDisplayLink() }
+        // The layer's cached contents may have been dropped while hidden;
+        // force a full redraw so the background isn't left transparent.
+        needsDisplay = true
     }
     
     /// Handle window occlusion state changes to pause/resume timers for CPU efficiency
@@ -1397,6 +1400,11 @@ class MainWindowView: NSView {
             }
             // Resume Metal overlay rendering
             if mainVisMode.usesMetal { metalOverlay?.startDisplayLink() }
+            // The layer's cached contents may have been dropped while occluded;
+            // force a full redraw so the background isn't left transparent
+            // (otherwise per-tick partial setNeedsDisplay(rect:) calls only
+            // repaint small sub-regions and leave the rest transparent).
+            needsDisplay = true
         } else {
             stopMarquee()
             marqueeLayer?.pauseAnimation()


### PR DESCRIPTION
## Summary
- The main window view is layer-backed with `layerContentsRedrawPolicy = .onSetNeedsDisplay`. While the window is occluded (buried) or minimized, macOS may drop the cached layer contents. On return, per-tick `setNeedsDisplay(rect:)` calls (time display, marquee, spectrum) only repaint small sub-regions — leaving the rest of the view transparent (background, title bar, transport, etc. show through to whatever is behind the window).
- Force a full redraw (`needsDisplay = true`) when the window becomes visible (`windowDidChangeOcclusionState`) or is deminiaturized.

## Test plan
- [ ] Play audio, bury the main window under other windows for several minutes, then bring it forward — background should be fully drawn.
- [ ] Minimize and restore the main window — background should be fully drawn.
- [ ] Verify normal playback drawing still works (time display, spectrum, marquee, transport buttons).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed a display issue where the window content wasn't refreshing correctly after being restored from minimized state or when becoming visible after being obscured by other windows.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->