### PR TITLE
Preserve Sonos cast session when switching sources

### DIFF
--- a/Sources/NullPlayer/Casting/CastManager.swift
+++ b/Sources/NullPlayer/Casting/CastManager.swift
@@ -1089,6 +1089,7 @@ class CastManager {
             // behind the current inflight task and deadlock the cast handoff.
             if session.device.type == .sonos {
                 let engine = WindowManager.shared.audioEngine
+                var requestedTrackRejected = false
 
                 while true {
                     var fetchedSampleRate: Int? = nil
@@ -1115,10 +1116,21 @@ class CastManager {
                           trackToCast.sampleRate.map { "\($0) Hz" } ?? "nil",
                           fetchedSampleRate.map { "\($0) Hz" } ?? "nil")
 
+                    if trackToCast.id == track.id {
+                        requestedTrackRejected = true
+                    }
+
                     guard let compatible = engine.advanceToFirstSonosCompatibleTrack() else {
-                        NSLog("CastManager: castNewTrack Sonos found no compatible replacement after rejecting '%@' — stopping cast",
+                        NSLog("CastManager: castNewTrack Sonos found no compatible replacement after rejecting '%@' — keeping cast session, surfacing error",
                               trackToCast.title)
-                        await _stopCastingCore()
+                        await MainActor.run {
+                            self.isCastingTrackChange = false
+                            self.pendingCastTrack = nil
+                            NotificationCenter.default.post(name: Self.trackChangeLoadingNotification, object: nil, userInfo: ["isLoading": false])
+                        }
+                        if requestedTrackRejected {
+                            self.postError(.playbackFailed("'\(track.title)' is not a supported format on Sonos"))
+                        }
                         return
                     }
 

--- a/Sources/NullPlayer/Windows/ModernLibraryBrowser/ModernLibraryBrowserView.swift
+++ b/Sources/NullPlayer/Windows/ModernLibraryBrowser/ModernLibraryBrowserView.swift
@@ -10084,7 +10084,7 @@ class ModernLibraryBrowserView: NSView {
                 self.isLoading = false; self.stopLoadingAnimation(); self.needsDisplay = true
                 return
             }
-            let engine = WindowManager.shared.audioEngine; engine.clearPlaylist(); engine.loadTracks(tracks); engine.play()
+            WindowManager.shared.audioEngine.loadTracks(tracks)
             self.isLoading = false; self.stopLoadingAnimation(); self.needsDisplay = true
             self.radioPlayTask = nil
         }
@@ -10111,7 +10111,7 @@ class ModernLibraryBrowserView: NSView {
                 self.isLoading = false; self.stopLoadingAnimation(); self.needsDisplay = true
                 return
             }
-            let engine = WindowManager.shared.audioEngine; engine.clearPlaylist(); engine.loadTracks(tracks); engine.play()
+            WindowManager.shared.audioEngine.loadTracks(tracks)
             self.isLoading = false; self.stopLoadingAnimation(); self.needsDisplay = true
             self.radioPlayTask = nil
         }
@@ -10138,7 +10138,7 @@ class ModernLibraryBrowserView: NSView {
                 self.isLoading = false; self.stopLoadingAnimation(); self.needsDisplay = true
                 return
             }
-            let engine = WindowManager.shared.audioEngine; engine.clearPlaylist(); engine.loadTracks(tracks); engine.play()
+            WindowManager.shared.audioEngine.loadTracks(tracks)
             self.isLoading = false; self.stopLoadingAnimation(); self.needsDisplay = true
             self.radioPlayTask = nil
         }
@@ -10165,7 +10165,7 @@ class ModernLibraryBrowserView: NSView {
                 self.isLoading = false; self.stopLoadingAnimation(); self.needsDisplay = true
                 return
             }
-            let engine = WindowManager.shared.audioEngine; engine.clearPlaylist(); engine.loadTracks(tracks); engine.play()
+            WindowManager.shared.audioEngine.loadTracks(tracks)
             self.isLoading = false; self.stopLoadingAnimation(); self.needsDisplay = true
             self.radioPlayTask = nil
         }
@@ -10179,7 +10179,7 @@ class ModernLibraryBrowserView: NSView {
         case .decadeRadio(let s, let e, _): tracks = MediaLibrary.shared.createLocalDecadeRadio(start: s, end: e)
         }
         if !tracks.isEmpty {
-            let engine = WindowManager.shared.audioEngine; engine.clearPlaylist(); engine.loadTracks(tracks); engine.play()
+            WindowManager.shared.audioEngine.loadTracks(tracks)
         }
     }
 

--- a/Sources/NullPlayer/Windows/PlexBrowser/PlexBrowserView.swift
+++ b/Sources/NullPlayer/Windows/PlexBrowser/PlexBrowserView.swift
@@ -11307,9 +11307,7 @@ class PlexBrowserView: NSView {
             // Clear current playlist, load radio tracks, and start playing
             NSLog("startTrackRadio: Loading tracks into audio engine...")
             let audioEngine = WindowManager.shared.audioEngine
-            audioEngine.clearPlaylist()
             audioEngine.loadTracks(tracks)
-            audioEngine.play()
             NSLog("Track Radio started with %d tracks", tracks.count)
         }
     }
@@ -11328,9 +11326,7 @@ class PlexBrowserView: NSView {
             
             // Clear current playlist, load radio tracks, and start playing
             let audioEngine = WindowManager.shared.audioEngine
-            audioEngine.clearPlaylist()
             audioEngine.loadTracks(tracks)
-            audioEngine.play()
             NSLog("Album Radio started with %d tracks", tracks.count)
         }
     }
@@ -11349,9 +11345,7 @@ class PlexBrowserView: NSView {
             
             // Clear current playlist, load radio tracks, and start playing
             let audioEngine = WindowManager.shared.audioEngine
-            audioEngine.clearPlaylist()
             audioEngine.loadTracks(tracks)
-            audioEngine.play()
             NSLog("Artist Radio started with %d tracks", tracks.count)
         }
     }
@@ -11371,9 +11365,7 @@ class PlexBrowserView: NSView {
                     }
                     if !libraryTracks.isEmpty {
                         let audioEngine = WindowManager.shared.audioEngine
-                        audioEngine.clearPlaylist()
                         audioEngine.loadTracks(libraryTracks)
-                        audioEngine.play()
                         NSLog("Library Radio started with %d random cached tracks", libraryTracks.count)
                     }
                 }
@@ -11381,9 +11373,7 @@ class PlexBrowserView: NSView {
             }
             
             let audioEngine = WindowManager.shared.audioEngine
-            audioEngine.clearPlaylist()
             audioEngine.loadTracks(tracks)
-            audioEngine.play()
             NSLog("Library Radio started with %d tracks", tracks.count)
         }
     }
@@ -16171,9 +16161,7 @@ class PlexBrowserView: NSView {
                 return
             }
             let audioEngine = WindowManager.shared.audioEngine
-            audioEngine.clearPlaylist()
             audioEngine.loadTracks(tracks)
-            audioEngine.play()
             NSLog("%@ started with %d tracks", radioType.displayName, tracks.count)
             self.isLoading = false; self.stopLoadingAnimation(); self.needsDisplay = true
             self.radioPlayTask = nil
@@ -16210,9 +16198,7 @@ class PlexBrowserView: NSView {
                 return
             }
             let audioEngine = WindowManager.shared.audioEngine
-            audioEngine.clearPlaylist()
             audioEngine.loadTracks(tracks)
-            audioEngine.play()
             self.isLoading = false; self.stopLoadingAnimation(); self.needsDisplay = true
             self.radioPlayTask = nil
         }
@@ -16248,9 +16234,7 @@ class PlexBrowserView: NSView {
                 return
             }
             let audioEngine = WindowManager.shared.audioEngine
-            audioEngine.clearPlaylist()
             audioEngine.loadTracks(tracks)
-            audioEngine.play()
             self.isLoading = false; self.stopLoadingAnimation(); self.needsDisplay = true
             self.radioPlayTask = nil
         }
@@ -16286,9 +16270,7 @@ class PlexBrowserView: NSView {
                 return
             }
             let audioEngine = WindowManager.shared.audioEngine
-            audioEngine.clearPlaylist()
             audioEngine.loadTracks(tracks)
-            audioEngine.play()
             self.isLoading = false; self.stopLoadingAnimation(); self.needsDisplay = true
             self.radioPlayTask = nil
         }
@@ -16306,9 +16288,7 @@ class PlexBrowserView: NSView {
         }
         guard !tracks.isEmpty else { return }
         let audioEngine = WindowManager.shared.audioEngine
-        audioEngine.clearPlaylist()
         audioEngine.loadTracks(tracks)
-        audioEngine.play()
     }
     
     // MARK: - Subsonic Playback


### PR DESCRIPTION
## Summary

When casting to Sonos, switching the audio source to a Plex track (or a Plex/Subsonic/Jellyfin/Emby/Local **library radio** playlist) would silently tear down the Sonos session, dropping playback back to local audio. Two independent paths contributed.

- `CastManager.castNewTrack` Sonos format loop called `_stopCastingCore()` when the forward-only rescue scan (`advanceToFirstSonosCompatibleTrack`) returned `nil`. After `playNow` inserts a single Plex track *after* the radio entry, no forward candidate exists, so any Plex track that failed the Sonos compatibility check (Hi-Res FLAC, ALAC, AIFF, WavPack, APE, or a lossless track whose Plex sample-rate fetch did not resolve to ≤ 48 kHz) killed the whole session. The session is now preserved on that failure; if the user-requested track was the one rejected, the reason is surfaced via `postError(.playbackFailed("'<title>' is not a supported format on Sonos"))`.
- Library-radio handlers wrapped `engine.loadTracks(tracks)` in `engine.clearPlaylist()` + `engine.play()`. `clearPlaylist()` calls `engine.stop()`, which routes through `CastManager.handleStopForActiveDevice()` and ends the Sonos session before `loadTracks` even runs; `loadTracks` then re-evaluates `wasCasting`, sees it false, and starts local playback. `loadTracks` already replaces the playlist and routes via `castNewTrack` when casting is active, so the surrounding calls were both redundant and harmful. All affected sites in `ModernLibraryBrowserView` and `PlexBrowserView` now call `loadTracks(tracks)` only.

## Test plan

- [ ] Start internet radio, **Start Casting** to Sonos, double-click a Plex track that's MP3 or 16-bit FLAC — plays through Sonos without restart
- [ ] Same flow with an incompatible Plex track (24/96 FLAC, ALAC, etc.) — cast session stays connected; "format not supported on Sonos" notification appears
- [ ] Start internet radio, cast to Sonos, switch source to Plex, **Play Library Radio** — Sonos continues playing the first generated track (was failing before)
- [ ] Repeat with Subsonic/Jellyfin/Emby/Local library radio
- [ ] Plex casting → click a radio station — radio takes over the Sonos session (regression check on the existing `isRadioToSonos` path)
- [ ] `swift test`

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved Sonos casting stability—cast sessions now persist when format compatibility issues occur instead of stopping playback.

* **Changes**
  * Updated radio playback behavior across Plex, Subsonic, Jellyfin, Emby, and local radio services for more resilient track loading.

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/ad-repo/nullplayer/pull/204)

<!-- end of auto-generated comment: release notes by coderabbit.ai -->