### PR TITLE
Handle Sonos network changes

### DIFF
--- a/Sources/NullPlayer/Casting/CastManager.swift
+++ b/Sources/NullPlayer/Casting/CastManager.swift
@@ -2203,7 +2203,6 @@ class CastManager {
     
     @objc private func handleDidWake() {
         NSLog("CastManager: Mac woke up, checking cast state")
-        guard isCasting else { return }
         
         Task {
             // Wait a moment for network to reconnect
@@ -2215,6 +2214,10 @@ class CastManager {
                oldIP != newIP {
                 NSLog("CastManager: IP changed after wake (%@ -> %@)", oldIP, newIP)
             }
+
+            upnpManager.refreshNetworkStateAfterWake()
+
+            guard isCasting else { return }
             
             // Poll Sonos to see if it's still playing
             if let result = await upnpManager.pollSonosPlaybackState() {

--- a/Sources/NullPlayer/Casting/LocalMediaServer.swift
+++ b/Sources/NullPlayer/Casting/LocalMediaServer.swift
@@ -745,33 +745,7 @@ class LocalMediaServer {
     
     /// Discover the local network IP address from network interfaces
     private func discoverLocalIPAddress() -> String? {
-        var address: String?
-        var ifaddr: UnsafeMutablePointer<ifaddrs>?
-        
-        guard getifaddrs(&ifaddr) == 0 else { return nil }
-        defer { freeifaddrs(ifaddr) }
-        
-        var ptr = ifaddr
-        while ptr != nil {
-            defer { ptr = ptr?.pointee.ifa_next }
-            
-            let interface = ptr!.pointee
-            let addrFamily = interface.ifa_addr.pointee.sa_family
-            
-            // Check for IPv4 (AF_INET)
-            if addrFamily == UInt8(AF_INET) {
-                let name = String(cString: interface.ifa_name)
-                // Skip loopback, prefer en0 (Wi-Fi) or en1 (Ethernet)
-                if name == "en0" || name == "en1" {
-                    var hostname = [CChar](repeating: 0, count: Int(NI_MAXHOST))
-                    getnameinfo(interface.ifa_addr, socklen_t(interface.ifa_addr.pointee.sa_len),
-                               &hostname, socklen_t(hostname.count), nil, 0, NI_NUMERICHOST)
-                    address = String(cString: hostname)
-                    break
-                }
-            }
-        }
-        return address
+        NetworkInterfaceResolver.discoverLocalIPv4Address()
     }
     
     /// Handle incoming HTTP requests for local media files

--- a/Sources/NullPlayer/Casting/UPnPManager.swift
+++ b/Sources/NullPlayer/Casting/UPnPManager.swift
@@ -42,7 +42,8 @@ class UPnPManager {
     private var hasReceivedInitialPathUpdate = false
     private var lastKnownLocalIP: String?
     private var lastPathWasSatisfied = false
-    private var lastNetworkChangeHandledAt: Date?
+    private var lastNetworkChangeHandledAt: UInt64?
+    private let networkChangeDebounceNanoseconds: UInt64 = 2_000_000_000
     
     /// Pending device descriptions being fetched - access via stateQueue
     private var _pendingDescriptions: Set<String> = []
@@ -366,37 +367,47 @@ class UPnPManager {
 
     /// Re-check the local IP after wake without waiting for NWPathMonitor timing.
     func refreshNetworkStateAfterWake() {
-        networkMonitorQueue.async { [weak self] in
+        DispatchQueue.main.async { [weak self] in
             guard let self = self else { return }
-            let previousIP = self.lastKnownLocalIP
-            let currentIP = self.discoverLocalIPAddress()
+            let shouldRefreshDiscovery = self.isDiscovering
+                || !self.devices.isEmpty
+                || self.activeSession?.device.type == .sonos
 
-            guard let previousIP = previousIP else {
-                self.lastKnownLocalIP = currentIP
-                self.lastPathWasSatisfied = currentIP != nil
-                guard currentIP != nil,
-                      self.isDiscovering || !self.devices.isEmpty || self.activeSession?.device.type == .sonos else {
+            self.networkMonitorQueue.async { [weak self] in
+                guard let self = self else { return }
+                let previousIP = self.lastKnownLocalIP
+                let currentIP = self.discoverLocalIPAddress()
+
+                guard let previousIP = previousIP else {
+                    self.lastKnownLocalIP = currentIP
+                    self.lastPathWasSatisfied = currentIP != nil
+                    // A wake before NWPathMonitor's first callback seeds the baseline.
+                    // Only existing discovery/session state needs an explicit refresh.
+                    guard currentIP != nil, shouldRefreshDiscovery else { return }
+                    self.handleNetworkChangeIfNeeded(
+                        previousIP: nil,
+                        newIP: currentIP,
+                        reason: "wake IP initialized",
+                        disconnectActiveSonosSession: false
+                    )
                     return
                 }
-                self.handleNetworkChangeIfNeeded(
-                    previousIP: nil,
-                    newIP: currentIP,
-                    reason: "wake IP initialized"
-                )
-                return
-            }
 
-            guard let currentIP = currentIP, currentIP != previousIP else { return }
-            self.handleNetworkChangeIfNeeded(
-                previousIP: previousIP,
-                newIP: currentIP,
-                reason: "wake IP refresh"
-            )
+                guard let currentIP = currentIP, currentIP != previousIP else { return }
+                self.handleNetworkChangeIfNeeded(
+                    previousIP: previousIP,
+                    newIP: currentIP,
+                    reason: "wake IP refresh",
+                    disconnectActiveSonosSession: true
+                )
+            }
         }
     }
 
     private func startNetworkMonitoringIfNeeded() {
-        networkMonitoringEnabled = true
+        networkMonitorQueue.sync {
+            networkMonitoringEnabled = true
+        }
         guard networkMonitor == nil else { return }
 
         let monitor = NWPathMonitor()
@@ -421,6 +432,8 @@ class UPnPManager {
             if let currentIP = currentIP {
                 lastKnownLocalIP = currentIP
             }
+            // The first NWPathMonitor callback establishes a baseline; later callbacks
+            // decide whether cached device URLs need to be invalidated.
             if path.status == .unsatisfied {
                 NSLog("UPnPManager: Network unavailable - discovery may fail")
             }
@@ -436,21 +449,27 @@ class UPnPManager {
         guard isSatisfied else { return }
         lastPathWasSatisfied = true
 
-        let ipChanged = currentIP != nil && currentIP != previousIP
+        let ipChanged = currentIP != nil && previousIP != nil && currentIP != previousIP
         let reconnected = !wasSatisfied
         guard ipChanged || reconnected else { return }
 
         handleNetworkChangeIfNeeded(
             previousIP: previousIP,
             newIP: currentIP,
-            reason: ipChanged ? "IP changed" : "network reconnected"
+            reason: ipChanged ? "IP changed" : "network reconnected",
+            disconnectActiveSonosSession: ipChanged
         )
     }
 
-    private func handleNetworkChangeIfNeeded(previousIP: String?, newIP: String?, reason: String) {
-        let now = Date()
+    private func handleNetworkChangeIfNeeded(
+        previousIP: String?,
+        newIP: String?,
+        reason: String,
+        disconnectActiveSonosSession: Bool
+    ) {
+        let now = DispatchTime.now().uptimeNanoseconds
         if let lastHandled = lastNetworkChangeHandledAt,
-           now.timeIntervalSince(lastHandled) < 2.0 {
+           now - lastHandled < networkChangeDebounceNanoseconds {
             NSLog("UPnPManager: Ignoring network change within debounce window (%@)", reason)
             return
         }
@@ -461,17 +480,27 @@ class UPnPManager {
         }
 
         DispatchQueue.main.async { [weak self] in
-            self?.handleNetworkChanged(previousIP: previousIP, newIP: newIP, reason: reason)
+            self?.handleNetworkChanged(
+                previousIP: previousIP,
+                newIP: newIP,
+                reason: reason,
+                disconnectActiveSonosSession: disconnectActiveSonosSession
+            )
         }
     }
 
-    private func handleNetworkChanged(previousIP: String?, newIP: String?, reason: String) {
+    private func handleNetworkChanged(
+        previousIP: String?,
+        newIP: String?,
+        reason: String,
+        disconnectActiveSonosSession: Bool
+    ) {
         NSLog("UPnPManager: Network changed (%@) - IP changed from %@ to %@",
               reason,
               previousIP ?? "nil",
               newIP ?? "nil")
 
-        let shouldDisconnectSonosSession = activeSession?.device.type == .sonos
+        let shouldDisconnectSonosSession = disconnectActiveSonosSession && activeSession?.device.type == .sonos
 
         stopDiscovery()
         clearDevices(postNotification: true) { [weak self] in
@@ -641,10 +670,15 @@ class UPnPManager {
     func stopDiscovery() {
         NSLog("UPnPManager: Stopping discovery")
         isDiscovering = false
-        networkMonitoringEnabled = false
+        networkMonitorQueue.sync {
+            networkMonitoringEnabled = false
+            hasReceivedInitialPathUpdate = false
+            lastKnownLocalIP = nil
+            lastPathWasSatisfied = false
+            lastNetworkChangeHandledAt = nil
+        }
         networkMonitor?.cancel()
         networkMonitor = nil
-        hasReceivedInitialPathUpdate = false
         
         // Stop SSDP discovery
         // The fd must be closed in the cancel handler, not immediately after cancel(),
@@ -1321,7 +1355,8 @@ class UPnPManager {
         }
     }
     
-    /// Remove all discovered devices
+    /// Remove all discovered devices.
+    /// If `postNotification` is true, the completion runs on main after the devices-changed notification is posted.
     func clearDevices(postNotification: Bool = false, completion: (() -> Void)? = nil) {
         NSLog("UPnPManager: clearDevices called")
         

--- a/Sources/NullPlayer/Casting/UPnPManager.swift
+++ b/Sources/NullPlayer/Casting/UPnPManager.swift
@@ -34,6 +34,14 @@ class UPnPManager {
     
     /// mDNS browser for Sonos discovery (fallback/supplement to SSDP)
     private var sonosBrowser: NWBrowser?
+
+    /// Network monitor used to detect interface/IP changes that invalidate cached device URLs.
+    private var networkMonitor: NWPathMonitor?
+    private let networkMonitorQueue = DispatchQueue(label: "com.nullplayer.upnp.networkmonitor")
+    private var hasReceivedInitialPathUpdate = false
+    private var lastKnownLocalIP: String?
+    private var lastPathWasSatisfied = false
+    private var lastNetworkChangeHandledAt: Date?
     
     /// Pending device descriptions being fetched - access via stateQueue
     private var _pendingDescriptions: Set<String> = []
@@ -311,6 +319,8 @@ class UPnPManager {
     
     /// Start discovering UPnP devices on the network
     func startDiscovery() {
+        startNetworkMonitoringIfNeeded()
+
         guard !isDiscovering else {
             NSLog("UPnPManager: Already discovering, skipping start")
             return
@@ -351,6 +361,129 @@ class UPnPManager {
         
         // Start mDNS discovery for Sonos (more reliable fallback)
         startSonosMDNSDiscovery()
+    }
+
+    /// Re-check the local IP after wake without waiting for NWPathMonitor timing.
+    func refreshNetworkStateAfterWake() {
+        networkMonitorQueue.async { [weak self] in
+            guard let self = self else { return }
+            let previousIP = self.lastKnownLocalIP
+            let currentIP = self.discoverLocalIPAddress()
+
+            guard let previousIP = previousIP else {
+                self.lastKnownLocalIP = currentIP
+                self.lastPathWasSatisfied = currentIP != nil
+                guard currentIP != nil,
+                      self.isDiscovering || !self.devices.isEmpty || self.activeSession?.device.type == .sonos else {
+                    return
+                }
+                self.handleNetworkChangeIfNeeded(
+                    previousIP: nil,
+                    newIP: currentIP,
+                    reason: "wake IP initialized"
+                )
+                return
+            }
+
+            guard let currentIP = currentIP, currentIP != previousIP else { return }
+            self.handleNetworkChangeIfNeeded(
+                previousIP: previousIP,
+                newIP: currentIP,
+                reason: "wake IP refresh"
+            )
+        }
+    }
+
+    private func startNetworkMonitoringIfNeeded() {
+        guard networkMonitor == nil else { return }
+
+        let monitor = NWPathMonitor()
+        monitor.pathUpdateHandler = { [weak self] path in
+            self?.handleNetworkPathUpdate(path)
+        }
+        monitor.start(queue: networkMonitorQueue)
+        networkMonitor = monitor
+    }
+
+    private func handleNetworkPathUpdate(_ path: NWPath) {
+        let isSatisfied = path.status == .satisfied
+        let wasSatisfied = lastPathWasSatisfied
+        let previousIP = lastKnownLocalIP
+        let currentIP = isSatisfied ? discoverLocalIPAddress() : nil
+
+        if !hasReceivedInitialPathUpdate {
+            hasReceivedInitialPathUpdate = true
+            lastPathWasSatisfied = isSatisfied
+            if let currentIP = currentIP {
+                lastKnownLocalIP = currentIP
+            }
+            if path.status == .unsatisfied {
+                NSLog("UPnPManager: Network unavailable - discovery may fail")
+            }
+            return
+        }
+
+        if path.status == .unsatisfied {
+            lastPathWasSatisfied = false
+            NSLog("UPnPManager: Network unavailable - discovery may fail")
+            return
+        }
+
+        guard isSatisfied else { return }
+        lastPathWasSatisfied = true
+
+        let ipChanged = currentIP != nil && currentIP != previousIP
+        let reconnected = !wasSatisfied
+        guard ipChanged || reconnected else { return }
+
+        handleNetworkChangeIfNeeded(
+            previousIP: previousIP,
+            newIP: currentIP,
+            reason: ipChanged ? "IP changed" : "network reconnected"
+        )
+    }
+
+    private func handleNetworkChangeIfNeeded(previousIP: String?, newIP: String?, reason: String) {
+        let now = Date()
+        if let lastHandled = lastNetworkChangeHandledAt,
+           now.timeIntervalSince(lastHandled) < 2.0 {
+            NSLog("UPnPManager: Ignoring network change within debounce window (%@)", reason)
+            return
+        }
+
+        lastNetworkChangeHandledAt = now
+        if let newIP = newIP {
+            lastKnownLocalIP = newIP
+        }
+
+        DispatchQueue.main.async { [weak self] in
+            self?.handleNetworkChanged(previousIP: previousIP, newIP: newIP, reason: reason)
+        }
+    }
+
+    private func handleNetworkChanged(previousIP: String?, newIP: String?, reason: String) {
+        NSLog("UPnPManager: Network changed (%@) - IP changed from %@ to %@",
+              reason,
+              previousIP ?? "nil",
+              newIP ?? "nil")
+
+        let shouldDisconnectSonosSession = activeSession?.device.type == .sonos
+
+        stopDiscovery()
+        clearDevices(postNotification: true) { [weak self] in
+            guard let self = self else { return }
+
+            if shouldDisconnectSonosSession {
+                self.disconnectSession()
+            }
+
+            self.startDiscovery()
+        }
+    }
+
+    /// Discover the local network IP address from network interfaces.
+    private func discoverLocalIPAddress() -> String? {
+        NetworkInterfaceResolver.discoverLocalIPv4Address()
     }
     
     /// Send an immediate M-SEARCH boost (for refresh operations)
@@ -1181,7 +1314,7 @@ class UPnPManager {
     }
     
     /// Remove all discovered devices
-    func clearDevices() {
+    func clearDevices(postNotification: Bool = false, completion: (() -> Void)? = nil) {
         NSLog("UPnPManager: clearDevices called")
         
         // Cancel any pending Sonos topology fetch (on main queue where it was scheduled)
@@ -1211,6 +1344,14 @@ class UPnPManager {
             self.sonosGroupsFetched = false
             
             NSLog("UPnPManager: Cleared %d devices, %d zones, cancelled %d tasks", deviceCount, zoneCount, taskCount)
+
+            if postNotification {
+                CastManager.postNotificationOnMain(name: CastManager.devicesDidChangeNotification)
+            }
+
+            if let completion = completion {
+                DispatchQueue.main.async(execute: completion)
+            }
         }
     }
     

--- a/Sources/NullPlayer/Casting/UPnPManager.swift
+++ b/Sources/NullPlayer/Casting/UPnPManager.swift
@@ -38,6 +38,7 @@ class UPnPManager {
     /// Network monitor used to detect interface/IP changes that invalidate cached device URLs.
     private var networkMonitor: NWPathMonitor?
     private let networkMonitorQueue = DispatchQueue(label: "com.nullplayer.upnp.networkmonitor")
+    private var networkMonitoringEnabled = false
     private var hasReceivedInitialPathUpdate = false
     private var lastKnownLocalIP: String?
     private var lastPathWasSatisfied = false
@@ -395,6 +396,7 @@ class UPnPManager {
     }
 
     private func startNetworkMonitoringIfNeeded() {
+        networkMonitoringEnabled = true
         guard networkMonitor == nil else { return }
 
         let monitor = NWPathMonitor()
@@ -406,6 +408,8 @@ class UPnPManager {
     }
 
     private func handleNetworkPathUpdate(_ path: NWPath) {
+        guard networkMonitoringEnabled else { return }
+
         let isSatisfied = path.status == .satisfied
         let wasSatisfied = lastPathWasSatisfied
         let previousIP = lastKnownLocalIP
@@ -637,6 +641,10 @@ class UPnPManager {
     func stopDiscovery() {
         NSLog("UPnPManager: Stopping discovery")
         isDiscovering = false
+        networkMonitoringEnabled = false
+        networkMonitor?.cancel()
+        networkMonitor = nil
+        hasReceivedInitialPathUpdate = false
         
         // Stop SSDP discovery
         // The fd must be closed in the cancel handler, not immediately after cancel(),

--- a/Sources/NullPlayer/Utilities/NetworkInterfaceResolver.swift
+++ b/Sources/NullPlayer/Utilities/NetworkInterfaceResolver.swift
@@ -1,6 +1,8 @@
 import Foundation
 
+/// Resolves the app's local IPv4 address from active Ethernet-style interfaces.
 enum NetworkInterfaceResolver {
+    /// Returns the preferred active non-loopback IPv4 address, favoring en0/en1 before other en* adapters.
     static func discoverLocalIPv4Address() -> String? {
         var preferredAddress: String?
         var ethernetAddress: String?
@@ -26,9 +28,12 @@ enum NetworkInterfaceResolver {
             guard name.hasPrefix("en") else { continue }
 
             var hostname = [CChar](repeating: 0, count: Int(NI_MAXHOST))
-            getnameinfo(socketAddress, socklen_t(socketAddress.pointee.sa_len),
-                        &hostname, socklen_t(hostname.count), nil, 0, NI_NUMERICHOST)
+            let result = getnameinfo(socketAddress, socklen_t(socketAddress.pointee.sa_len),
+                                     &hostname, socklen_t(hostname.count), nil, 0, NI_NUMERICHOST)
+            guard result == 0 else { continue }
+
             let address = String(cString: hostname)
+            guard !address.isEmpty else { continue }
 
             if name == "en0" || name == "en1" {
                 preferredAddress = address

--- a/Sources/NullPlayer/Utilities/NetworkInterfaceResolver.swift
+++ b/Sources/NullPlayer/Utilities/NetworkInterfaceResolver.swift
@@ -1,0 +1,45 @@
+import Foundation
+
+enum NetworkInterfaceResolver {
+    static func discoverLocalIPv4Address() -> String? {
+        var preferredAddress: String?
+        var ethernetAddress: String?
+        var ifaddr: UnsafeMutablePointer<ifaddrs>?
+
+        guard getifaddrs(&ifaddr) == 0 else { return nil }
+        defer { freeifaddrs(ifaddr) }
+
+        var ptr = ifaddr
+        while ptr != nil {
+            defer { ptr = ptr?.pointee.ifa_next }
+
+            guard let interface = ptr?.pointee,
+                  let socketAddress = interface.ifa_addr,
+                  socketAddress.pointee.sa_family == UInt8(AF_INET) else {
+                continue
+            }
+
+            let flags = Int32(interface.ifa_flags)
+            guard flags & IFF_UP != 0, flags & IFF_LOOPBACK == 0 else { continue }
+
+            let name = String(cString: interface.ifa_name)
+            guard name.hasPrefix("en") else { continue }
+
+            var hostname = [CChar](repeating: 0, count: Int(NI_MAXHOST))
+            getnameinfo(socketAddress, socklen_t(socketAddress.pointee.sa_len),
+                        &hostname, socklen_t(hostname.count), nil, 0, NI_NUMERICHOST)
+            let address = String(cString: hostname)
+
+            if name == "en0" || name == "en1" {
+                preferredAddress = address
+                break
+            }
+
+            if ethernetAddress == nil {
+                ethernetAddress = address
+            }
+        }
+
+        return preferredAddress ?? ethernetAddress
+    }
+}

--- a/Tests/NullPlayerAppTests/NetworkInterfaceResolverTests.swift
+++ b/Tests/NullPlayerAppTests/NetworkInterfaceResolverTests.swift
@@ -1,0 +1,20 @@
+import XCTest
+@testable import NullPlayer
+
+final class NetworkInterfaceResolverTests: XCTestCase {
+    func testDiscoverLocalIPv4AddressReturnsNilOrDottedQuad() {
+        guard let address = NetworkInterfaceResolver.discoverLocalIPv4Address() else {
+            return
+        }
+
+        let octets = address.split(separator: ".", omittingEmptySubsequences: false)
+        XCTAssertEqual(octets.count, 4)
+
+        for octet in octets {
+            guard let value = Int(octet), (0...255).contains(value) else {
+                XCTFail("Expected dotted-quad IPv4 address, got \(address)")
+                return
+            }
+        }
+    }
+}

--- a/skills/sonos-casting/SKILL.md
+++ b/skills/sonos-casting/SKILL.md
@@ -224,12 +224,13 @@ NullPlayer polls Sonos every 5 seconds during casting:
 - See `skills/audio-system/audio-pipelines.md` — Cast Route-Change Safety.
 
 **Network change detection:**
-- LocalMediaServer monitors network changes via NWPathMonitor
-- IP address refreshed automatically when Wi-Fi changes
+- LocalMediaServer monitors network changes via NWPathMonitor and refreshes its own bound IP when Wi-Fi changes.
+- UPnPManager also monitors network changes. When the active local IP changes, or the network returns after being unavailable, it stops SSDP/mDNS discovery, clears cached Sonos/DLNA device URLs and Sonos topology, then starts discovery on the new interface.
+- Active Sonos casts are ended on network change. A LAN switch leaves the old coordinator IP unreachable, and the same speaker may have a different IP on the new LAN, so the user starts a new cast after rediscovery.
 
 **Mac sleep/wake handling:**
 - CastManager observes sleep/wake notifications
-- On wake: waits 2s for network, polls Sonos state, updates UI
+- On wake: waits 2s for network, refreshes local/UPnP network state, then polls Sonos state if casting and updates UI
 
 **Server health checks:**
 - LocalMediaServer pings itself every 30 seconds

--- a/skills/sonos-casting/SKILL.md
+++ b/skills/sonos-casting/SKILL.md
@@ -225,8 +225,8 @@ NullPlayer polls Sonos every 5 seconds during casting:
 
 **Network change detection:**
 - LocalMediaServer monitors network changes via NWPathMonitor and refreshes its own bound IP when Wi-Fi changes.
-- UPnPManager also monitors network changes. When the active local IP changes, or the network returns after being unavailable, it stops SSDP/mDNS discovery, clears cached Sonos/DLNA device URLs and Sonos topology, then starts discovery on the new interface.
-- Active Sonos casts are ended on network change. A LAN switch leaves the old coordinator IP unreachable, and the same speaker may have a different IP on the new LAN, so the user starts a new cast after rediscovery.
+- UPnPManager also monitors network changes. When the active local IP changes, or the network returns after being unavailable, it stops SSDP/mDNS discovery, clears cached Sonos/DLNA device URLs and Sonos topology, then starts discovery on the current interface.
+- Active Sonos casts are ended only when the local IP actually changes. A pure reconnect refreshes discovery without tearing down a working speaker session.
 
 **Mac sleep/wake handling:**
 - CastManager observes sleep/wake notifications


### PR DESCRIPTION
## Summary
- add UPnP network monitoring to reset stale Sonos/DLNA discovery state after IP/path changes
- refresh UPnP network state after wake even when not currently casting
- share local IPv4 interface resolution between LocalMediaServer and UPnPManager
- update Sonos casting skill docs for network-change recovery behavior

## Tests
- swift build
- swift test

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Bug Fixes**
  * Enhanced network state detection and refresh after Mac wake events for improved connection stability
  * Improved automatic recovery when network interfaces or IP addresses change

* **Refactor**
  * Optimized local network address discovery

* **Documentation**
  * Updated Sonos casting guide with network resilience and wake-handling details

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/ad-repo/nullplayer/pull/209?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->