### PR TITLE
Guard audio graph reconnect exceptions

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,11 @@
 # Changelog
 
+## 0.22.1
+
+### Bug Fixes
+
+- **Audio route-change exception guarded** — `AVAudioEngine` graph reconnects now catch Objective-C exceptions raised by `AVAudioEngine.connect(_:to:format:)` during route churn. A failed reconnect is deferred and retried through the existing audio graph recovery path instead of aborting the app.
+
 ## 0.22.0
 
 ### New Features

--- a/Package.swift
+++ b/Package.swift
@@ -108,6 +108,12 @@ let package = Package(
             dependencies: [],
             path: "Sources/NullPlayerCore"
         ),
+        .target(
+            name: "ObjCExceptionCatcher",
+            dependencies: [],
+            path: "Sources/ObjCExceptionCatcher",
+            publicHeadersPath: "include"
+        ),
         // System library target for libprojectM (ProjectM visualization)
         // To enable projectM support:
         // 1. Build libprojectM v4.1.6+ as a universal binary
@@ -130,6 +136,7 @@ let package = Package(
             name: "NullPlayer",
             dependencies: [
                 "NullPlayerCore",
+                "ObjCExceptionCatcher",
                 "CVisClassicCore",
                 "CGeissCore",
                 "CTripexCore",

--- a/Sources/NullPlayer/Audio/AudioEngine.swift
+++ b/Sources/NullPlayer/Audio/AudioEngine.swift
@@ -5,6 +5,7 @@ import CoreAudio
 import AudioToolbox
 import AudioStreaming
 import NullPlayerCore
+import ObjCExceptionCatcher
 
 // MARK: - Notifications
 
@@ -1149,6 +1150,27 @@ class AudioEngine {
         state = fallbackState
         stopTimeUpdates()
     }
+
+    private func reconnectAudioGraph(format mixerFormat: AVAudioFormat) -> Bool {
+        var exceptionError: NSError?
+        let connected = NPObjCExceptionCatch({
+            self.engine.connect(self.playerNode, to: self.mixerNode, format: mixerFormat)
+            self.engine.connect(self.crossfadePlayerNode, to: self.mixerNode, format: mixerFormat)
+            self.engine.connect(self.mixerNode, to: self.eqNode, format: mixerFormat)
+            self.engine.connect(self.eqNode, to: self.engine.mainMixerNode, format: mixerFormat)
+        }, &exceptionError)
+
+        guard connected else {
+            let reason = exceptionError?.localizedFailureReason
+                ?? exceptionError?.localizedDescription
+                ?? "unknown Objective-C exception"
+            NSLog("AudioEngine: AVAudioEngine graph reconnect failed; deferring rebuild: %@", reason)
+            audioGraphRebuildDeferredForCast = true
+            return false
+        }
+
+        return true
+    }
     
     /// Rebuild the audio graph with the new output format
     /// Called after a device change that affects the audio format
@@ -1199,11 +1221,16 @@ class AudioEngine {
         engine.disconnectNodeOutput(mixerNode)
         engine.disconnectNodeOutput(eqNode)
         
-        // Reconnect all nodes with new format
-        engine.connect(playerNode, to: mixerNode, format: mixerFormat)
-        engine.connect(crossfadePlayerNode, to: mixerNode, format: mixerFormat)
-        engine.connect(mixerNode, to: eqNode, format: mixerFormat)
-        engine.connect(eqNode, to: engine.mainMixerNode, format: mixerFormat)
+        // Reconnect all nodes with new format. AVAudioEngine raises NSException
+        // for some route-change graph states, so Swift do/catch is not enough.
+        guard reconnectAudioGraph(format: mixerFormat) else {
+            moveToNonPlayingStateAfterGraphRebuildFailure(
+                position: resumePosition,
+                fallbackState: wasStopped ? .stopped : .paused
+            )
+            scheduleDeferredAudioGraphRebuildRetry()
+            return
+        }
 
         if tapWasInstalled {
             installSpectrumTap(format: nil)

--- a/Sources/ObjCExceptionCatcher/ObjCExceptionCatcher.m
+++ b/Sources/ObjCExceptionCatcher/ObjCExceptionCatcher.m
@@ -1,0 +1,25 @@
+#import "ObjCExceptionCatcher.h"
+
+static NSString * const NPObjCExceptionErrorDomain = @"com.nullplayer.objc-exception";
+
+BOOL NPObjCExceptionCatch(NPObjCExceptionTryBlock tryBlock, NSError **error) {
+    @try {
+        tryBlock();
+        return YES;
+    } @catch (NSException *exception) {
+        if (error != nil) {
+            NSMutableDictionary<NSErrorUserInfoKey, id> *userInfo = [NSMutableDictionary dictionary];
+            if (exception.name != nil) {
+                userInfo[NSLocalizedDescriptionKey] = exception.name;
+            }
+            if (exception.reason != nil) {
+                userInfo[NSLocalizedFailureReasonErrorKey] = exception.reason;
+            }
+            userInfo[@"NSExceptionName"] = exception.name ?: @"";
+            userInfo[@"NSExceptionReason"] = exception.reason ?: @"";
+
+            *error = [NSError errorWithDomain:NPObjCExceptionErrorDomain code:1 userInfo:userInfo];
+        }
+        return NO;
+    }
+}

--- a/Sources/ObjCExceptionCatcher/include/ObjCExceptionCatcher.h
+++ b/Sources/ObjCExceptionCatcher/include/ObjCExceptionCatcher.h
@@ -1,0 +1,9 @@
+#import <Foundation/Foundation.h>
+
+NS_ASSUME_NONNULL_BEGIN
+
+typedef void (^NPObjCExceptionTryBlock)(void);
+
+BOOL NPObjCExceptionCatch(NPObjCExceptionTryBlock tryBlock, NSError * _Nullable * _Nullable error);
+
+NS_ASSUME_NONNULL_END

--- a/skills/audio-system/SKILL.md
+++ b/skills/audio-system/SKILL.md
@@ -349,6 +349,8 @@ When audio isn't playing:
 ### Local Playback (AVAudioEngine)
 MP3, M4A, AAC, WAV, AIFF, FLAC, ALAC, OGG
 
+Route-change graph rebuilds must catch Objective-C exceptions from `AVAudioEngine.connect(_:to:format:)` via the `ObjCExceptionCatcher` bridge. If reconnect raises `AVAudioEngineGraph::UpdateGraphAfterReconfig`, defer the rebuild and retry through the existing cast/route-stabilization path instead of relying on Swift `do/catch`.
+
 ### Streaming Playback (AudioStreaming)
 HTTP/HTTPS URLs with MP3, AAC, Ogg Vorbis
 

--- a/skills/audio-system/audio-pipelines.md
+++ b/skills/audio-system/audio-pipelines.md
@@ -178,6 +178,13 @@ When a rebuild is deferred:
 - If a rebuild cannot restart playback after nodes were stopped/disconnected, move the engine to a non-playing state, stop time updates, and keep the rebuild deferred for retry.
 - Local files loaded in `.stopped` state still need to be re-scheduled after rebuild, but must not auto-play.
 
+`AVAudioEngine.connect(_:to:format:)` can raise an Objective-C `NSException` from `AVAudioEngineGraph::UpdateGraphAfterReconfig` during route churn. Swift `do/catch` does not catch this. All route-change graph reconnect work must go through the `ObjCExceptionCatcher` bridge (`NPObjCExceptionCatch`) and treat a caught exception as a failed rebuild:
+
+- Log the exception reason.
+- Set `audioGraphRebuildDeferredForCast = true`.
+- Move local playback to a non-playing state if nodes were already stopped/disconnected.
+- Schedule the normal deferred rebuild retry path instead of allowing the process to abort.
+
 This prevents `AVAudioEngineGraph::UpdateGraphAfterReconfig` exceptions during cast/room/output churn and keeps the next local playback action intact once routing stabilizes.
 
 ### Device Preference Persistence


### PR DESCRIPTION
## Summary
- add a small ObjCExceptionCatcher target for catching NSException from AVAudioEngine route-change reconnects
- wrap AudioEngine graph reconnects so UpdateGraphAfterReconfig exceptions defer and retry instead of aborting
- document the route-change exception requirement in audio-system skills and add a changelog entry

## Testing
- swift build
- swift test

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed crashes during audio device or format changes by implementing graceful error handling and automatic retry logic for audio connection failures.

* **Documentation**
  * Updated audio system documentation to reflect improved exception handling behavior during route changes.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/ad-repo/nullplayer/pull/211?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->