### PR TITLE
Continuous U-shape border + top-right corner fix for classic chrome windows

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@
 
 - **Main window transparency after occlusion fixed** — the main window no longer renders partially transparent after being occluded, minimized, or hidden behind other windows. Returning to visibility now triggers a full redraw rather than relying on per-tick sub-region repaints.
 - **Internet radio Sonos discovery and cast classification fixed** — internet radio is now correctly treated as non-local for cast logging and Sonos device discovery. A new explicit `isRadioOrigin` flag on `Track` ensures radio sessions are routed and reported correctly when casting.
+- **Classic playlist / spectrum / waveform / projectM / library chrome rebuilt as a continuous U-shape border** — these windows now render with a visible 7px bottom strip matching the side borders' artwork, side borders that extend through the bottom-corner regions, and a continuous gold-trim outline that wraps left → bottom → right with no slits at the corners. The top-right corner is also fixed to mirror the leftCorner sprite (with the close/shade button icons re-drawn on top), eliminating the offset that previously left the interior content area wider under the title bar than below it. Tile destinations are pixel-snapped to prevent the sub-pixel blue seams that appear at fractional `Skin.scaleFactor` values.
 
 ## 0.21.1
 

--- a/Sources/NullPlayer/Skin/SkinElements.swift
+++ b/Sources/NullPlayer/Skin/SkinElements.swift
@@ -659,8 +659,8 @@ struct SkinElements {
         /// Title bar height
         static let titleHeight: CGFloat = 20
         
-        /// Bottom border height (thin decorative border, no control bar)
-        static let bottomHeight: CGFloat = 3
+        /// Bottom border height (decorative border, no control bar)
+        static let bottomHeight: CGFloat = 7
         
         // === TITLE BAR (active: y=0, inactive: y=21) ===
         // Total width: 25 + 100 + 25 + 25 = 175px (tiled to fill)
@@ -997,7 +997,7 @@ struct SkinElements {
             static let titleBarHeight: CGFloat = 20 * Skin.scaleFactor
             static let leftBorder: CGFloat = 12
             static let rightBorder: CGFloat = 12
-            static let bottomBorder: CGFloat = 3 * Skin.scaleFactor
+            static let bottomBorder: CGFloat = 7 * Skin.scaleFactor
         }
 
         /// Window control button positions in title bar (scaled)
@@ -1030,7 +1030,7 @@ struct SkinElements {
             static let titleBarHeight: CGFloat = 20 * Skin.scaleFactor
             static let leftBorder: CGFloat = 12
             static let rightBorder: CGFloat = 12
-            static let bottomBorder: CGFloat = 3 * Skin.scaleFactor
+            static let bottomBorder: CGFloat = 7 * Skin.scaleFactor
         }
     }
 

--- a/Sources/NullPlayer/Skin/SkinElements.swift
+++ b/Sources/NullPlayer/Skin/SkinElements.swift
@@ -765,7 +765,7 @@ struct SkinElements {
             static let tabBarHeight: CGFloat = 24
             static let serverBarHeight: CGFloat = 24
             static let searchBarHeight: CGFloat = 26
-            static let statusBarHeight: CGFloat = 3  // Thin bottom border
+            static let statusBarHeight: CGFloat = 7 * Skin.scaleFactor  // Match playlist/spectrum/waveform bottom border
             static let scrollbarWidth: CGFloat = 0   // No scrollbar - users scroll with trackpad/wheel
             static let alphabetWidth: CGFloat = 16
             static let leftBorder: CGFloat = 12
@@ -863,7 +863,7 @@ struct SkinElements {
             static let titleBarHeight: CGFloat = 18
             static let searchBarHeight: CGFloat = 24
             static let columnHeaderHeight: CGFloat = 22
-            static let statusBarHeight: CGFloat = 3   // Thin bottom border
+            static let statusBarHeight: CGFloat = 7 * Skin.scaleFactor   // Match playlist/spectrum/waveform bottom border
             static let scrollbarWidth: CGFloat = 0    // No scrollbar - users scroll with trackpad/wheel
             static let leftBorder: CGFloat = 3        // Thin side borders
             static let rightBorder: CGFloat = 3       // Edge only (no scrollbar)
@@ -903,9 +903,9 @@ struct SkinElements {
             static let titleBarHeight: CGFloat = 20
             static let leftBorder: CGFloat = 12
             static let rightBorder: CGFloat = 12
-            static let bottomBorder: CGFloat = 3
+            static let bottomBorder: CGFloat = 7 * Skin.scaleFactor
         }
-        
+
         // MARK: - Title Bar (same style as playlist)
         
         struct TitleBar {

--- a/Sources/NullPlayer/Skin/SkinElements.swift
+++ b/Sources/NullPlayer/Skin/SkinElements.swift
@@ -865,8 +865,8 @@ struct SkinElements {
             static let columnHeaderHeight: CGFloat = 22
             static let statusBarHeight: CGFloat = 7 * Skin.scaleFactor   // Match playlist/spectrum/waveform bottom border
             static let scrollbarWidth: CGFloat = 0    // No scrollbar - users scroll with trackpad/wheel
-            static let leftBorder: CGFloat = 3        // Thin side borders
-            static let rightBorder: CGFloat = 3       // Edge only (no scrollbar)
+            static let leftBorder: CGFloat = 12       // Match playlist-style side rails
+            static let rightBorder: CGFloat = 12      // Match playlist-style side rails
             static let padding: CGFloat = 3
         }
         

--- a/Sources/NullPlayer/Skin/SkinRenderer.swift
+++ b/Sources/NullPlayer/Skin/SkinRenderer.swift
@@ -1676,16 +1676,15 @@ class SkinRenderer {
         // Fill background with black for visualization area
         NSColor.black.setFill()
         context.fill(bounds)
-        
+
         let titleHeight = SkinElements.Playlist.titleHeight  // 20px like playlist
-        let bottomHeight = SkinElements.ProjectM.Layout.bottomBorder
+        let bottomHeight = 7 * Skin.scaleFactor
 
         // Left/right side borders using the same leftSideTile sprite as the playlist
         drawPlaylistStyleSideBorders(in: context, bounds: bounds, titleHeight: titleHeight, bottomHeight: bottomHeight)
 
-        // Bottom bar solid fill
-        NSColor(calibratedRed: 0.08, green: 0.08, blue: 0.12, alpha: 1.0).setFill()
-        context.fill(NSRect(x: 0, y: bounds.height - bottomHeight, width: bounds.width, height: bottomHeight))
+        // Bottom strip: rotated side-tile so it matches the left/right borders.
+        drawPlaylistStyleBottomBorder(in: context, bounds: bounds, bottomHeight: bottomHeight)
 
         // Draw title bar using PLEDIT.BMP sprites (without custom text)
         drawSpectrumAnalyzerTitleBar(in: context, bounds: bounds, isActive: isActive, pressedButton: pressedButton)
@@ -2114,31 +2113,30 @@ class SkinRenderer {
         }
     }
     
-    /// Draw GEN.BMP bottom bar (three-part: left corner, tiled middle, right corner)
-    private func drawGenBottomBar(cgImage: CGImage, in context: CGContext, bounds: NSRect) {
+    /// Draw GEN.BMP bottom bar (three-part: left corner, tiled middle, right corner).
+    /// When `height` is provided, the sprite is vertically squashed to that height.
+    private func drawGenBottomBar(cgImage: CGImage, in context: CGContext, bounds: NSRect, height: CGFloat? = nil) {
         let bottomLeftCorner = SkinElements.GenWindow.Chrome.bottomLeftCorner
         let bottomTile = SkinElements.GenWindow.Chrome.bottomTile
         let bottomRightCorner = SkinElements.GenWindow.Chrome.bottomRightCorner
-        
-        let bottomY = bounds.height - bottomLeftCorner.height
-        
-        // Draw left corner
+
+        let drawHeight = height ?? bottomLeftCorner.height
+        let bottomY = bounds.height - drawHeight
+
         drawSprite(from: cgImage, sourceRect: bottomLeftCorner,
-                  destRect: NSRect(x: 0, y: bottomY, width: bottomLeftCorner.width, height: bottomLeftCorner.height),
+                  destRect: NSRect(x: 0, y: bottomY, width: bottomLeftCorner.width, height: drawHeight),
                   in: context)
-        
-        // Draw right corner
+
         let rightCornerX = bounds.width - bottomRightCorner.width
         drawSprite(from: cgImage, sourceRect: bottomRightCorner,
-                  destRect: NSRect(x: rightCornerX, y: bottomY, width: bottomRightCorner.width, height: bottomRightCorner.height),
+                  destRect: NSRect(x: rightCornerX, y: bottomY, width: bottomRightCorner.width, height: drawHeight),
                   in: context)
-        
-        // Draw tiled middle section
+
         let middleX = bottomLeftCorner.width
         let middleWidth = bounds.width - bottomLeftCorner.width - bottomRightCorner.width
         if middleWidth > 0 {
             drawTiledSprite(from: cgImage, sourceRect: bottomTile,
-                           destRect: NSRect(x: middleX, y: bottomY, width: middleWidth, height: bottomTile.height),
+                           destRect: NSRect(x: middleX, y: bottomY, width: middleWidth, height: drawHeight),
                            in: context, tileVertically: false)
         }
     }
@@ -2404,10 +2402,8 @@ class SkinRenderer {
         // Draw side borders
         drawPlaylistSideBorders(in: context, bounds: bounds)
         
-        // Match the simple bottom strip used by waveform/spectrum/projectm windows.
-        let borderY = bounds.height - bottomHeight
-        NSColor(calibratedRed: 0.08, green: 0.08, blue: 0.12, alpha: 1.0).setFill()
-        context.fill(NSRect(x: 0, y: borderY, width: bounds.width, height: bottomHeight))
+        // Bottom strip: rotated side-tile so it matches the left/right borders.
+        drawPlaylistStyleBottomBorder(in: context, bounds: bounds, bottomHeight: bottomHeight)
         
         // Scrollbar removed - users scroll with trackpad/wheel
     }
@@ -2514,6 +2510,63 @@ class SkinRenderer {
         }
     }
     
+    /// Build a horizontally-tileable bottom-border tile by rotating the playlist `leftSideTile`
+    /// 90° CCW so its outer edge ends up at the bottom of the strip. Result: 29 × 12 image.
+    private func rotatedSideTileForBottomBorder() -> CGImage? {
+        guard let pleditImage = skin.pledit,
+              let pleditCG = pleditImage.cgImage(forProposedRect: nil, context: nil, hints: nil) else {
+            return nil
+        }
+        let src = SkinElements.Playlist.leftSideTile  // 12 × 29
+        let cropRect = CGRect(x: src.origin.x, y: src.origin.y, width: src.width, height: src.height)
+        guard let srcCG = pleditCG.cropping(to: cropRect) else { return nil }
+
+        let outW = Int(src.height)  // 29
+        let outH = Int(src.width)   // 12
+        let colorSpace = CGColorSpaceCreateDeviceRGB()
+        let bitmapInfo = CGImageAlphaInfo.premultipliedLast.rawValue
+        guard let ctx = CGContext(data: nil, width: outW, height: outH,
+                                  bitsPerComponent: 8, bytesPerRow: 0,
+                                  space: colorSpace, bitmapInfo: bitmapInfo) else { return nil }
+        ctx.interpolationQuality = .none
+
+        // Bottom-up CG context. Rotate 90° CCW so the tile's outer edge (source x=0)
+        // ends up at the BOTTOM (y=0 in CG bottom-up = visible bottom of the strip).
+        ctx.translateBy(x: CGFloat(outW), y: 0)
+        ctx.rotate(by: .pi / 2)
+        ctx.draw(srcCG, in: CGRect(x: 0, y: 0, width: src.width, height: src.height))
+        return ctx.makeImage()
+    }
+
+    /// Draw the bottom border strip using the side-tile texture rotated 90°, so it matches
+    /// the look of the left/right borders. Falls back to a solid dark fill.
+    private func drawPlaylistStyleBottomBorder(in context: CGContext, bounds: NSRect, bottomHeight: CGFloat) {
+        // Snap to integer pixels so the strip aligns with the snapped side-tile rects below it.
+        let snappedHeight = bottomHeight.rounded(.down)
+        let bottomY = (bounds.height - snappedHeight).rounded(.down)
+        guard let rotated = rotatedSideTileForBottomBorder() else {
+            NSColor(calibratedRed: 0.08, green: 0.08, blue: 0.10, alpha: 1.0).setFill()
+            context.fill(NSRect(x: 0, y: bottomY, width: bounds.width, height: snappedHeight))
+            return
+        }
+        let tileNaturalWidth = CGFloat(rotated.width)
+        context.saveGState()
+        context.clip(to: NSRect(x: 0, y: bottomY, width: bounds.width, height: snappedHeight))
+        context.interpolationQuality = .none
+        var x: CGFloat = 0
+        while x < bounds.width {
+            let drawWidth = min(tileNaturalWidth, bounds.width - x)
+            // Render rotated tile into top-down context: translate to dest, flip Y locally.
+            context.saveGState()
+            context.translateBy(x: x, y: bottomY + snappedHeight)
+            context.scaleBy(x: 1, y: -1)
+            context.draw(rotated, in: CGRect(x: 0, y: 0, width: drawWidth, height: snappedHeight))
+            context.restoreGState()
+            x += tileNaturalWidth
+        }
+        context.restoreGState()
+    }
+
     /// Draw left and right side borders (shared by playlist, spectrum, waveform, projectM).
     /// Both borders use the same leftSideTile sprite; the right border is drawn horizontally
     /// mirrored so both sides appear identical.
@@ -2537,10 +2590,14 @@ class SkinRenderer {
             context.fill(NSRect(x: bounds.width - sideW, y: contentTop, width: sideW, height: contentBottom - contentTop))
         }
 
-        var y = contentBottom - tileH
+        // Snap tile rects to integer pixels — when bottomHeight/contentBottom is fractional
+        // (e.g. scaleFactor == 1.25), unsnapped destination rects let sub-pixel rendering
+        // bleed between adjacent tiles, producing visible blue seams at every tile join.
+        let snappedBottom = contentBottom.rounded(.down)
+        var y = snappedBottom - tileH
         while y > contentTop - tileH {
-            let drawY = max(contentTop, y)
-            let h = min(tileH, contentBottom - drawY)
+            let drawY = max(contentTop, y).rounded(.down)
+            let h = min(tileH, snappedBottom - drawY)
             if h > 0 {
                 let leftDest = NSRect(x: 0, y: drawY, width: sideW, height: h)
                 let rightDest = NSRect(x: bounds.width - sideW, y: drawY, width: sideW, height: h)

--- a/Sources/NullPlayer/Skin/SkinRenderer.swift
+++ b/Sources/NullPlayer/Skin/SkinRenderer.swift
@@ -2605,7 +2605,7 @@ class SkinRenderer {
     private func drawPlaylistStyleBottomBorder(in context: CGContext, bounds: NSRect, bottomHeight: CGFloat) {
         let sideW: CGFloat = 12
         let goldTrimHeight: CGFloat = 2
-        let snappedHeight = bottomHeight.rounded(.down)
+        let snappedHeight = bottomHeight.rounded(.up)
         let bottomY = (bounds.height - snappedHeight).rounded(.down)
         let stripStartX = sideW
         let stripEndX = max(stripStartX, bounds.width - sideW)

--- a/Sources/NullPlayer/Skin/SkinRenderer.swift
+++ b/Sources/NullPlayer/Skin/SkinRenderer.swift
@@ -1501,14 +1501,13 @@ class SkinRenderer {
         context.fill(bounds)
         
         let titleHeight = SkinElements.Playlist.titleHeight  // 20px like playlist
-        let bottomHeight = SkinElements.ProjectM.Layout.bottomBorder
+        let bottomHeight = 7 * Skin.scaleFactor  // match playlist/spectrum/waveform
 
         // Left/right side borders using the same leftSideTile sprite as the playlist
         drawPlaylistStyleSideBorders(in: context, bounds: bounds, titleHeight: titleHeight, bottomHeight: bottomHeight)
 
-        // Bottom bar solid fill
-        NSColor(calibratedRed: 0.08, green: 0.08, blue: 0.12, alpha: 1.0).setFill()
-        context.fill(NSRect(x: 0, y: bounds.height - bottomHeight, width: bounds.width, height: bottomHeight))
+        // Bottom strip: rotated side-tile + continuous gold trim across the bottom (U-shape).
+        drawPlaylistStyleBottomBorder(in: context, bounds: bounds, bottomHeight: bottomHeight)
 
         // Draw title bar using PLEDIT.BMP sprites (without custom text)
         drawProjectMTitleBarFromPledit(in: context, bounds: bounds, isActive: isActive, pressedButton: pressedButton)
@@ -1534,11 +1533,18 @@ class SkinRenderer {
         // Draw left corner
         drawSprite(from: pleditImage, sourceRect: leftCorner,
                   to: NSRect(x: 0, y: 0, width: leftCornerWidth, height: titleHeight), in: context)
-        
-        // Draw right corner (contains window buttons)
-        drawSprite(from: pleditImage, sourceRect: rightCorner,
-                  to: NSRect(x: bounds.width - rightCornerWidth, y: 0, width: rightCornerWidth, height: titleHeight), in: context)
-        
+
+        // Right corner: mirror the leftCorner sprite so its inner bevel aligns with the
+        // 12-wide side border below (same fix as playlist/spectrum/waveform).
+        let rightMirrorRect = NSRect(x: bounds.width - leftCornerWidth, y: 0,
+                                     width: leftCornerWidth, height: titleHeight)
+        context.saveGState()
+        context.translateBy(x: rightMirrorRect.midX, y: 0)
+        context.scaleBy(x: -1, y: 1)
+        context.translateBy(x: -rightMirrorRect.midX, y: 0)
+        drawSprite(from: pleditImage, sourceRect: leftCorner, to: rightMirrorRect, in: context)
+        context.restoreGState()
+
         // Fill the middle section with tiles
         let middleStart = leftCornerWidth
         let middleEnd = bounds.width - rightCornerWidth
@@ -1549,18 +1555,27 @@ class SkinRenderer {
                       to: NSRect(x: x, y: 0, width: w, height: titleHeight), in: context)
             x += tileWidth
         }
-        
+
+        // Re-draw the close icon (baked into rightCorner) on top of the mirrored corner.
+        let closeIconYOffset: CGFloat = isActive ? 0 : 21
+        let closeBtnSource = NSRect(x: 167, y: 3 + closeIconYOffset, width: 9, height: 9)
+        drawSprite(from: pleditImage, sourceRect: closeBtnSource,
+                  to: NSRect(x: bounds.width - SkinElements.Playlist.TitleBarButtons.closeOffset,
+                             y: 3, width: 9, height: 9), in: context)
+
+        _ = rightCorner
+
         // Note: Custom text removed - let the skin's title bar show through
-        
+
         // Draw close button pressed state if needed
         if pressedButton == .close {
-            let closeRect = NSRect(x: bounds.width - SkinElements.Playlist.TitleBarButtons.closeOffset, 
+            let closeRect = NSRect(x: bounds.width - SkinElements.Playlist.TitleBarButtons.closeOffset,
                                    y: 3, width: 9, height: 9)
             NSColor(calibratedWhite: 0.3, alpha: 0.5).setFill()
             context.fill(closeRect)
         }
     }
-    
+
     /// Draw "PROJECTM" text using GenFont from gen.png
     /// Creates a solid background gap in the title bar decorations for the text
     private func drawProjectMTitleText(in context: CGContext, bounds: NSRect, titleHeight: CGFloat, isActive: Bool = true) {
@@ -1710,11 +1725,20 @@ class SkinRenderer {
         // Draw left corner
         drawSprite(from: pleditImage, sourceRect: leftCorner,
                   to: NSRect(x: 0, y: 0, width: leftCornerWidth, height: titleHeight), in: context)
-        
-        // Draw right corner (contains window buttons)
-        drawSprite(from: pleditImage, sourceRect: rightCorner,
-                  to: NSRect(x: bounds.width - rightCornerWidth, y: 0, width: rightCornerWidth, height: titleHeight), in: context)
-        
+
+        // Right corner: mirror the leftCorner sprite so its inner bevel aligns with the
+        // 12-wide side border below (same fix as the playlist — the original rightCorner
+        // sprite was designed for the legacy 20-wide scrollbar tile and its inner bevel
+        // sits too far inward, leaving the interior content area wider under the title bar).
+        let rightMirrorRect = NSRect(x: bounds.width - leftCornerWidth, y: 0,
+                                     width: leftCornerWidth, height: titleHeight)
+        context.saveGState()
+        context.translateBy(x: rightMirrorRect.midX, y: 0)
+        context.scaleBy(x: -1, y: 1)
+        context.translateBy(x: -rightMirrorRect.midX, y: 0)
+        drawSprite(from: pleditImage, sourceRect: leftCorner, to: rightMirrorRect, in: context)
+        context.restoreGState()
+
         // Fill the middle section with tiles
         let middleStart = leftCornerWidth
         let middleEnd = bounds.width - rightCornerWidth
@@ -1725,18 +1749,27 @@ class SkinRenderer {
                       to: NSRect(x: x, y: 0, width: w, height: titleHeight), in: context)
             x += tileWidth
         }
-        
+
+        // Re-draw the close icon (baked into rightCorner) on top of the mirrored corner.
+        let closeIconYOffset: CGFloat = isActive ? 0 : 21
+        let closeBtnSource = NSRect(x: 167, y: 3 + closeIconYOffset, width: 9, height: 9)
+        drawSprite(from: pleditImage, sourceRect: closeBtnSource,
+                  to: NSRect(x: bounds.width - SkinElements.Playlist.TitleBarButtons.closeOffset,
+                             y: 3, width: 9, height: 9), in: context)
+
+        _ = rightCorner  // original sprite no longer drawn; reference kept above for parity
+
         // Note: Custom text removed - let the skin's title bar show through
-        
+
         // Draw close button pressed state if needed
         if pressedButton == .close {
-            let closeRect = NSRect(x: bounds.width - SkinElements.Playlist.TitleBarButtons.closeOffset, 
+            let closeRect = NSRect(x: bounds.width - SkinElements.Playlist.TitleBarButtons.closeOffset,
                                    y: 3, width: 9, height: 9)
             NSColor(calibratedWhite: 0.3, alpha: 0.5).setFill()
             context.fill(closeRect)
         }
     }
-    
+
     /// Draw "NULLPLAYER ANALYZER" text using GenFont from gen.png
     private func drawSpectrumAnalyzerTitleText(in context: CGContext, bounds: NSRect, titleHeight: CGFloat, isActive: Bool = true) {
         // Load gen.png from skin or bundle
@@ -2562,25 +2595,35 @@ class SkinRenderer {
         return ctx.makeImage()
     }
 
-    /// Draw the bottom border strip using the side-tile texture rotated 90°, so it matches
-    /// the look of the left/right borders. Falls back to a solid dark fill.
+    /// Draw the bottom border strip using the side-tile texture rotated 90°. The strip is
+    /// inset by `sideW` on each end so the side borders (drawn full-height by
+    /// `drawPlaylistStyleSideBorders`) form the bottom-corner regions with their own
+    /// vertical artwork. After the inset strip, a 2px-tall gold-trim row is drawn across the
+    /// FULL width so the gold outline is continuous all the way from the left side border's
+    /// outer bevel, across the bottom, to the right side border's outer bevel — one U-shape
+    /// with no slits at the corners.
     private func drawPlaylistStyleBottomBorder(in context: CGContext, bounds: NSRect, bottomHeight: CGFloat) {
-        // Snap to integer pixels so the strip aligns with the snapped side-tile rects below it.
+        let sideW: CGFloat = 12
+        let goldTrimHeight: CGFloat = 2
         let snappedHeight = bottomHeight.rounded(.down)
         let bottomY = (bounds.height - snappedHeight).rounded(.down)
+        let stripStartX = sideW
+        let stripEndX = max(stripStartX, bounds.width - sideW)
+
         guard let rotated = rotatedSideTileForBottomBorder() else {
             NSColor(calibratedRed: 0.08, green: 0.08, blue: 0.10, alpha: 1.0).setFill()
-            context.fill(NSRect(x: 0, y: bottomY, width: bounds.width, height: snappedHeight))
+            context.fill(NSRect(x: stripStartX, y: bottomY, width: stripEndX - stripStartX, height: snappedHeight))
             return
         }
         let tileNaturalWidth = CGFloat(rotated.width)
+
+        // 1) Inset rotated tile strip between the side borders.
         context.saveGState()
-        context.clip(to: NSRect(x: 0, y: bottomY, width: bounds.width, height: snappedHeight))
+        context.clip(to: NSRect(x: stripStartX, y: bottomY, width: stripEndX - stripStartX, height: snappedHeight))
         context.interpolationQuality = .none
-        var x: CGFloat = 0
-        while x < bounds.width {
-            let drawWidth = min(tileNaturalWidth, bounds.width - x)
-            // Render rotated tile into top-down context: translate to dest, flip Y locally.
+        var x: CGFloat = stripStartX
+        while x < stripEndX {
+            let drawWidth = min(tileNaturalWidth, stripEndX - x)
             context.saveGState()
             context.translateBy(x: x, y: bottomY + snappedHeight)
             context.scaleBy(x: 1, y: -1)
@@ -2589,16 +2632,44 @@ class SkinRenderer {
             x += tileNaturalWidth
         }
         context.restoreGState()
+
+        // 2) Crop the rotated tile's bottom `goldTrimHeight` rows — those rows come from the
+        //    leftSideTile's outer bevel (the gold-trim column), so every pixel is the same
+        //    gold-trim pixel as the side borders' outer edges. Tile that strip across the FULL
+        //    window width at the very bottom row, so the gold outline runs continuously left
+        //    → across → right with no slits at the corners.
+        let goldStripRect = CGRect(x: 0, y: 0, width: rotated.width, height: Int(goldTrimHeight))
+        guard let goldStrip = rotated.cropping(to: goldStripRect) else { return }
+        let goldNaturalWidth = CGFloat(goldStrip.width)
+        let goldY = (bounds.height - goldTrimHeight).rounded(.down)
+        context.saveGState()
+        context.clip(to: NSRect(x: 0, y: goldY, width: bounds.width, height: goldTrimHeight))
+        context.interpolationQuality = .none
+        var gx: CGFloat = 0
+        while gx < bounds.width {
+            let drawWidth = min(goldNaturalWidth, bounds.width - gx)
+            context.saveGState()
+            context.translateBy(x: gx, y: goldY + goldTrimHeight)
+            context.scaleBy(x: 1, y: -1)
+            context.draw(goldStrip, in: CGRect(x: 0, y: 0, width: drawWidth, height: goldTrimHeight))
+            context.restoreGState()
+            gx += goldNaturalWidth
+        }
+        context.restoreGState()
     }
 
     /// Draw left and right side borders (shared by playlist, spectrum, waveform, projectM).
     /// Both borders use the same leftSideTile sprite; the right border is drawn horizontally
     /// mirrored so both sides appear identical.
     private func drawPlaylistStyleSideBorders(in context: CGContext, bounds: NSRect, titleHeight: CGFloat, bottomHeight: CGFloat) {
+        _ = bottomHeight  // Side borders extend the full window height so the bottom-corner
+                          // regions are filled with the same vertical artwork (gold trim
+                          // included). The bottom strip insets between the side borders so
+                          // there's no rotation seam at the corners.
         let sideW: CGFloat = 12
         let tileH: CGFloat = 29
         let contentTop = titleHeight
-        let contentBottom = bounds.height - bottomHeight
+        let contentBottom = bounds.height
         let backingScale = NSScreen.main?.backingScaleFactor ?? 2.0
 
         guard let pleditImage = skin.pledit else {
@@ -2793,10 +2864,18 @@ class SkinRenderer {
         // Use NSImage-based drawing (same as ProjectM) to avoid interpolation artifacts
         drawSprite(from: pleditImage, sourceRect: leftCorner,
                   to: NSRect(x: 0, y: 0, width: leftCornerWidth, height: titleHeight), in: context)
-        
-        drawSprite(from: pleditImage, sourceRect: rightCorner,
-                  to: NSRect(x: bounds.width - rightCornerWidth, y: 0, width: rightCornerWidth, height: titleHeight), in: context)
-        
+
+        // Right corner: mirror the leftCorner sprite so its inner bevel aligns with the
+        // 12-wide side border below (same fix as playlist/spectrum/waveform/projectM).
+        let rightMirrorRect = NSRect(x: bounds.width - leftCornerWidth, y: 0,
+                                     width: leftCornerWidth, height: titleHeight)
+        context.saveGState()
+        context.translateBy(x: rightMirrorRect.midX, y: 0)
+        context.scaleBy(x: -1, y: 1)
+        context.translateBy(x: -rightMirrorRect.midX, y: 0)
+        drawSprite(from: pleditImage, sourceRect: leftCorner, to: rightMirrorRect, in: context)
+        context.restoreGState()
+
         // Fill the middle section with tiles
         let middleStart = leftCornerWidth
         let middleEnd = bounds.width - rightCornerWidth
@@ -2807,9 +2886,22 @@ class SkinRenderer {
                       to: NSRect(x: x, y: 0, width: w, height: titleHeight), in: context)
             x += tileWidth
         }
-        
+
+        // Re-draw the close + shade icons (baked into rightCorner) on top of mirrored corner.
+        let closeIconYOffset: CGFloat = isActive ? 0 : 21
+        let closeBtnSource = NSRect(x: 167, y: 3 + closeIconYOffset, width: 9, height: 9)
+        let shadeBtnSource = NSRect(x: 158, y: 3 + closeIconYOffset, width: 9, height: 9)
+        drawSprite(from: pleditImage, sourceRect: closeBtnSource,
+                  to: NSRect(x: bounds.width - SkinElements.Playlist.TitleBarButtons.closeOffset,
+                             y: 3, width: 9, height: 9), in: context)
+        drawSprite(from: pleditImage, sourceRect: shadeBtnSource,
+                  to: NSRect(x: bounds.width - SkinElements.Playlist.TitleBarButtons.shadeOffset,
+                             y: 3, width: 9, height: 9), in: context)
+
+        _ = rightCorner
+
         // Note: Custom text removed - let the skin's title bar show through
-        
+
         if pressedButton == .close {
             let closeRect = NSRect(x: bounds.width - SkinElements.Playlist.TitleBarButtons.closeOffset,
                                    y: 3, width: 9, height: 9)
@@ -2847,9 +2939,18 @@ class SkinRenderer {
             x += tileWidth
         }
         
-        drawSprite(from: image, sourceRect: layout.rightCorner,
-                  to: NSRect(x: bounds.width - rightCornerWidth, y: 0, width: rightCornerWidth, height: titleHeight), in: context)
-        
+        // Right corner: mirror the leftCorner sprite so the outer bevel matches the side
+        // border below (same fix as playlist/spectrum/waveform/projectM). The close + shade
+        // buttons are drawn separately via drawButton below, so no icon overlay is needed.
+        let rightMirrorRect = NSRect(x: bounds.width - rightCornerWidth, y: 0,
+                                     width: rightCornerWidth, height: titleHeight)
+        context.saveGState()
+        context.translateBy(x: rightMirrorRect.midX, y: 0)
+        context.scaleBy(x: -1, y: 1)
+        context.translateBy(x: -rightMirrorRect.midX, y: 0)
+        drawSprite(from: image, sourceRect: layout.leftCorner, to: rightMirrorRect, in: context)
+        context.restoreGState()
+
         // Draw "NULLPLAYER LIBRARY" text using GenFont with proper active/inactive colors
         drawLibraryTitleText(in: context, bounds: bounds, titleHeight: titleHeight, isActive: isActive)
         
@@ -3452,50 +3553,18 @@ class SkinRenderer {
         drawPlaylistStyleSideBorders(in: context, bounds: bounds, titleHeight: titleHeight, bottomHeight: borderHeight)
     }
     
-    /// Draw Plex browser status bar at bottom
+    /// Draw Plex browser status bar at bottom — uses the same U-shape rotated-side-tile +
+    /// continuous gold-trim treatment as the playlist/spectrum/waveform/projectM windows.
     private func drawPlexBrowserStatusBar(in context: CGContext, bounds: NSRect) {
-        // Try to use library-window.png first
-        if let libraryImage = skin.libraryWindowImage {
-            drawLibraryWindowStatusBar(from: libraryImage, in: context, bounds: bounds)
-            return
-        }
-        
-        // Fall back to playlist colors
-        let layout = SkinElements.PlexBrowser.Layout.self
-        let statusHeight = layout.statusBarHeight
-        let statusY = bounds.height - statusHeight
-        
-        // Use playlist colors for consistent look
-        let colors = skin.playlistColors
-        
-        // Draw status bar background
-        colors.normalBackground.withAlphaComponent(0.8).setFill()
-        context.fill(NSRect(x: 0, y: statusY, width: bounds.width, height: statusHeight))
-        
-        // Draw top border line - skip on non-Retina displays to prevent visible lines
-        let backingScale = NSScreen.main?.backingScaleFactor ?? 2.0
-        if backingScale >= 1.5 {
-            NSColor(calibratedWhite: 0.3, alpha: 0.5).setFill()
-            context.fill(NSRect(x: 0, y: statusY, width: bounds.width, height: 1))
-        }
+        let bottomHeight = SkinElements.PlexBrowser.Layout.statusBarHeight
+        drawPlaylistStyleBottomBorder(in: context, bounds: bounds, bottomHeight: bottomHeight)
     }
     
-    /// Draw bottom border using a thin line like other windows
-    private func drawLibraryWindowStatusBar(from image: NSImage, in context: CGContext, bounds: NSRect) {
-        // Just draw a thin bottom border line (2-3 pixels) to match playlist/EQ windows
-        let borderHeight = SkinElements.LibraryWindow.Layout.statusBarHeight
-        let statusY = bounds.height - borderHeight
-        
-        // Draw thin bottom border matching the window chrome color
-        NSColor(calibratedRed: 0.12, green: 0.12, blue: 0.18, alpha: 1.0).setFill()
-        context.fill(NSRect(x: 0, y: statusY, width: bounds.width, height: borderHeight))
-        
-        // Draw highlight line at top of border - skip on non-Retina displays to prevent visible lines
-        let backingScale = NSScreen.main?.backingScaleFactor ?? 2.0
-        if backingScale >= 1.5 {
-            NSColor(calibratedRed: 0.20, green: 0.20, blue: 0.30, alpha: 1.0).setFill()
-            context.fill(NSRect(x: 0, y: statusY, width: bounds.width, height: 1))
-        }
+    /// Draw bottom border matching playlist/spectrum/waveform: rotated side-tile strip inset
+    /// between the side borders + continuous gold trim across the full bottom (U-shape).
+    private func drawLibraryWindowStatusBar(from _: NSImage, in context: CGContext, bounds: NSRect) {
+        let bottomHeight = 7 * Skin.scaleFactor
+        drawPlaylistStyleBottomBorder(in: context, bounds: bounds, bottomHeight: bottomHeight)
     }
     
     /// Draw Plex browser scrollbar

--- a/Sources/NullPlayer/Skin/SkinRenderer.swift
+++ b/Sources/NullPlayer/Skin/SkinRenderer.swift
@@ -2488,9 +2488,33 @@ class SkinRenderer {
         
         drawSprite(from: pleditImage, sourceRect: leftCorner,
                   to: NSRect(x: 0, y: 0, width: leftCornerWidth + cornerOverlap, height: titleHeight), in: context)
-        
-        drawSprite(from: pleditImage, sourceRect: rightCorner,
-                  to: NSRect(x: bounds.width - rightCornerWidth - cornerOverlap, y: 0, width: rightCornerWidth + cornerOverlap, height: titleHeight), in: context)
+
+        // Right corner: mirror the leftCorner sprite so its inner+outer bevels match the
+        // mirrored leftSideTile border below it (symmetric with the left). The original
+        // rightCorner sprite places its inner bevel ~3px from the window edge (designed to
+        // abut the old 20-wide scrollbar tile), so its interior boundary doesn't line up with
+        // the 12-wide side border below — leaving the interior content area wider under the
+        // title bar than below it. Mirroring leftCorner avoids that step.
+        let rightMirrorRect = NSRect(x: bounds.width - leftCornerWidth - cornerOverlap, y: 0,
+                                     width: leftCornerWidth + cornerOverlap, height: titleHeight)
+        context.saveGState()
+        context.translateBy(x: rightMirrorRect.midX, y: 0)
+        context.scaleBy(x: -1, y: 1)
+        context.translateBy(x: -rightMirrorRect.midX, y: 0)
+        drawSprite(from: pleditImage, sourceRect: leftCorner, to: rightMirrorRect, in: context)
+        context.restoreGState()
+
+        // The close + shade button icons were baked into rightCorner; re-draw just those
+        // icons on top of the mirrored corner so the user-facing buttons are preserved.
+        let buttonInactiveYOffset: CGFloat = isActive ? 0 : 21
+        let closeBtnSource = NSRect(x: 167, y: 3 + buttonInactiveYOffset, width: 9, height: 9)
+        let shadeBtnSource = NSRect(x: 158, y: 3 + buttonInactiveYOffset, width: 9, height: 9)
+        drawSprite(from: pleditImage, sourceRect: closeBtnSource,
+                  to: NSRect(x: bounds.width - SkinElements.Playlist.TitleBarButtons.closeOffset,
+                             y: 3, width: 9, height: 9), in: context)
+        drawSprite(from: pleditImage, sourceRect: shadeBtnSource,
+                  to: NSRect(x: bounds.width - SkinElements.Playlist.TitleBarButtons.shadeOffset,
+                             y: 3, width: 9, height: 9), in: context)
         
         // Draw window control button pressed states if needed
         if pressedButton == .close {

--- a/skills/ui-guide/SKILL.md
+++ b/skills/ui-guide/SKILL.md
@@ -173,6 +173,18 @@ Valid widths: 275, 300, 425, 450, 475, 500, 550px
 
 **Non-Retina displays**: Even with aligned widths, tile seams may be visible on 1x displays. See the non-retina-fixes skill for techniques like background fill, tile overlap, and bottom-to-top drawing.
 
+## Classic Playlist-Style Window Chrome
+
+`drawPlaylistWindow` / `drawSpectrumAnalyzerWindow` / `drawProjectMNormal` / `drawPlexBrowserWindow` all share three helpers in `SkinRenderer` and render as one continuous U-shape outline:
+
+- **`drawPlaylistStyleSideBorders`** — vertical `leftSideTile` (mirrored on the right). The side borders extend to `bounds.height`, INCLUDING the bottom-corner regions, so the outer gold trim runs continuously down each side.
+- **`drawPlaylistStyleBottomBorder`** — rotated `leftSideTile` strip inset between the side borders (`x = 12` to `bounds.width − 12`), plus a 2px-tall gold-trim row tiled across the FULL window width at the very bottom. The gold trim is cropped from the rotated tile's bottom 2 rows, which come from the source's gold-bevel column, so every pixel matches the side borders' outer trim color.
+- **Top-right corner fix** — the right corner of the title bar is rendered by MIRRORING the `leftCorner` sprite (not by drawing the original `rightCorner`). The original `rightCorner` artwork was designed to abut the legacy 20-wide scrollbar tile, so its inner bevel sits too far inward and leaves the interior content area visibly wider under the title bar than below. The close (and shade, where applicable) button icons baked into the original `rightCorner` are re-drawn on top from sprite coords `(167, 3, 9, 9)` and `(158, 3, 9, 9)` (with `+21` y offset for the inactive state).
+
+**Bottom-border thickness lives in layout structs**: `Playlist.bottomHeight`, `SpectrumWindow.Layout.bottomBorder`, `WaveformWindow.Layout.bottomBorder`, `ProjectM.Layout.bottomBorder`, `PlexBrowser.Layout.statusBarHeight`, and `LibraryWindow.Layout.statusBarHeight` are all `7 * Skin.scaleFactor`. Interior content rendering uses these constants, so keep them in sync if you change the strip height.
+
+**Pixel snapping**: Both helpers snap tile destinations with `.rounded(.down)` to avoid sub-pixel rendering that bleeds the default Winamp skin's blue-tinted edge pixels between adjacent tiles. See non-retina-fixes skill for the underlying issue.
+
 ## Menu Bar Integration (AppKit)
 
 When adding or refactoring top menu bar content:


### PR DESCRIPTION
## Summary
- Playlist, spectrum, waveform, ProjectM, and library windows now share one continuous U-shape outer border (side borders extend through the bottom corners, rotated bottom strip insets between them, and a 2px gold-trim row spans the full bottom to bridge the corners).
- Top-right corner of every classic chrome title bar mirrors `leftCorner` instead of using the legacy `rightCorner`, with the close (and shade, where applicable) icons re-drawn on top. This eliminates the bevel offset that previously left the interior content area visibly wider under the title bar than below it.
- Bumped `bottomBorder` / `statusBarHeight` layout constants for ProjectM / PlexBrowser / LibraryWindow from `3` to `7 * Skin.scaleFactor` so interior content rendering matches the visible strip height.

## Test plan
- [ ] Open the playlist, spectrum, waveform, ProjectM, and library windows; verify the outer border reads as one continuous U-shape with no slits at the bottom corners.
- [ ] Verify the top-right corner of each window matches the top-left (no offset, no widened interior under the title bar).
- [ ] Verify the close X and (where applicable) shade icons still render correctly in normal + pressed states and remain hit-testable at the same positions.
- [ ] Test at non-Retina (1x) backing scale and at the default `Skin.scaleFactor` of 1.25 — no blue tile seams should appear at corner boundaries.
- [ ] Test active vs inactive title bar appearance (focus a different window and back).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed window border and corner alignment issues across Classic playlist, spectrum analyzer, and library windows.
  * Corrected bottom border rendering with continuous trim outline and proper corner wrapping.
  * Eliminated sub-pixel seams that appeared when scaling UI elements at fractional scale factors.
  * Improved visual consistency of window chrome across all visualization modes.

* **Documentation**
  * Updated documentation for window chrome rendering specifications.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/ad-repo/nullplayer/pull/205?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->