### PR TITLE
Improve Data tab artist details

### DIFF
--- a/Sources/NullPlayer/Resources/Info.plist
+++ b/Sources/NullPlayer/Resources/Info.plist
@@ -15,7 +15,7 @@
     <key>CFBundleIconFile</key>
     <string>AppIcon</string>
     <key>CFBundleShortVersionString</key>
-    <string>0.22.0</string>
+    <string>0.22.1</string>
     <key>CFBundleVersion</key>
     <string>1</string>
     <key>LSMinimumSystemVersion</key>

--- a/Sources/NullPlayer/Windows/ModernStats/PlayHistoryAgent.swift
+++ b/Sources/NullPlayer/Windows/ModernStats/PlayHistoryAgent.swift
@@ -77,7 +77,13 @@ final class PlayHistoryAgent: ObservableObject {
     @Published var backfillTotal = 0
 
     @Published private(set) var filter = StatsFilterState() {
-        didSet { if filter != oldValue { invalidateCache(); scheduleRefresh() } }
+        didSet {
+            if filter != oldValue {
+                invalidateCache()
+                artistTracks = []
+                scheduleRefresh()
+            }
+        }
     }
     @Published var granularity = StatsGranularity.day {
         didSet { cachedTimeSeries = nil; scheduleRefresh() }

--- a/Sources/NullPlayer/Windows/ModernStats/PlayHistoryAgent.swift
+++ b/Sources/NullPlayer/Windows/ModernStats/PlayHistoryAgent.swift
@@ -52,6 +52,7 @@ private struct StatsRefreshResult {
     var contentTypeBreakdown: [TopDimensionRow]
     var outputDeviceBreakdown: [TopDimensionRow]
     var recentEvents: [RecentEventRow]
+    var artistTracks: [ArtistTrackRow]
 }
 
 @MainActor
@@ -68,6 +69,7 @@ final class PlayHistoryAgent: ObservableObject {
     @Published var contentTypeBreakdown: [TopDimensionRow] = []
     @Published var outputDeviceBreakdown: [TopDimensionRow] = []
     @Published var recentEvents:   [RecentEventRow]  = []
+    @Published var artistTracks:   [ArtistTrackRow]  = []
     @Published var isLoading: Bool = false
     @Published var error: String? = nil
     @Published var isBackfilling = false
@@ -95,6 +97,7 @@ final class PlayHistoryAgent: ObservableObject {
     private var cachedContentTypeBreakdown: [TopDimensionRow]?
     private var cachedOutputDeviceBreakdown: [TopDimensionRow]?
     private var cachedRecentEvents:   [RecentEventRow]?
+    private var cachedArtistTracks:   [ArtistTrackRow]?
 
     private let store = PlayHistoryStore()
 
@@ -140,6 +143,7 @@ final class PlayHistoryAgent: ObservableObject {
         cachedSourceBreakdown = nil; cachedContentTypeBreakdown = nil
         cachedOutputDeviceBreakdown = nil
         cachedRecentEvents = nil
+        cachedArtistTracks = nil
     }
 
     func scheduleRefresh() {
@@ -178,6 +182,8 @@ final class PlayHistoryAgent: ObservableObject {
                 let outputDeviceBreakdown = try store.fetchTopDimension(dimension: .outputDevice, filter: currentFilter)
                 try Task.checkCancellation()
                 let recentEvents = try store.fetchRecentEvents(filter: currentFilter)
+                try Task.checkCancellation()
+                let artistTracks = try store.fetchArtistTracks(filter: currentFilter)
                 return StatsRefreshResult(
                     playTimeSummaries: playTimeSummaries,
                     topArtists: topArtists,
@@ -190,7 +196,8 @@ final class PlayHistoryAgent: ObservableObject {
                     sourceBreakdown: sourceBreakdown,
                     contentTypeBreakdown: contentTypeBreakdown,
                     outputDeviceBreakdown: outputDeviceBreakdown,
-                    recentEvents: recentEvents
+                    recentEvents: recentEvents,
+                    artistTracks: artistTracks
                 )
             }.value
             try Task.checkCancellation()
@@ -206,6 +213,7 @@ final class PlayHistoryAgent: ObservableObject {
             contentTypeBreakdown = result.contentTypeBreakdown
             outputDeviceBreakdown = result.outputDeviceBreakdown
             recentEvents = result.recentEvents
+            artistTracks = result.artistTracks
             cachedPlayTimeSummaries = result.playTimeSummaries
             cachedTopArtists = result.topArtists
             cachedTopMovies = result.topMovies
@@ -218,6 +226,7 @@ final class PlayHistoryAgent: ObservableObject {
             cachedContentTypeBreakdown = result.contentTypeBreakdown
             cachedOutputDeviceBreakdown = result.outputDeviceBreakdown
             cachedRecentEvents = result.recentEvents
+            cachedArtistTracks = result.artistTracks
         } catch is CancellationError {
             // Refresh was superseded by a newer request — discard results silently
         } catch {

--- a/Sources/NullPlayer/Windows/ModernStats/PlayHistoryStore.swift
+++ b/Sources/NullPlayer/Windows/ModernStats/PlayHistoryStore.swift
@@ -308,12 +308,34 @@ final class PlayHistoryStore: Sendable {
             """
         guard let db = MediaLibraryStore.shared.analyticsConnection else { return [] }
         let stmt = try db.prepare(sql, params)
-        return stmt.map { row in
+        var rows = stmt.map { row in
             let name = row[0] as? String ?? "Unknown"
             let count = Int(row[1] as? Int64 ?? 0)
             let mins = row[2] as? Double ?? 0
             return TopDimensionRow(id: name, displayName: name, playCount: count, totalMinutes: mins)
         }
+        if !rows.contains(where: { $0.id == "Unknown" }),
+           let unknownRow = try fetchUnknownGenreRow(whereStr: whereStr, params: params) {
+            rows.append(unknownRow)
+        }
+        return rows
+    }
+
+    private func fetchUnknownGenreRow(whereStr: String, params: [Binding?]) throws -> TopDimensionRow? {
+        var unknownWhereStr = whereStr
+        addCondition("(pe.event_genre IS NULL OR trim(pe.event_genre) = '')", to: &unknownWhereStr)
+        let sql = """
+            SELECT COUNT(*), COALESCE(SUM(pe.duration_listened), 0.0) / 60.0
+            \(historyFromClause)
+            \(unknownWhereStr)
+            """
+        guard let db = MediaLibraryStore.shared.analyticsConnection else { return nil }
+        let stmt = try db.prepare(sql, params)
+        guard let row = stmt.makeIterator().next() else { return nil }
+        let count = Int(row[0] as? Int64 ?? 0)
+        guard count > 0 else { return nil }
+        let mins = row[1] as? Double ?? 0
+        return TopDimensionRow(id: "Unknown", displayName: "Unknown", playCount: count, totalMinutes: mins)
     }
 
     func fetchContentTypeBreakdown(filter: StatsFilterState) throws -> [TopDimensionRow] {

--- a/Sources/NullPlayer/Windows/ModernStats/PlayHistoryStore.swift
+++ b/Sources/NullPlayer/Windows/ModernStats/PlayHistoryStore.swift
@@ -63,6 +63,15 @@ struct RecentEventRow: Identifiable, Sendable {
     }
 }
 
+struct ArtistTrackRow: Identifiable, Sendable {
+    let id: String
+    let title: String
+    let album: String
+    let playCount: Int
+    let totalSeconds: Double
+    let lastPlayedAt: Date
+}
+
 struct PlayTimeSummaryRow: Identifiable, Sendable {
     let id: String
     let title: String
@@ -359,6 +368,53 @@ final class PlayHistoryStore: Sendable {
                                   genre: genre, source: source,
                                   playedAt: Date(timeIntervalSince1970: ts),
                                   durationListened: dur, skipped: skip)
+        }
+    }
+
+    func fetchArtistTracks(filter: StatsFilterState) throws -> [ArtistTrackRow] {
+        guard filter.selectedArtist != nil else { return [] }
+
+        var (whereStr, params) = whereClause(for: filter)
+        addCondition("COALESCE(pe.content_type, 'music') = 'music'", to: &whereStr)
+
+        let titleExpr = "COALESCE(NULLIF(trim(pe.event_title), ''), NULLIF(trim(lt.title), ''), 'Unknown')"
+        let albumExpr = "COALESCE(NULLIF(trim(pe.event_album), ''), NULLIF(trim(lt.album), ''), 'Unknown Album')"
+        let trackKeyExpr = """
+            COALESCE(
+                NULLIF(trim(pe.track_url), ''),
+                NULLIF(trim(pe.track_id), ''),
+                \(titleExpr) || '|' || \(albumExpr)
+            )
+            """
+        let sql = """
+            SELECT \(trackKeyExpr) AS track_key,
+                   MAX(\(titleExpr)) AS title,
+                   MAX(\(albumExpr)) AS album,
+                   COUNT(*) AS play_count,
+                   COALESCE(SUM(pe.duration_listened), 0.0) AS total_seconds,
+                   MAX(pe.played_at) AS last_played_at
+            \(historyFromClause)
+            \(whereStr)
+            GROUP BY track_key
+            ORDER BY play_count DESC, last_played_at DESC
+            """
+        guard let db = MediaLibraryStore.shared.analyticsConnection else { return [] }
+        let stmt = try db.prepare(sql, params)
+        return stmt.compactMap { row in
+            guard let id = row[0] as? String else { return nil }
+            let title = row[1] as? String ?? "Unknown"
+            let album = row[2] as? String ?? "Unknown Album"
+            let count = Int(row[3] as? Int64 ?? 0)
+            let seconds = row[4] as? Double ?? 0
+            let lastPlayed = row[5] as? Double ?? 0
+            return ArtistTrackRow(
+                id: id,
+                title: title,
+                album: album,
+                playCount: count,
+                totalSeconds: seconds,
+                lastPlayedAt: Date(timeIntervalSince1970: lastPlayed)
+            )
         }
     }
 

--- a/Sources/NullPlayer/Windows/ModernStats/StatsContentView.swift
+++ b/Sources/NullPlayer/Windows/ModernStats/StatsContentView.swift
@@ -389,7 +389,7 @@ struct PlayTimeSummarySection: View {
                                 .foregroundColor(.accentColor)
                         }
                     } else {
-                        Button("Discover Genres") { agent.startGenreBackfill() }
+                        Button("Reconcile Genres") { agent.startGenreBackfill() }
                             .buttonStyle(.plain)
                             .foregroundColor(.accentColor)
                     }

--- a/Sources/NullPlayer/Windows/ModernStats/StatsContentView.swift
+++ b/Sources/NullPlayer/Windows/ModernStats/StatsContentView.swift
@@ -102,6 +102,18 @@ struct StatsOverviewView: View {
     @ObservedObject var agent: PlayHistoryAgent
     var skinTextColor: Color = .primary
 
+    private func compactTopDimensionHeight(rowCount: Int, maxHeight: CGFloat = 180) -> CGFloat {
+        guard rowCount > 0 else { return 56 }
+
+        let titleHeight: CGFloat = 20
+        let titleSpacing: CGFloat = 4
+        let rowHeight: CGFloat = 18
+        let rowSpacing: CGFloat = 3
+        let rowVerticalPadding: CGFloat = 4
+        let visibleRowsHeight = CGFloat(rowCount) * rowHeight + CGFloat(max(0, rowCount - 1)) * rowSpacing
+        return min(maxHeight, titleHeight + titleSpacing + rowVerticalPadding + visibleRowsHeight)
+    }
+
     var body: some View {
         ScrollView(.vertical) {
             VStack(spacing: 16) {
@@ -117,6 +129,15 @@ struct StatsOverviewView: View {
                     )
                 )
                 .frame(height: 220)
+
+                if let selectedArtist = agent.filter.selectedArtist {
+                    ArtistTrackDetailView(
+                        artistName: selectedArtist,
+                        rows: agent.artistTracks,
+                        skinTextColor: skinTextColor,
+                        onClear: { agent.selectArtist(nil) }
+                    )
+                }
 
                 TopDimensionChartView(
                     title: "Top Movies",
@@ -134,7 +155,7 @@ struct StatsOverviewView: View {
                     selected: .constant(nil),
                     allowsSelection: false
                 )
-                .frame(height: 180)
+                .frame(height: compactTopDimensionHeight(rowCount: agent.topTVShows.count))
 
                 InternetRadioSection(
                     rows: agent.topRadioStations,
@@ -184,6 +205,129 @@ struct StatsOverviewView: View {
             }
             .padding(12)
         }
+    }
+}
+
+struct ArtistTrackDetailView: View {
+    let artistName: String
+    let rows: [ArtistTrackRow]
+    var skinTextColor: Color = .primary
+    let onClear: () -> Void
+
+    private var listHeight: CGFloat {
+        let headerHeight: CGFloat = 22
+        let rowHeight: CGFloat = 34
+        let emptyHeight: CGFloat = 44
+        guard !rows.isEmpty else { return emptyHeight }
+        return min(260, headerHeight + CGFloat(rows.count) * rowHeight)
+    }
+
+    var body: some View {
+        VStack(alignment: .leading, spacing: 6) {
+            HStack(spacing: 8) {
+                Text("Tracks by \(artistName)")
+                    .font(.subheadline)
+                    .fontWeight(.medium)
+                    .foregroundColor(skinTextColor)
+                    .lineLimit(1)
+                Spacer(minLength: 8)
+                Text(trackCountLabel)
+                    .font(.caption)
+                    .foregroundColor(.secondary)
+                Button(action: onClear) {
+                    Image(systemName: "xmark.circle.fill")
+                        .font(.system(size: 12))
+                        .foregroundColor(.secondary)
+                }
+                .buttonStyle(.plain)
+                .help("Clear artist filter")
+            }
+
+            if rows.isEmpty {
+                Text("No tracks recorded for this artist.")
+                    .font(.caption)
+                    .foregroundColor(.secondary)
+                    .frame(maxWidth: .infinity, minHeight: listHeight, alignment: .center)
+            } else {
+                VStack(spacing: 0) {
+                    ArtistTrackHeaderRow(skinTextColor: skinTextColor)
+                    Divider()
+                    ScrollView(.vertical, showsIndicators: true) {
+                        LazyVStack(spacing: 0) {
+                            ForEach(Array(rows.enumerated()), id: \.element.id) { index, row in
+                                ArtistTrackRowView(row: row, skinTextColor: skinTextColor)
+                                if index < rows.count - 1 {
+                                    Divider()
+                                }
+                            }
+                        }
+                    }
+                }
+                .frame(height: listHeight)
+            }
+        }
+        .frame(maxWidth: .infinity)
+    }
+
+    private var trackCountLabel: String {
+        rows.count == 1 ? "1 track" : "\(rows.count) tracks"
+    }
+}
+
+private struct ArtistTrackHeaderRow: View {
+    var skinTextColor: Color = .primary
+
+    var body: some View {
+        HStack(spacing: 8) {
+            Text("Track")
+                .frame(maxWidth: .infinity, alignment: .leading)
+            Text("Plays")
+                .frame(width: 42, alignment: .trailing)
+            Text("Time")
+                .frame(width: 64, alignment: .trailing)
+            Text("Last")
+                .frame(width: 78, alignment: .trailing)
+        }
+        .font(.caption2)
+        .foregroundColor(skinTextColor.opacity(0.65))
+        .frame(height: 22)
+    }
+}
+
+private struct ArtistTrackRowView: View {
+    let row: ArtistTrackRow
+    var skinTextColor: Color = .primary
+
+    var body: some View {
+        HStack(spacing: 8) {
+            VStack(alignment: .leading, spacing: 1) {
+                Text(row.title)
+                    .font(.caption)
+                    .foregroundColor(skinTextColor)
+                    .lineLimit(1)
+                Text(row.album)
+                    .font(.caption2)
+                    .foregroundColor(.secondary)
+                    .lineLimit(1)
+            }
+            .frame(maxWidth: .infinity, alignment: .leading)
+            Text("\(row.playCount)")
+                .font(.caption2)
+                .foregroundColor(skinTextColor.opacity(0.75))
+                .monospacedDigit()
+                .frame(width: 42, alignment: .trailing)
+            Text(formatStatsPlayTime(row.totalSeconds))
+                .font(.caption2)
+                .foregroundColor(skinTextColor.opacity(0.75))
+                .monospacedDigit()
+                .frame(width: 64, alignment: .trailing)
+            Text(row.lastPlayedAt.formatted(date: .abbreviated, time: .omitted))
+                .font(.caption2)
+                .foregroundColor(skinTextColor.opacity(0.75))
+                .monospacedDigit()
+                .frame(width: 78, alignment: .trailing)
+        }
+        .frame(height: 34)
     }
 }
 

--- a/Sources/NullPlayer/Windows/ModernStats/StatsContentView.swift
+++ b/Sources/NullPlayer/Windows/ModernStats/StatsContentView.swift
@@ -102,18 +102,6 @@ struct StatsOverviewView: View {
     @ObservedObject var agent: PlayHistoryAgent
     var skinTextColor: Color = .primary
 
-    private func compactTopDimensionHeight(rowCount: Int, maxHeight: CGFloat = 180) -> CGFloat {
-        guard rowCount > 0 else { return 56 }
-
-        let titleHeight: CGFloat = 20
-        let titleSpacing: CGFloat = 4
-        let rowHeight: CGFloat = 18
-        let rowSpacing: CGFloat = 3
-        let rowVerticalPadding: CGFloat = 4
-        let visibleRowsHeight = CGFloat(rowCount) * rowHeight + CGFloat(max(0, rowCount - 1)) * rowSpacing
-        return min(maxHeight, titleHeight + titleSpacing + rowVerticalPadding + visibleRowsHeight)
-    }
-
     var body: some View {
         ScrollView(.vertical) {
             VStack(spacing: 16) {
@@ -128,7 +116,7 @@ struct StatsOverviewView: View {
                         set: { (v: String?) in agent.selectArtist(v) }
                     )
                 )
-                .frame(height: 220)
+                .frame(height: topDimensionListHeight(rowCount: agent.topArtists.count, maxHeight: 220))
 
                 if let selectedArtist = agent.filter.selectedArtist {
                     ArtistTrackDetailView(
@@ -146,7 +134,7 @@ struct StatsOverviewView: View {
                     selected: .constant(nil),
                     allowsSelection: false
                 )
-                .frame(height: 180)
+                .frame(height: topDimensionListHeight(rowCount: agent.topMovies.count))
 
                 TopDimensionChartView(
                     title: "Top TV Shows",
@@ -155,7 +143,7 @@ struct StatsOverviewView: View {
                     selected: .constant(nil),
                     allowsSelection: false
                 )
-                .frame(height: compactTopDimensionHeight(rowCount: agent.topTVShows.count))
+                .frame(height: topDimensionListHeight(rowCount: agent.topTVShows.count))
 
                 InternetRadioSection(
                     rows: agent.topRadioStations,
@@ -487,6 +475,18 @@ private func formatStatsPlayTime(_ duration: Double) -> String {
     return "<1m"
 }
 
+private func topDimensionListHeight(rowCount: Int, maxHeight: CGFloat = 180) -> CGFloat {
+    guard rowCount > 0 else { return 56 }
+
+    let titleHeight: CGFloat = 20
+    let titleSpacing: CGFloat = 4
+    let rowHeight: CGFloat = 18
+    let rowSpacing: CGFloat = 3
+    let rowVerticalPadding: CGFloat = 4
+    let visibleRowsHeight = CGFloat(rowCount) * rowHeight + CGFloat(max(0, rowCount - 1)) * rowSpacing
+    return min(maxHeight, titleHeight + titleSpacing + rowVerticalPadding + visibleRowsHeight)
+}
+
 struct InternetRadioSection: View {
     let rows: [TopDimensionRow]
     let totalSeconds: Double
@@ -528,7 +528,7 @@ struct InternetRadioSection: View {
                     allowsSelection: false,
                     showsTotalMinutes: true
                 )
-                .frame(height: 180)
+                .frame(height: topDimensionListHeight(rowCount: rows.count))
             }
             .frame(maxWidth: .infinity, alignment: .leading)
         }

--- a/Sources/NullPlayer/Windows/ModernStats/StatsContentView.swift
+++ b/Sources/NullPlayer/Windows/ModernStats/StatsContentView.swift
@@ -392,6 +392,7 @@ struct PlayTimeSummarySection: View {
                         Button("Reconcile Genres") { agent.startGenreBackfill() }
                             .buttonStyle(.plain)
                             .foregroundColor(.accentColor)
+                            .help("Attempt to fill in missing play history genres")
                     }
                 }
             }


### PR DESCRIPTION
## Summary
- show a track detail list when selecting a Top Artists row in the Data tab
- include album, play count, total listen time, and last played date for each artist track
- compact the Top TV Shows section height to avoid the large gap above Internet Radio

## Verification
- swift build
- swift test

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Added detailed track-level statistics when viewing individual artists, including play counts and last-played timestamps.
  * Dynamic layout adjustments for stats sections for improved responsiveness.

* **Bug Fixes**
  * Improved genre data handling to ensure complete representation in statistics.

* **Chores**
  * Version bump to 0.22.1.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/ad-repo/nullplayer/pull/208?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->