### PR TITLE
Separate local and radio source menu items

### DIFF
--- a/Sources/NullPlayer/Windows/ModernLibraryBrowser/ModernLibraryBrowserView.swift
+++ b/Sources/NullPlayer/Windows/ModernLibraryBrowser/ModernLibraryBrowserView.swift
@@ -3820,6 +3820,7 @@ class ModernLibraryBrowserView: NSView {
         let localItem = NSMenuItem(title: "Local Files", action: #selector(selectLocalSource), keyEquivalent: "")
         localItem.target = self; if case .local = currentSource { localItem.state = .on }
         menu.addItem(localItem)
+        menu.addItem(NSMenuItem.separator())
         let radioItem = NSMenuItem(title: "Internet Radio", action: #selector(selectRadioSource), keyEquivalent: "")
         radioItem.target = self; if case .radio = currentSource { radioItem.state = .on }
         menu.addItem(radioItem)

--- a/Sources/NullPlayer/Windows/PlexBrowser/PlexBrowserView.swift
+++ b/Sources/NullPlayer/Windows/PlexBrowser/PlexBrowserView.swift
@@ -7618,6 +7618,7 @@ class PlexBrowserView: NSView {
             localItem.state = .on
         }
         menu.addItem(localItem)
+        menu.addItem(NSMenuItem.separator())
         
         // Internet Radio option
         let radioItem = NSMenuItem(title: "Internet Radio", action: #selector(selectRadioSource), keyEquivalent: "")


### PR DESCRIPTION
## Summary
- add a divider between Local Files and Internet Radio in the classic library source menu
- add the same divider in the modern library source menu

## Test plan
- [x] swift build

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Style**
  * Improved the visual organization of source selection menus by adding visual separators between menu item groups, enhancing menu clarity and navigation when browsing media sources across library interfaces.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/ad-repo/nullplayer/pull/207?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->