### PR TITLE
Add configurable library columns across UI modes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## 0.22.1
 
+### Improvements
+
+- **Library browser columns are configurable across UI modes** — classic and modern library browsers now share the same Artist, Album, and Track column inventories, with sectioned right-click header menus for Artists and Albums. Classic column visibility persists separately from Modern, and the Title column remains locked on.
+
 ### Bug Fixes
 
 - **Audio route-change exception guarded** — `AVAudioEngine` graph reconnects now catch Objective-C exceptions raised by `AVAudioEngine.connect(_:to:format:)` during route churn. A failed reconnect is deferred and retried through the existing audio graph recovery path instead of aborting the app.

--- a/Sources/NullPlayer/Windows/ModernLibraryBrowser/ModernLibraryBrowserView.swift
+++ b/Sources/NullPlayer/Windows/ModernLibraryBrowser/ModernLibraryBrowserView.swift
@@ -92,7 +92,7 @@ enum ModernBrowserSource: Equatable, Codable {
     var isRemote: Bool {
         switch self { case .local, .radio: return false; case .plex, .subsonic, .jellyfin, .emby: return true }
     }
-    
+
     private static let userDefaultsKey = "BrowserSource"
     func save() {
         if let data = try? JSONEncoder().encode(self) {
@@ -235,6 +235,7 @@ class ModernLibraryBrowserView: NSView {
     // Column state
     private var columnWidths: [String: CGFloat] = [:] { didSet { saveColumnWidths() } }
     private var resizingColumnId: String?
+    private var resizingColumnGroup: LibraryColumnVisibilityGroup?
     private var resizeStartX: CGFloat = 0
     private var resizeStartWidth: CGFloat = 0
     private var columnSortId: String? { didSet { saveColumnSort(); applyColumnSort(collapseExpanded: true) } }
@@ -1793,8 +1794,9 @@ class ModernLibraryBrowserView: NSView {
         let separatorColor = skin.textDimColor.withAlphaComponent(0.2)
         
         var x = rect.minX + 4 - horizontalScrollOffset
+        let group = currentColumnGroup()
         for (index, column) in columns.enumerated() {
-            let width = widthForColumn(column, availableWidth: rect.width, columns: columns)
+            let width = widthForColumn(column, availableWidth: rect.width, columns: columns, group: group)
             let isSortColumn = columnSortId == column.id
             let isCenteredRadioColumn = (browseMode == .radio && column.id == "genre") ||
                 (hasInternetRadioColumns && column.id == "rating")
@@ -1850,8 +1852,9 @@ class ModernLibraryBrowserView: NSView {
         let smallFont = skin.scaledSystemFont(size: 7.2)
         
         var x = rect.minX + indent + 4 - horizontalScrollOffset
+        let group = columnGroup(for: item)
         for column in columns {
-            let width = widthForColumn(column, availableWidth: totalWidth, columns: columns)
+            let width = widthForColumn(column, availableWidth: totalWidth, columns: columns, group: group)
             let value = item.columnValue(for: column)
             let isCenteredRadioColumn = (browseMode == .radio && column.id == "genre") ||
                 (isInternetRadioItem(item) && column.id == "rating")
@@ -2428,24 +2431,47 @@ class ModernLibraryBrowserView: NSView {
 
     private func hasArtistRows() -> Bool {
         if displayItems.contains(where: {
+            guard $0.indentLevel == 0 else { return false }
             switch $0.type { case .artist, .subsonicArtist, .localArtist, .jellyfinArtist, .embyArtist: return true; default: return false }
         }) {
             return true
         }
         return false
     }
-    
-    private func columnsForItem(_ item: ModernDisplayItem) -> [ModernBrowserColumn]? {
+
+    private func columnGroup(for item: ModernDisplayItem) -> LibraryColumnVisibilityGroup? {
         switch item.type {
         case .track, .subsonicTrack, .localTrack, .jellyfinTrack, .embyTrack:
-            return visibleColumns(allColumns: ModernBrowserColumn.allTrackColumns, visibleIds: visibleTrackColumnIds)
+            return .track
         case .album, .subsonicAlbum, .localAlbum, .jellyfinAlbum, .embyAlbum:
-            return visibleColumns(allColumns: ModernBrowserColumn.allAlbumColumns, visibleIds: visibleAlbumColumnIds)
+            return .album
         case .artist, .subsonicArtist, .localArtist, .jellyfinArtist, .embyArtist:
-            if item.indentLevel == 0 {
-                return visibleColumns(allColumns: ModernBrowserColumn.allArtistColumns, visibleIds: visibleArtistColumnIds)
-            }
+            return item.indentLevel == 0 ? .artist : nil
+        default:
             return nil
+        }
+    }
+
+    private func currentColumnGroup() -> LibraryColumnVisibilityGroup? {
+        if hasTrackRows() { return .track }
+        if hasAlbumRows() { return .album }
+        if hasArtistRows() { return .artist }
+        return nil
+    }
+
+    private func columnsForItem(_ item: ModernDisplayItem) -> [ModernBrowserColumn]? {
+        switch columnGroup(for: item) {
+        case .track:
+            return visibleColumns(allColumns: ModernBrowserColumn.allTrackColumns, visibleIds: visibleTrackColumnIds)
+        case .album:
+            return visibleColumns(allColumns: ModernBrowserColumn.allAlbumColumns, visibleIds: visibleAlbumColumnIds)
+        case .artist:
+            return visibleColumns(allColumns: ModernBrowserColumn.allArtistColumns, visibleIds: visibleArtistColumnIds)
+        case nil:
+            break
+        }
+
+        switch item.type {
         case .radioStation:
             if isInternetRadioItem(item) {
                 return ModernBrowserColumn.internetRadioColumns
@@ -2456,27 +2482,53 @@ class ModernLibraryBrowserView: NSView {
         }
     }
     
-    private func widthForColumn(_ column: ModernBrowserColumn, availableWidth: CGFloat, columns: [ModernBrowserColumn]) -> CGFloat {
+    private func columnWidthKey(_ columnId: String, group: LibraryColumnVisibilityGroup) -> String {
+        "\(group.rawValue):\(columnId)"
+    }
+
+    private func storedColumnWidth(for column: ModernBrowserColumn, group: LibraryColumnVisibilityGroup?) -> CGFloat? {
+        guard let group else { return columnWidths[column.id] }
+        return columnWidths[columnWidthKey(column.id, group: group)]
+    }
+
+    private func setColumnWidth(_ width: CGFloat, for columnId: String, group: LibraryColumnVisibilityGroup) {
+        columnWidths[columnWidthKey(columnId, group: group)] = width
+    }
+
+    private func widthForColumn(
+        _ column: ModernBrowserColumn,
+        availableWidth: CGFloat,
+        columns: [ModernBrowserColumn],
+        group: LibraryColumnVisibilityGroup?
+    ) -> CGFloat {
         if column.id == "title" {
             // If a stored width exists for the title column (set when user resizes any column), use it
-            if let storedWidth = columnWidths["title"] {
+            if let storedWidth = storedColumnWidth(for: column, group: group) {
                 return max(column.minWidth, storedWidth)
             }
             // Otherwise, title is flexible and fills remaining space
             let fixedWidth = columns.filter { $0.id != "title" }.reduce(0) {
-                $0 + (columnWidths[$1.id] ?? $1.minWidth)
+                $0 + (storedColumnWidth(for: $1, group: group) ?? $1.minWidth)
             }
             return max(column.minWidth, availableWidth - fixedWidth - 8)
         }
-        return columnWidths[column.id] ?? column.minWidth
+        return storedColumnWidth(for: column, group: group) ?? column.minWidth
     }
     
-    private func totalColumnsWidth(columns: [ModernBrowserColumn]) -> CGFloat {
+    private func totalColumnsWidth(columns: [ModernBrowserColumn], group: LibraryColumnVisibilityGroup?) -> CGFloat {
         var total: CGFloat = 8
         for column in columns {
-            total += column.id == "title" ? column.minWidth : (columnWidths[column.id] ?? column.minWidth)
+            total += column.id == "title" ? column.minWidth : (storedColumnWidth(for: column, group: group) ?? column.minWidth)
         }
         return total
+    }
+
+    private func clampHorizontalScrollOffset() {
+        let columns = currentVisibleColumns()
+        let group = currentColumnGroup()
+        let availableWidth = bounds.width - Layout.borderWidth * 2 - Layout.scrollbarWidth - Layout.alphabetWidth
+        let maxOffset = max(0, totalColumnsWidth(columns: columns, group: group) - availableWidth)
+        horizontalScrollOffset = max(0, min(horizontalScrollOffset, maxOffset))
     }
     
     private func saveColumnWidths() {
@@ -2485,8 +2537,22 @@ class ModernLibraryBrowserView: NSView {
     
     private func loadColumnWidths() {
         if let saved = UserDefaults.standard.dictionary(forKey: "BrowserColumnWidths") as? [String: CGFloat] {
-            columnWidths = saved
+            columnWidths = migrateColumnWidths(saved)
         }
+    }
+
+    private func migrateColumnWidths(_ saved: [String: CGFloat]) -> [String: CGFloat] {
+        var migrated: [String: CGFloat] = [:]
+        for (key, width) in saved {
+            if key.contains(":") {
+                migrated[key] = width
+                continue
+            }
+            for group in LibraryColumnVisibilityGroup.allCases where allColumns(for: group).contains(where: { $0.id == key }) {
+                migrated[columnWidthKey(key, group: group)] = width
+            }
+        }
+        return migrated
     }
     
     private func saveColumnSort() {
@@ -2535,7 +2601,10 @@ class ModernLibraryBrowserView: NSView {
         if hasAlbumRows() {
             return visibleColumns(allColumns: ModernBrowserColumn.allAlbumColumns, visibleIds: visibleAlbumColumnIds)
         }
-        return visibleColumns(allColumns: ModernBrowserColumn.allArtistColumns, visibleIds: visibleArtistColumnIds)
+        if hasArtistRows() {
+            return visibleColumns(allColumns: ModernBrowserColumn.allArtistColumns, visibleIds: visibleArtistColumnIds)
+        }
+        return []
     }
     
     private func applyColumnSort(collapseExpanded: Bool = false) {
@@ -2595,10 +2664,15 @@ class ModernLibraryBrowserView: NSView {
             let bVal = b.columnValue(for: sortColumn)
             
             if sortColumn.id == "trackNum" || sortColumn.id == "year" || sortColumn.id == "plays" ||
-               sortColumn.id == "albums" || sortColumn.id == "discNum" || sortColumn.id == "channels" {
+               sortColumn.id == "albums" || sortColumn.id == "discNum" {
                 let aNum = Int(aVal.components(separatedBy: "-").last ?? aVal) ?? 0
                 let bNum = Int(bVal.components(separatedBy: "-").last ?? bVal) ?? 0
                 return ascending ? aNum < bNum : aNum > bNum
+            }
+            if sortColumn.id == "channels" {
+                let aChannels = LibraryColumnVisibility.channelSortValue(aVal)
+                let bChannels = LibraryColumnVisibility.channelSortValue(bVal)
+                return ascending ? aChannels < bChannels : aChannels > bChannels
             }
             if sortColumn.id == "duration" {
                 let aSeconds = parseDuration(aVal)
@@ -2791,8 +2865,9 @@ class ModernLibraryBrowserView: NSView {
         let indent = CGFloat(item.indentLevel) * 16
         let availableWidth = rowRect.width - indent
         var x = rowRect.minX + indent + 4 - horizontalScrollOffset
+        let group = columnGroup(for: item)
         for column in columns {
-            let width = widthForColumn(column, availableWidth: availableWidth, columns: columns)
+            let width = widthForColumn(column, availableWidth: availableWidth, columns: columns, group: group)
             if column.id == "rating" {
                 let cellRect = NSRect(x: x, y: rowRect.minY, width: width, height: rowRect.height)
                 guard cellRect.contains(point) else { return nil }
@@ -2839,6 +2914,7 @@ class ModernLibraryBrowserView: NSView {
         guard point.y >= headerBottomY && point.y < headerTopY else { return nil }
         
         let columns = currentVisibleColumns()
+        let group = currentColumnGroup()
         guard columns.count > 1 else { return nil }
         
         let headerWidth = bounds.width - Layout.borderWidth * 2 - Layout.scrollbarWidth - Layout.alphabetWidth
@@ -2846,7 +2922,7 @@ class ModernLibraryBrowserView: NSView {
         var x = Layout.borderWidth + 4 - horizontalScrollOffset
         
         for (index, column) in columns.enumerated() {
-            let width = widthForColumn(column, availableWidth: headerWidth, columns: columns)
+            let width = widthForColumn(column, availableWidth: headerWidth, columns: columns, group: group)
             let edgeX = x + width
             
             // Allow resizing any non-last column by dragging its right edge
@@ -2877,11 +2953,12 @@ class ModernLibraryBrowserView: NSView {
         guard point.y >= headerBottomY && point.y < headerTopY else { return nil }
         
         let columns = currentVisibleColumns()
+        let group = currentColumnGroup()
         
         let headerWidth = bounds.width - Layout.borderWidth * 2 - Layout.scrollbarWidth - Layout.alphabetWidth
         var x = Layout.borderWidth + 4 - horizontalScrollOffset
         for column in columns {
-            let width = widthForColumn(column, availableWidth: headerWidth, columns: columns)
+            let width = widthForColumn(column, availableWidth: headerWidth, columns: columns, group: group)
             if point.x >= x && point.x < x + width { return column.id }
             x += width
         }
@@ -3014,14 +3091,16 @@ class ModernLibraryBrowserView: NSView {
         // Column resize (check before sort so edge-drag doesn't trigger sort)
         if let columnId = hitTestColumnResize(at: point) {
             resizingColumnId = columnId
+            resizingColumnGroup = currentColumnGroup()
             resizeStartX = point.x
             let columns = currentVisibleColumns()
+            let group = resizingColumnGroup
             let headerWidth = bounds.width - Layout.borderWidth * 2 - Layout.scrollbarWidth - Layout.alphabetWidth
-            resizeStartWidth = widthForColumn(ModernBrowserColumn.findColumn(id: columnId)!, availableWidth: headerWidth, columns: columns)
+            resizeStartWidth = widthForColumn(ModernBrowserColumn.findColumn(id: columnId)!, availableWidth: headerWidth, columns: columns, group: group)
             // Freeze the title column's current width so it doesn't flex during resize
-            if columnWidths["title"] == nil {
-                let titleWidth = widthForColumn(.title, availableWidth: headerWidth, columns: columns)
-                columnWidths["title"] = titleWidth
+            if let group, storedColumnWidth(for: .title, group: group) == nil {
+                let titleWidth = widthForColumn(.title, availableWidth: headerWidth, columns: columns, group: group)
+                setColumnWidth(titleWidth, for: "title", group: group)
             }
             NSCursor.resizeLeftRight.push()
             return
@@ -3057,11 +3136,11 @@ class ModernLibraryBrowserView: NSView {
     }
     
     override func mouseDragged(with event: NSEvent) {
-        if let columnId = resizingColumnId {
+        if let columnId = resizingColumnId, let group = resizingColumnGroup {
             let point = convert(event.locationInWindow, from: nil)
             let deltaX = point.x - resizeStartX
             let minWidth = ModernBrowserColumn.findColumn(id: columnId)?.minWidth ?? 30
-            columnWidths[columnId] = max(minWidth, resizeStartWidth + deltaX)
+            setColumnWidth(max(minWidth, resizeStartWidth + deltaX), for: columnId, group: group)
             needsDisplay = true; return
         }
 
@@ -3085,7 +3164,7 @@ class ModernLibraryBrowserView: NSView {
     override func mouseUp(with event: NSEvent) {
         let point = convert(event.locationInWindow, from: nil)
         
-        if resizingColumnId != nil { resizingColumnId = nil; NSCursor.pop() }
+        if resizingColumnId != nil { resizingColumnId = nil; resizingColumnGroup = nil; NSCursor.pop() }
         if isDraggingWindow {
             isDraggingWindow = false
             if let window = window { WindowManager.shared.windowDidFinishDragging(window) }
@@ -3178,8 +3257,9 @@ class ModernLibraryBrowserView: NSView {
 
         if abs(event.deltaX) > 0 {
             let columns = currentVisibleColumns()
+            let group = currentColumnGroup()
             let availableWidth = bounds.width - Layout.borderWidth * 2 - Layout.scrollbarWidth - Layout.alphabetWidth
-            let totalWidth = columns.reduce(CGFloat(8)) { $0 + (columnWidths[$1.id] ?? $1.minWidth) }
+            let totalWidth = totalColumnsWidth(columns: columns, group: group)
             let maxOffset = max(0, totalWidth - availableWidth)
             if maxOffset > 0 {
                 horizontalScrollOffset = max(0, min(maxOffset, horizontalScrollOffset - event.deltaX * 3))
@@ -4361,6 +4441,7 @@ class ModernLibraryBrowserView: NSView {
         }
 
         setVisibleColumnIds(ids, for: group)
+        clampHorizontalScrollOffset()
         needsDisplay = true
     }
     
@@ -4369,8 +4450,9 @@ class ModernLibraryBrowserView: NSView {
               let group = LibraryColumnVisibilityGroup(rawValue: rawValue) else { return }
 
         setVisibleColumnIds(defaultColumnIds(for: group), for: group)
-        let columnIds = Set(allColumns(for: group).map { $0.id })
-        columnWidths = columnWidths.filter { !columnIds.contains($0.key) }
+        let prefix = "\(group.rawValue):"
+        columnWidths = columnWidths.filter { !$0.key.hasPrefix(prefix) }
+        clampHorizontalScrollOffset()
         needsDisplay = true
     }
     
@@ -10606,7 +10688,7 @@ extension ModernDisplayItem {
         case "discNum": return track.parentIndex.map { String($0) } ?? ""
         case "dateAdded": return track.addedAt.map { Self.formatDate($0) } ?? ""
         case "lastPlayed": return ""  // Not available in Plex API
-        case "path": return track.media.first?.parts.first?.file?.components(separatedBy: "/").last ?? ""
+        case "path": return track.media.first?.parts.first?.file ?? ""
         default: return ""
         }
     }
@@ -10635,7 +10717,7 @@ extension ModernDisplayItem {
         case "discNum": return song.discNumber.map { String($0) } ?? ""
         case "dateAdded": return song.created.map { Self.formatDate($0) } ?? ""
         case "lastPlayed": return ""  // Not available in Subsonic API
-        case "path": return song.path?.components(separatedBy: "/").last ?? ""
+        case "path": return song.path ?? ""
         default: return ""
         }
     }
@@ -10660,7 +10742,7 @@ extension ModernDisplayItem {
         case "discNum": return track.discNumber.map { String($0) } ?? ""
         case "dateAdded": return Self.formatDate(track.dateAdded)
         case "lastPlayed": return track.lastPlayed.map { Self.formatDate($0) } ?? ""
-        case "path": return track.url.lastPathComponent
+        case "path": return track.url.path
         default: return ""
         }
     }
@@ -10710,7 +10792,7 @@ extension ModernDisplayItem {
         case "discNum": return song.discNumber.map { String($0) } ?? ""
         case "dateAdded": return song.created.map { Self.formatDate($0) } ?? ""
         case "lastPlayed": return ""
-        case "path": return song.path?.components(separatedBy: "/").last ?? ""
+        case "path": return song.path ?? ""
         default: return ""
         }
     }
@@ -10751,7 +10833,7 @@ extension ModernDisplayItem {
         case "discNum": return song.discNumber.map { String($0) } ?? ""
         case "dateAdded": return song.created.map { Self.formatDate($0) } ?? ""
         case "lastPlayed": return ""
-        case "path": return song.path?.components(separatedBy: "/").last ?? ""
+        case "path": return song.path ?? ""
         default: return ""
         }
     }

--- a/Sources/NullPlayer/Windows/ModernLibraryBrowser/ModernLibraryBrowserView.swift
+++ b/Sources/NullPlayer/Windows/ModernLibraryBrowser/ModernLibraryBrowserView.swift
@@ -244,7 +244,7 @@ class ModernLibraryBrowserView: NSView {
     private var visibleTrackColumnIds: [String] = ModernBrowserColumn.defaultTrackColumnIds { didSet { saveVisibleColumns() } }
     private var visibleAlbumColumnIds: [String] = ModernBrowserColumn.defaultAlbumColumnIds { didSet { saveVisibleColumns() } }
     private var visibleArtistColumnIds: [String] = ModernBrowserColumn.defaultArtistColumnIds { didSet { saveVisibleColumns() } }
-    
+
     // Display items
     private var displayItems: [ModernDisplayItem] = []
     
@@ -2395,42 +2395,55 @@ class ModernLibraryBrowserView: NSView {
         if hasInternetRadioColumns {
             return ModernBrowserColumn.internetRadioColumns
         }
+        let columns = currentVisibleColumns()
+        guard !columns.isEmpty else { return nil }
+        return columns
+    }
+
+    private func visibleColumns(allColumns: [ModernBrowserColumn], visibleIds: [String]) -> [ModernBrowserColumn] {
+        LibraryColumnVisibility.visibleColumns(allColumns: allColumns, visibleIds: visibleIds) { $0.id }
+    }
+
+    private func normalizedColumnIds(_ ids: [String], allColumns: [ModernBrowserColumn]) -> [String] {
+        LibraryColumnVisibility.normalizedIds(ids, allIds: allColumns.map { $0.id })
+    }
+
+    private func hasTrackRows() -> Bool {
         if displayItems.contains(where: {
             switch $0.type { case .track, .subsonicTrack, .localTrack, .jellyfinTrack, .embyTrack: return true; default: return false }
         }) {
-            return ModernBrowserColumn.trackColumns
+            return true
         }
+        return false
+    }
+
+    private func hasAlbumRows() -> Bool {
         if displayItems.contains(where: {
             switch $0.type { case .album, .subsonicAlbum, .localAlbum, .jellyfinAlbum, .embyAlbum: return true; default: return false }
         }) {
-            return ModernBrowserColumn.albumColumns
+            return true
         }
+        return false
+    }
+
+    private func hasArtistRows() -> Bool {
         if displayItems.contains(where: {
             switch $0.type { case .artist, .subsonicArtist, .localArtist, .jellyfinArtist, .embyArtist: return true; default: return false }
         }) {
-            return ModernBrowserColumn.artistColumns
+            return true
         }
-        return nil
+        return false
     }
     
     private func columnsForItem(_ item: ModernDisplayItem) -> [ModernBrowserColumn]? {
         switch item.type {
         case .track, .subsonicTrack, .localTrack, .jellyfinTrack, .embyTrack:
-            let visible = visibleTrackColumnIds
-            return ModernBrowserColumn.allTrackColumns
-                .filter { visible.contains($0.id) }
-                .sorted { visible.firstIndex(of: $0.id)! < visible.firstIndex(of: $1.id)! }
+            return visibleColumns(allColumns: ModernBrowserColumn.allTrackColumns, visibleIds: visibleTrackColumnIds)
         case .album, .subsonicAlbum, .localAlbum, .jellyfinAlbum, .embyAlbum:
-            let visible = visibleAlbumColumnIds
-            return ModernBrowserColumn.allAlbumColumns
-                .filter { visible.contains($0.id) }
-                .sorted { visible.firstIndex(of: $0.id)! < visible.firstIndex(of: $1.id)! }
+            return visibleColumns(allColumns: ModernBrowserColumn.allAlbumColumns, visibleIds: visibleAlbumColumnIds)
         case .artist, .subsonicArtist, .localArtist, .jellyfinArtist, .embyArtist:
             if item.indentLevel == 0 {
-                let visible = visibleArtistColumnIds
-                return ModernBrowserColumn.allArtistColumns
-                    .filter { visible.contains($0.id) }
-                    .sorted { visible.firstIndex(of: $0.id)! < visible.firstIndex(of: $1.id)! }
+                return visibleColumns(allColumns: ModernBrowserColumn.allArtistColumns, visibleIds: visibleArtistColumnIds)
             }
             return nil
         case .radioStation:
@@ -2501,13 +2514,13 @@ class ModernLibraryBrowserView: NSView {
     
     private func loadVisibleColumns() {
         if let saved = UserDefaults.standard.stringArray(forKey: "BrowserVisibleTrackColumns") {
-            visibleTrackColumnIds = saved
+            visibleTrackColumnIds = normalizedColumnIds(saved, allColumns: ModernBrowserColumn.allTrackColumns)
         }
         if let saved = UserDefaults.standard.stringArray(forKey: "BrowserVisibleAlbumColumns") {
-            visibleAlbumColumnIds = saved
+            visibleAlbumColumnIds = normalizedColumnIds(saved, allColumns: ModernBrowserColumn.allAlbumColumns)
         }
         if let saved = UserDefaults.standard.stringArray(forKey: "BrowserVisibleArtistColumns") {
-            visibleArtistColumnIds = saved
+            visibleArtistColumnIds = normalizedColumnIds(saved, allColumns: ModernBrowserColumn.allArtistColumns)
         }
     }
     
@@ -2516,32 +2529,13 @@ class ModernLibraryBrowserView: NSView {
         if hasInternetRadioColumns {
             return ModernBrowserColumn.internetRadioColumns
         }
-        if displayItems.contains(where: {
-            switch $0.type { case .track, .subsonicTrack, .localTrack, .jellyfinTrack: return true; default: return false }
-        }) {
-            return ModernBrowserColumn.allTrackColumns.filter { visibleTrackColumnIds.contains($0.id) }
-                .sorted { visibleTrackColumnIds.firstIndex(of: $0.id)! < visibleTrackColumnIds.firstIndex(of: $1.id)! }
+        if hasTrackRows() {
+            return visibleColumns(allColumns: ModernBrowserColumn.allTrackColumns, visibleIds: visibleTrackColumnIds)
         }
-        if displayItems.contains(where: {
-            switch $0.type { case .album, .subsonicAlbum, .localAlbum, .jellyfinAlbum: return true; default: return false }
-        }) {
-            return ModernBrowserColumn.allAlbumColumns.filter { visibleAlbumColumnIds.contains($0.id) }
-                .sorted { visibleAlbumColumnIds.firstIndex(of: $0.id)! < visibleAlbumColumnIds.firstIndex(of: $1.id)! }
+        if hasAlbumRows() {
+            return visibleColumns(allColumns: ModernBrowserColumn.allAlbumColumns, visibleIds: visibleAlbumColumnIds)
         }
-        return ModernBrowserColumn.allArtistColumns.filter { visibleArtistColumnIds.contains($0.id) }
-            .sorted { visibleArtistColumnIds.firstIndex(of: $0.id)! < visibleArtistColumnIds.firstIndex(of: $1.id)! }
-    }
-    
-    /// Returns all possible columns for the given column category (for the right-click menu)
-    private func allColumnsForCurrentView() -> [ModernBrowserColumn] {
-        if hasInternetRadioColumns { return ModernBrowserColumn.internetRadioColumns }
-        if displayItems.contains(where: {
-            switch $0.type { case .track, .subsonicTrack, .localTrack, .jellyfinTrack: return true; default: return false }
-        }) { return ModernBrowserColumn.allTrackColumns }
-        if displayItems.contains(where: {
-            switch $0.type { case .album, .subsonicAlbum, .localAlbum, .jellyfinAlbum: return true; default: return false }
-        }) { return ModernBrowserColumn.allAlbumColumns }
-        return ModernBrowserColumn.allArtistColumns
+        return visibleColumns(allColumns: ModernBrowserColumn.allArtistColumns, visibleIds: visibleArtistColumnIds)
     }
     
     private func applyColumnSort(collapseExpanded: Bool = false) {
@@ -4272,78 +4266,111 @@ class ModernLibraryBrowserView: NSView {
         if hasInternetRadioColumns { return }
         let menu = NSMenu()
         menu.autoenablesItems = false
-        
-        let allColumns = allColumnsForCurrentView()
-        let visibleIds = currentVisibleColumnIds()
-        
-        for column in allColumns {
-            let item = NSMenuItem(title: column.title, action: #selector(toggleColumnVisibility(_:)), keyEquivalent: "")
-            item.target = self
-            item.representedObject = column.id
-            item.state = visibleIds.contains(column.id) ? .on : .off
-            // Title column is always visible
-            if column.id == "title" { item.isEnabled = false }
-            menu.addItem(item)
+
+        for group in columnGroupsForCurrentMenu() {
+            addColumnVisibilityGroup(group, to: menu)
         }
-        
-        menu.addItem(NSMenuItem.separator())
-        let resetItem = NSMenuItem(title: "Reset to Default", action: #selector(resetColumnsToDefault), keyEquivalent: "")
-        resetItem.target = self
-        menu.addItem(resetItem)
         
         NSMenu.popUpContextMenu(menu, with: event, for: self)
     }
-    
-    private func currentVisibleColumnIds() -> [String] {
-        if hasInternetRadioColumns { return ModernBrowserColumn.internetRadioColumns.map { $0.id } }
-        if displayItems.contains(where: {
-            switch $0.type { case .track, .subsonicTrack, .localTrack, .jellyfinTrack: return true; default: return false }
-        }) { return visibleTrackColumnIds }
-        if displayItems.contains(where: {
-            switch $0.type { case .album, .subsonicAlbum, .localAlbum, .jellyfinAlbum: return true; default: return false }
-        }) { return visibleAlbumColumnIds }
-        return visibleArtistColumnIds
+
+    private func columnGroupsForCurrentMenu() -> [LibraryColumnVisibilityGroup] {
+        LibraryColumnVisibility.menuGroups(
+            isArtistsMode: browseMode == .artists,
+            isAlbumsMode: browseMode == .albums,
+            hasTrackRows: hasTrackRows(),
+            hasAlbumRows: hasAlbumRows(),
+            hasArtistRows: hasArtistRows()
+        )
     }
-    
-    @objc private func toggleColumnVisibility(_ sender: NSMenuItem) {
-        guard let columnId = sender.representedObject as? String else { return }
-        
-        // Determine which column ID list to modify
-        if displayItems.contains(where: {
-            switch $0.type { case .track, .subsonicTrack, .localTrack, .jellyfinTrack: return true; default: return false }
-        }) {
-            if let index = visibleTrackColumnIds.firstIndex(of: columnId) {
-                visibleTrackColumnIds.remove(at: index)
-                // Clear sort if hiding the sorted column
-                if columnSortId == columnId { columnSortId = nil }
-            } else {
-                visibleTrackColumnIds.append(columnId)
+
+    private func addColumnVisibilityGroup(_ group: LibraryColumnVisibilityGroup, to menu: NSMenu) {
+        if !menu.items.isEmpty {
+            menu.addItem(NSMenuItem.separator())
+        }
+
+        let header = NSMenuItem(title: group.headerTitle, action: nil, keyEquivalent: "")
+        header.isEnabled = false
+        menu.addItem(header)
+
+        let visibleIds = Set(visibleColumnIds(for: group))
+        for column in allColumns(for: group) {
+            let item = NSMenuItem()
+            item.view = ColumnVisibilityCheckboxView(
+                title: column.title,
+                isChecked: column.id == "title" || visibleIds.contains(column.id),
+                isEnabled: column.id != "title"
+            ) { [weak self] isVisible in
+                self?.toggleColumnVisibility(group: group, columnId: column.id, visible: isVisible)
             }
-        } else if displayItems.contains(where: {
-            switch $0.type { case .album, .subsonicAlbum, .localAlbum, .jellyfinAlbum: return true; default: return false }
-        }) {
-            if let index = visibleAlbumColumnIds.firstIndex(of: columnId) {
-                visibleAlbumColumnIds.remove(at: index)
-                if columnSortId == columnId { columnSortId = nil }
-            } else {
-                visibleAlbumColumnIds.append(columnId)
+            menu.addItem(item)
+        }
+
+        let resetItem = NSMenuItem(title: group.resetTitle, action: #selector(resetColumnGroup(_:)), keyEquivalent: "")
+        resetItem.target = self
+        resetItem.representedObject = group.rawValue
+        menu.addItem(resetItem)
+    }
+
+    private func allColumns(for group: LibraryColumnVisibilityGroup) -> [ModernBrowserColumn] {
+        switch group {
+        case .artist: return ModernBrowserColumn.allArtistColumns
+        case .album: return ModernBrowserColumn.allAlbumColumns
+        case .track: return ModernBrowserColumn.allTrackColumns
+        }
+    }
+
+    private func defaultColumnIds(for group: LibraryColumnVisibilityGroup) -> [String] {
+        switch group {
+        case .artist: return ModernBrowserColumn.defaultArtistColumnIds
+        case .album: return ModernBrowserColumn.defaultAlbumColumnIds
+        case .track: return ModernBrowserColumn.defaultTrackColumnIds
+        }
+    }
+
+    private func visibleColumnIds(for group: LibraryColumnVisibilityGroup) -> [String] {
+        switch group {
+        case .artist: return normalizedColumnIds(visibleArtistColumnIds, allColumns: ModernBrowserColumn.allArtistColumns)
+        case .album: return normalizedColumnIds(visibleAlbumColumnIds, allColumns: ModernBrowserColumn.allAlbumColumns)
+        case .track: return normalizedColumnIds(visibleTrackColumnIds, allColumns: ModernBrowserColumn.allTrackColumns)
+        }
+    }
+
+    private func setVisibleColumnIds(_ ids: [String], for group: LibraryColumnVisibilityGroup) {
+        switch group {
+        case .artist:
+            visibleArtistColumnIds = normalizedColumnIds(ids, allColumns: ModernBrowserColumn.allArtistColumns)
+        case .album:
+            visibleAlbumColumnIds = normalizedColumnIds(ids, allColumns: ModernBrowserColumn.allAlbumColumns)
+        case .track:
+            visibleTrackColumnIds = normalizedColumnIds(ids, allColumns: ModernBrowserColumn.allTrackColumns)
+        }
+    }
+
+    private func toggleColumnVisibility(group: LibraryColumnVisibilityGroup, columnId: String, visible: Bool) {
+        guard columnId != "title" else { return }
+
+        var ids = visibleColumnIds(for: group)
+        if visible {
+            if !ids.contains(columnId) {
+                ids.append(columnId)
             }
         } else {
-            if let index = visibleArtistColumnIds.firstIndex(of: columnId) {
-                visibleArtistColumnIds.remove(at: index)
-                if columnSortId == columnId { columnSortId = nil }
-            } else {
-                visibleArtistColumnIds.append(columnId)
-            }
+            ids.removeAll { $0 == columnId }
+            if columnSortId == columnId { columnSortId = nil }
         }
+
+        setVisibleColumnIds(ids, for: group)
         needsDisplay = true
     }
     
-    @objc private func resetColumnsToDefault() {
-        visibleTrackColumnIds = ModernBrowserColumn.defaultTrackColumnIds
-        visibleAlbumColumnIds = ModernBrowserColumn.defaultAlbumColumnIds
-        visibleArtistColumnIds = ModernBrowserColumn.defaultArtistColumnIds
-        columnWidths.removeAll()
+    @objc private func resetColumnGroup(_ sender: NSMenuItem) {
+        guard let rawValue = sender.representedObject as? String,
+              let group = LibraryColumnVisibilityGroup(rawValue: rawValue) else { return }
+
+        setVisibleColumnIds(defaultColumnIds(for: group), for: group)
+        let columnIds = Set(allColumns(for: group).map { $0.id })
+        columnWidths = columnWidths.filter { !columnIds.contains($0.key) }
         needsDisplay = true
     }
     
@@ -10571,7 +10598,7 @@ extension ModernDisplayItem {
         case "genre": return track.genre ?? ""
         case "duration": return track.formattedDuration
         case "bitrate": return track.media.first?.bitrate.map { "\($0)k" } ?? ""
-        case "sampleRate": return ""  // Not available in Plex API track model
+        case "sampleRate": return track.media.first?.audioSampleRate.map { Self.formatSampleRate($0) } ?? ""
         case "channels": return track.media.first?.audioChannels.map { Self.formatChannels($0) } ?? ""
         case "size": return Self.formatFileSize(track.media.first?.parts.first?.size)
         case "rating": return Self.formatRating(track.userRating)
@@ -10596,7 +10623,7 @@ extension ModernDisplayItem {
         case "genre": return song.genre ?? ""
         case "duration": return song.formattedDuration
         case "bitrate": return song.bitRate.map { "\($0)k" } ?? ""
-        case "sampleRate": return ""  // Not available in Subsonic API
+        case "sampleRate": return song.samplingRate.map { Self.formatSampleRate($0) } ?? ""
         case "channels": return ""  // Not available in Subsonic API
         case "size": return Self.formatFileSize(song.size)
         case "rating":
@@ -10811,6 +10838,7 @@ extension ModernDisplayItem {
             case .track(let t): return t.addedAt
             case .subsonicTrack(let s): return s.created
             case .jellyfinTrack(let s): return s.created
+            case .embyTrack(let s): return s.created
             default: return nil
             }
         case "lastPlayed":

--- a/Sources/NullPlayer/Windows/ModernLibraryBrowser/ModernLibraryBrowserView.swift
+++ b/Sources/NullPlayer/Windows/ModernLibraryBrowser/ModernLibraryBrowserView.swift
@@ -2515,19 +2515,21 @@ class ModernLibraryBrowserView: NSView {
         return storedColumnWidth(for: column, group: group) ?? column.minWidth
     }
     
-    private func totalColumnsWidth(columns: [ModernBrowserColumn], group: LibraryColumnVisibilityGroup?) -> CGFloat {
-        var total: CGFloat = 8
-        for column in columns {
-            total += column.id == "title" ? column.minWidth : (storedColumnWidth(for: column, group: group) ?? column.minWidth)
+    private func totalColumnsWidth(
+        columns: [ModernBrowserColumn],
+        availableWidth: CGFloat,
+        group: LibraryColumnVisibilityGroup?
+    ) -> CGFloat {
+        8 + columns.reduce(0) { total, column in
+            total + widthForColumn(column, availableWidth: availableWidth, columns: columns, group: group)
         }
-        return total
     }
 
     private func clampHorizontalScrollOffset() {
         let columns = currentVisibleColumns()
         let group = currentColumnGroup()
         let availableWidth = bounds.width - Layout.borderWidth * 2 - Layout.scrollbarWidth - Layout.alphabetWidth
-        let maxOffset = max(0, totalColumnsWidth(columns: columns, group: group) - availableWidth)
+        let maxOffset = max(0, totalColumnsWidth(columns: columns, availableWidth: availableWidth, group: group) - availableWidth)
         horizontalScrollOffset = max(0, min(horizontalScrollOffset, maxOffset))
     }
     
@@ -3259,7 +3261,7 @@ class ModernLibraryBrowserView: NSView {
             let columns = currentVisibleColumns()
             let group = currentColumnGroup()
             let availableWidth = bounds.width - Layout.borderWidth * 2 - Layout.scrollbarWidth - Layout.alphabetWidth
-            let totalWidth = totalColumnsWidth(columns: columns, group: group)
+            let totalWidth = totalColumnsWidth(columns: columns, availableWidth: availableWidth, group: group)
             let maxOffset = max(0, totalWidth - availableWidth)
             if maxOffset > 0 {
                 horizontalScrollOffset = max(0, min(maxOffset, horizontalScrollOffset - event.deltaX * 3))

--- a/Sources/NullPlayer/Windows/PlexBrowser/PlexBrowserView.swift
+++ b/Sources/NullPlayer/Windows/PlexBrowser/PlexBrowserView.swift
@@ -324,7 +324,12 @@ class PlexBrowserView: NSView {
     private var columnWidths: [String: CGFloat] = [:] {
         didSet { saveColumnWidths() }
     }
-    
+
+    /// Visible columns (ordered lists of column IDs; persisted separately from Modern UI)
+    private var visibleTrackColumnIds: [String] = BrowserColumn.defaultTrackColumnIds { didSet { saveVisibleColumns() } }
+    private var visibleAlbumColumnIds: [String] = BrowserColumn.defaultAlbumColumnIds { didSet { saveVisibleColumns() } }
+    private var visibleArtistColumnIds: [String] = BrowserColumn.defaultArtistColumnIds { didSet { saveVisibleColumns() } }
+
     /// Column being resized (id) and resize state
     private var resizingColumnId: String?
     private var resizeStartX: CGFloat = 0
@@ -389,44 +394,57 @@ class PlexBrowserView: NSView {
         if hasInternetRadioColumns {
             return BrowserColumn.internetRadioColumns
         }
-        if displayItems.contains(where: {
+        let columns = currentVisibleColumns()
+        guard !columns.isEmpty else { return nil }
+        return columns
+    }
+
+    private func visibleColumns(allColumns: [BrowserColumn], visibleIds: [String]) -> [BrowserColumn] {
+        LibraryColumnVisibility.visibleColumns(allColumns: allColumns, visibleIds: visibleIds) { $0.id }
+    }
+
+    private func normalizedColumnIds(_ ids: [String], allColumns: [BrowserColumn]) -> [String] {
+        LibraryColumnVisibility.normalizedIds(ids, allIds: allColumns.map { $0.id })
+    }
+
+    private func hasTrackRows() -> Bool {
+        displayItems.contains {
             switch $0.type {
             case .track, .subsonicTrack, .localTrack, .jellyfinTrack, .embyTrack: return true
             default: return false
             }
-        }) {
-            return BrowserColumn.trackColumns
         }
-        if displayItems.contains(where: {
+    }
+
+    private func hasAlbumRows() -> Bool {
+        displayItems.contains {
             switch $0.type {
             case .album, .subsonicAlbum, .localAlbum, .jellyfinAlbum, .embyAlbum: return true
             default: return false
             }
-        }) {
-            return BrowserColumn.albumColumns
         }
-        if displayItems.contains(where: {
+    }
+
+    private func hasArtistRows() -> Bool {
+        displayItems.contains {
             switch $0.type {
             case .artist, .subsonicArtist, .localArtist, .jellyfinArtist, .embyArtist: return true
             default: return false
             }
-        }) {
-            return BrowserColumn.artistColumns
         }
-        return nil
     }
     
     /// Get columns for a specific item (nil = use simple list rendering)
     private func columnsForItem(_ item: PlexDisplayItem) -> [BrowserColumn]? {
         switch item.type {
         case .track, .subsonicTrack, .localTrack, .jellyfinTrack, .embyTrack:
-            return BrowserColumn.trackColumns
+            return visibleColumns(allColumns: BrowserColumn.allTrackColumns, visibleIds: visibleTrackColumnIds)
         case .album, .subsonicAlbum, .localAlbum, .jellyfinAlbum, .embyAlbum:
-            return BrowserColumn.albumColumns
+            return visibleColumns(allColumns: BrowserColumn.allAlbumColumns, visibleIds: visibleAlbumColumnIds)
         case .artist, .subsonicArtist, .localArtist, .jellyfinArtist, .embyArtist:
             // Only show columns for top-level artists (not nested under search results)
             if item.indentLevel == 0 {
-                return BrowserColumn.artistColumns
+                return visibleColumns(allColumns: BrowserColumn.allArtistColumns, visibleIds: visibleArtistColumnIds)
             }
             return nil
         case .radioStation:
@@ -474,6 +492,37 @@ class PlexBrowserView: NSView {
         if let saved = UserDefaults.standard.dictionary(forKey: "BrowserColumnWidths") as? [String: CGFloat] {
             columnWidths = saved
         }
+    }
+
+    private func saveVisibleColumns() {
+        UserDefaults.standard.set(visibleTrackColumnIds, forKey: "ClassicBrowserVisibleTrackColumns")
+        UserDefaults.standard.set(visibleAlbumColumnIds, forKey: "ClassicBrowserVisibleAlbumColumns")
+        UserDefaults.standard.set(visibleArtistColumnIds, forKey: "ClassicBrowserVisibleArtistColumns")
+    }
+
+    private func loadVisibleColumns() {
+        if let saved = UserDefaults.standard.stringArray(forKey: "ClassicBrowserVisibleTrackColumns") {
+            visibleTrackColumnIds = normalizedColumnIds(saved, allColumns: BrowserColumn.allTrackColumns)
+        }
+        if let saved = UserDefaults.standard.stringArray(forKey: "ClassicBrowserVisibleAlbumColumns") {
+            visibleAlbumColumnIds = normalizedColumnIds(saved, allColumns: BrowserColumn.allAlbumColumns)
+        }
+        if let saved = UserDefaults.standard.stringArray(forKey: "ClassicBrowserVisibleArtistColumns") {
+            visibleArtistColumnIds = normalizedColumnIds(saved, allColumns: BrowserColumn.allArtistColumns)
+        }
+    }
+
+    private func currentVisibleColumns() -> [BrowserColumn] {
+        if hasInternetRadioColumns {
+            return BrowserColumn.internetRadioColumns
+        }
+        if hasTrackRows() {
+            return visibleColumns(allColumns: BrowserColumn.allTrackColumns, visibleIds: visibleTrackColumnIds)
+        }
+        if hasAlbumRows() {
+            return visibleColumns(allColumns: BrowserColumn.allAlbumColumns, visibleIds: visibleAlbumColumnIds)
+        }
+        return visibleColumns(allColumns: BrowserColumn.allArtistColumns, visibleIds: visibleArtistColumnIds)
     }
     
     /// Apply column sort to display items
@@ -560,7 +609,8 @@ class PlexBrowserView: NSView {
             let bVal = b.columnValue(for: sortColumn)
             
             // Try numeric comparison for numeric columns
-            if sortColumn.id == "trackNum" || sortColumn.id == "year" || sortColumn.id == "plays" || sortColumn.id == "albums" {
+            if sortColumn.id == "trackNum" || sortColumn.id == "year" || sortColumn.id == "plays" ||
+               sortColumn.id == "albums" || sortColumn.id == "discNum" || sortColumn.id == "channels" {
                 let aNum = Int(aVal.components(separatedBy: "-").last ?? aVal) ?? 0
                 let bNum = Int(bVal.components(separatedBy: "-").last ?? bVal) ?? 0
                 return ascending ? aNum < bNum : aNum > bNum
@@ -573,11 +623,12 @@ class PlexBrowserView: NSView {
                 return ascending ? aSeconds < bSeconds : aSeconds > bSeconds
             }
             
-            // Bitrate comparison
-            if sortColumn.id == "bitrate" {
-                let aKbps = Int(aVal.replacingOccurrences(of: "k", with: "")) ?? 0
-                let bKbps = Int(bVal.replacingOccurrences(of: "k", with: "")) ?? 0
-                return ascending ? aKbps < bKbps : aKbps > bKbps
+            // Bitrate / sample-rate comparison
+            if sortColumn.id == "bitrate" || sortColumn.id == "sampleRate" {
+                let cleaned = { (value: String) -> Double in
+                    Double(value.replacingOccurrences(of: "k", with: "")) ?? 0
+                }
+                return ascending ? cleaned(aVal) < cleaned(bVal) : cleaned(aVal) > cleaned(bVal)
             }
             
             // Size comparison
@@ -1010,6 +1061,7 @@ class PlexBrowserView: NSView {
         
         // Load saved column widths and sort
         loadColumnWidths()
+        loadVisibleColumns()
         loadColumnSort()
         
         // Load saved source
@@ -6815,6 +6867,25 @@ class PlexBrowserView: NSView {
         
         return nil
     }
+
+    private func hitTestColumnHeaderArea(at skinPoint: NSPoint) -> Bool {
+        guard !browseMode.isHistoryMode else { return false }
+        if hasInternetRadioColumns { return false }
+        let hasColumns = displayItems.contains { columnsForItem($0) != nil }
+        guard hasColumns else { return false }
+
+        var headerY = Layout.titleBarHeight + Layout.serverBarHeight + Layout.tabBarHeight
+        if browseMode == .search {
+            headerY += Layout.searchBarHeight
+        }
+        let headerRect = NSRect(
+            x: Layout.leftBorder,
+            y: headerY,
+            width: originalWindowSize.width - Layout.leftBorder - Layout.rightBorder - Layout.scrollbarWidth - Layout.alphabetWidth,
+            height: columnHeaderHeight
+        )
+        return headerRect.contains(skinPoint)
+    }
     
     /// Check if point hits the scrollbar (disabled - no scrollbar widget)
     private func hitTestScrollbar(at skinPoint: NSPoint) -> Bool {
@@ -6873,6 +6944,12 @@ class PlexBrowserView: NSView {
             showArtContextMenu(at: event)
             return
         }
+
+        // Right-click on column header: show column visibility menu
+        if hitTestColumnHeaderArea(at: skinPoint) {
+            showColumnConfigMenu(at: event)
+            return
+        }
         
         // Check list area for item context menu
         if !isArtOnlyMode, !browseMode.isHistoryMode, let clickedIndex = hitTestListArea(at: skinPoint) {
@@ -6901,6 +6978,118 @@ class PlexBrowserView: NSView {
         }
         // Default right-click behavior
         super.rightMouseDown(with: event)
+    }
+
+    private func showColumnConfigMenu(at event: NSEvent) {
+        if hasInternetRadioColumns { return }
+        let menu = NSMenu()
+        menu.autoenablesItems = false
+
+        for group in columnGroupsForCurrentMenu() {
+            addColumnVisibilityGroup(group, to: menu)
+        }
+
+        NSMenu.popUpContextMenu(menu, with: event, for: self)
+    }
+
+    private func columnGroupsForCurrentMenu() -> [LibraryColumnVisibilityGroup] {
+        LibraryColumnVisibility.menuGroups(
+            isArtistsMode: browseMode == .artists,
+            isAlbumsMode: browseMode == .albums,
+            hasTrackRows: hasTrackRows(),
+            hasAlbumRows: hasAlbumRows(),
+            hasArtistRows: hasArtistRows()
+        )
+    }
+
+    private func addColumnVisibilityGroup(_ group: LibraryColumnVisibilityGroup, to menu: NSMenu) {
+        if !menu.items.isEmpty {
+            menu.addItem(NSMenuItem.separator())
+        }
+
+        let header = NSMenuItem(title: group.headerTitle, action: nil, keyEquivalent: "")
+        header.isEnabled = false
+        menu.addItem(header)
+
+        let visibleIds = Set(visibleColumnIds(for: group))
+        for column in allColumns(for: group) {
+            let item = NSMenuItem()
+            item.view = ColumnVisibilityCheckboxView(
+                title: column.title,
+                isChecked: column.id == "title" || visibleIds.contains(column.id),
+                isEnabled: column.id != "title"
+            ) { [weak self] isVisible in
+                self?.toggleColumnVisibility(group: group, columnId: column.id, visible: isVisible)
+            }
+            menu.addItem(item)
+        }
+
+        let resetItem = NSMenuItem(title: group.resetTitle, action: #selector(resetColumnGroup(_:)), keyEquivalent: "")
+        resetItem.target = self
+        resetItem.representedObject = group.rawValue
+        menu.addItem(resetItem)
+    }
+
+    private func allColumns(for group: LibraryColumnVisibilityGroup) -> [BrowserColumn] {
+        switch group {
+        case .artist: return BrowserColumn.allArtistColumns
+        case .album: return BrowserColumn.allAlbumColumns
+        case .track: return BrowserColumn.allTrackColumns
+        }
+    }
+
+    private func defaultColumnIds(for group: LibraryColumnVisibilityGroup) -> [String] {
+        switch group {
+        case .artist: return BrowserColumn.defaultArtistColumnIds
+        case .album: return BrowserColumn.defaultAlbumColumnIds
+        case .track: return BrowserColumn.defaultTrackColumnIds
+        }
+    }
+
+    private func visibleColumnIds(for group: LibraryColumnVisibilityGroup) -> [String] {
+        switch group {
+        case .artist: return normalizedColumnIds(visibleArtistColumnIds, allColumns: BrowserColumn.allArtistColumns)
+        case .album: return normalizedColumnIds(visibleAlbumColumnIds, allColumns: BrowserColumn.allAlbumColumns)
+        case .track: return normalizedColumnIds(visibleTrackColumnIds, allColumns: BrowserColumn.allTrackColumns)
+        }
+    }
+
+    private func setVisibleColumnIds(_ ids: [String], for group: LibraryColumnVisibilityGroup) {
+        switch group {
+        case .artist:
+            visibleArtistColumnIds = normalizedColumnIds(ids, allColumns: BrowserColumn.allArtistColumns)
+        case .album:
+            visibleAlbumColumnIds = normalizedColumnIds(ids, allColumns: BrowserColumn.allAlbumColumns)
+        case .track:
+            visibleTrackColumnIds = normalizedColumnIds(ids, allColumns: BrowserColumn.allTrackColumns)
+        }
+    }
+
+    private func toggleColumnVisibility(group: LibraryColumnVisibilityGroup, columnId: String, visible: Bool) {
+        guard columnId != "title" else { return }
+
+        var ids = visibleColumnIds(for: group)
+        if visible {
+            if !ids.contains(columnId) {
+                ids.append(columnId)
+            }
+        } else {
+            ids.removeAll { $0 == columnId }
+            if columnSortId == columnId { columnSortId = nil }
+        }
+
+        setVisibleColumnIds(ids, for: group)
+        needsDisplay = true
+    }
+
+    @objc private func resetColumnGroup(_ sender: NSMenuItem) {
+        guard let rawValue = sender.representedObject as? String,
+              let group = LibraryColumnVisibilityGroup(rawValue: rawValue) else { return }
+
+        setVisibleColumnIds(defaultColumnIds(for: group), for: group)
+        let columnIds = Set(allColumns(for: group).map { $0.id })
+        columnWidths = columnWidths.filter { !columnIds.contains($0.key) }
+        needsDisplay = true
     }
     
     /// Show the visualizer effect selection menu
@@ -16873,24 +17062,41 @@ private struct BrowserColumn {
     static let playCount = BrowserColumn(id: "plays", title: "Plays", minWidth: 45)
     static let dateAdded = BrowserColumn(id: "dateAdded", title: "Date Added", minWidth: 80)
     static let lastPlayed = BrowserColumn(id: "lastPlayed", title: "Last Played", minWidth: 80)
-    
-    /// Columns shown for track lists
-    static let trackColumns: [BrowserColumn] = [
-        .trackNumber, .title, .artist, .album, .rating, .year, .genre, .duration, .bitrate, .size, .playCount, .dateAdded, .lastPlayed
+    static let discNumber = BrowserColumn(id: "discNum", title: "Disc", minWidth: 35)
+    static let albumArtist = BrowserColumn(id: "albumArtist", title: "Album Artist", minWidth: 100)
+    static let sampleRate = BrowserColumn(id: "sampleRate", title: "Sample Rate", minWidth: 60)
+    static let channels = BrowserColumn(id: "channels", title: "Channels", minWidth: 50)
+    static let filePath = BrowserColumn(id: "path", title: "Path", minWidth: 150)
+
+    static let allTrackColumns: [BrowserColumn] = [
+        .trackNumber, .title, .artist, .album, .albumArtist, .year, .genre, .duration,
+        .bitrate, .sampleRate, .channels, .size, .rating, .playCount, .discNumber,
+        .dateAdded, .lastPlayed, .filePath
     ]
     
-    /// Columns shown for album lists  
-    static let albumColumns: [BrowserColumn] = [
+    static let allAlbumColumns: [BrowserColumn] = [
         .title, .year, .genre, .duration, .rating
     ]
     
     // Artist-specific columns
     static let albums = BrowserColumn(id: "albums", title: "Albums", minWidth: 55)
     
-    /// Columns shown for artist lists
-    static let artistColumns: [BrowserColumn] = [
-        .title, .albums, .genre
+    static let allArtistColumns: [BrowserColumn] = [
+        .title, .rating, .albums, .genre
     ]
+
+    static let defaultTrackColumnIds: [String] = ["trackNum", "title", "artist", "album", "rating", "year", "genre", "duration", "bitrate", "size", "plays"]
+    static let defaultAlbumColumnIds: [String] = ["title", "year", "genre", "duration", "rating"]
+    static let defaultArtistColumnIds: [String] = ["title", "rating", "albums", "genre"]
+
+    /// Default columns shown for track lists.
+    static let trackColumns: [BrowserColumn] = defaultTrackColumnIds.compactMap { id in allTrackColumns.first { $0.id == id } }
+
+    /// Default columns shown for album lists.
+    static let albumColumns: [BrowserColumn] = defaultAlbumColumnIds.compactMap { id in allAlbumColumns.first { $0.id == id } }
+
+    /// Default columns shown for artist lists.
+    static let artistColumns: [BrowserColumn] = defaultArtistColumnIds.compactMap { id in allArtistColumns.first { $0.id == id } }
 
     /// Fixed columns shown for Internet Radio source.
     static let internetRadioColumns: [BrowserColumn] = [
@@ -16899,9 +17105,9 @@ private struct BrowserColumn {
     
     /// Find a column by ID across all column types
     static func findColumn(id: String) -> BrowserColumn? {
-        if let c = trackColumns.first(where: { $0.id == id }) { return c }
-        if let c = albumColumns.first(where: { $0.id == id }) { return c }
-        if let c = artistColumns.first(where: { $0.id == id }) { return c }
+        if let c = allTrackColumns.first(where: { $0.id == id }) { return c }
+        if let c = allAlbumColumns.first(where: { $0.id == id }) { return c }
+        if let c = allArtistColumns.first(where: { $0.id == id }) { return c }
         if let c = internetRadioColumns.first(where: { $0.id == id }) { return c }
         return nil
     }
@@ -16942,6 +17148,12 @@ extension PlexDisplayItem {
             return jellyfinAlbumValue(album, for: column)
         case .jellyfinArtist(let artist):
             return jellyfinArtistValue(artist, for: column)
+        case .embyTrack(let song):
+            return embyTrackValue(song, for: column)
+        case .embyAlbum(let album):
+            return embyAlbumValue(album, for: column)
+        case .embyArtist(let artist):
+            return embyArtistValue(artist, for: column)
         case .radioStation(let station):
             return radioStationValue(station, for: column)
         default:
@@ -16985,6 +17197,8 @@ extension PlexDisplayItem {
             return track.grandparentTitle ?? ""
         case "album":
             return track.parentTitle ?? ""
+        case "albumArtist":
+            return track.grandparentTitle ?? ""
         case "year":
             return track.parentYear.map { String($0) } ?? ""
         case "genre":
@@ -16993,16 +17207,24 @@ extension PlexDisplayItem {
             return track.formattedDuration
         case "bitrate":
             return track.media.first?.bitrate.map { "\($0)k" } ?? ""
+        case "sampleRate":
+            return track.media.first?.audioSampleRate.map { Self.formatSampleRate($0) } ?? ""
+        case "channels":
+            return track.media.first?.audioChannels.map { Self.formatChannels($0) } ?? ""
         case "size":
             return Self.formatFileSize(track.media.first?.parts.first?.size)
         case "rating":
             return Self.formatRating(track.userRating)
         case "plays":
             return track.ratingCount.map { String($0) } ?? ""
+        case "discNum":
+            return track.parentIndex.map { String($0) } ?? ""
         case "dateAdded":
             return track.addedAt.map { Self.formatDate($0) } ?? ""
         case "lastPlayed":
             return ""
+        case "path":
+            return track.media.first?.parts.first?.file?.components(separatedBy: "/").last ?? ""
         default:
             return ""
         }
@@ -17021,6 +17243,8 @@ extension PlexDisplayItem {
             return song.artist ?? ""
         case "album":
             return song.album ?? ""
+        case "albumArtist":
+            return song.albumArtist ?? song.artist ?? ""
         case "year":
             return song.year.map { String($0) } ?? ""
         case "genre":
@@ -17029,16 +17253,24 @@ extension PlexDisplayItem {
             return song.formattedDuration
         case "bitrate":
             return song.bitRate.map { "\($0)k" } ?? ""
+        case "sampleRate":
+            return song.samplingRate.map { Self.formatSampleRate($0) } ?? ""
+        case "channels":
+            return ""
         case "size":
             return Self.formatFileSize(song.size)
         case "rating":
             return Self.formatRating(song.userRating.map { Double($0 * 2) })
         case "plays":
             return song.playCount.map { String($0) } ?? ""
+        case "discNum":
+            return song.discNumber.map { String($0) } ?? ""
         case "dateAdded":
             return song.created.map { Self.formatDate($0) } ?? ""
         case "lastPlayed":
             return ""
+        case "path":
+            return song.path?.components(separatedBy: "/").last ?? ""
         default:
             return ""
         }
@@ -17057,6 +17289,8 @@ extension PlexDisplayItem {
             return track.artist ?? ""
         case "album":
             return track.album ?? ""
+        case "albumArtist":
+            return track.albumArtist ?? track.artist ?? ""
         case "year":
             return track.year.map { String($0) } ?? ""
         case "genre":
@@ -17065,16 +17299,24 @@ extension PlexDisplayItem {
             return track.formattedDuration
         case "bitrate":
             return track.bitrate.map { "\($0)k" } ?? ""
+        case "sampleRate":
+            return track.sampleRate.map { Self.formatSampleRate($0) } ?? ""
+        case "channels":
+            return track.channels.map { Self.formatChannels($0) } ?? ""
         case "size":
             return Self.formatFileSize(track.fileSize)
         case "rating":
             return Self.formatRating(track.rating.map { Double($0) })
         case "plays":
             return track.playCount > 0 ? String(track.playCount) : ""
+        case "discNum":
+            return track.discNumber.map { String($0) } ?? ""
         case "dateAdded":
             return Self.formatDate(track.dateAdded)
         case "lastPlayed":
             return track.lastPlayed.map { Self.formatDate($0) } ?? ""
+        case "path":
+            return track.url.lastPathComponent
         default:
             return ""
         }
@@ -17141,6 +17383,8 @@ extension PlexDisplayItem {
             return String(artist.albumCount)
         case "genre":
             return artist.genre ?? ""
+        case "rating":
+            return ""
         default:
             return ""
         }
@@ -17154,6 +17398,8 @@ extension PlexDisplayItem {
             return String(artist.albumCount)
         case "genre":
             return ""  // Subsonic artists don't have genre
+        case "rating":
+            return artist.starred != nil ? "★★★★★" : ""
         default:
             return ""
         }
@@ -17189,6 +17435,8 @@ extension PlexDisplayItem {
             return song.artist ?? ""
         case "album":
             return song.album ?? ""
+        case "albumArtist":
+            return song.albumArtist ?? song.artist ?? ""
         case "year":
             return song.year.map { String($0) } ?? ""
         case "genre":
@@ -17197,16 +17445,27 @@ extension PlexDisplayItem {
             return PlexDisplayItem.formatDuration(TimeInterval(song.duration))
         case "bitrate":
             return song.bitRate.map { "\($0)k" } ?? ""
+        case "sampleRate":
+            return song.sampleRate.map { Self.formatSampleRate($0) } ?? ""
+        case "channels":
+            return song.channels.map { Self.formatChannels($0) } ?? ""
         case "size":
-            return ""
+            return Self.formatFileSize(song.size)
         case "rating":
+            if let userRating = song.userRating, userRating > 0 {
+                return Self.formatRating(Double(userRating) / 10.0)
+            }
             return song.isFavorite ? "★★★★★" : ""
         case "plays":
             return song.playCount.map { String($0) } ?? ""
+        case "discNum":
+            return song.discNumber.map { String($0) } ?? ""
         case "dateAdded":
             return song.created.map { Self.formatDate($0) } ?? ""
         case "lastPlayed":
             return ""
+        case "path":
+            return song.path?.components(separatedBy: "/").last ?? ""
         default:
             return ""
         }
@@ -17221,9 +17480,9 @@ extension PlexDisplayItem {
         case "genre":
             return album.genre ?? ""
         case "duration":
-            return ""
+            return album.formattedDuration
         case "rating":
-            return ""
+            return album.isFavorite ? "★★★★★" : ""
         default:
             return ""
         }
@@ -17237,6 +17496,89 @@ extension PlexDisplayItem {
             return String(artist.albumCount)
         case "genre":
             return ""
+        case "rating":
+            return artist.isFavorite ? "★★★★★" : ""
+        default:
+            return ""
+        }
+    }
+
+    // MARK: - Emby Track Values
+
+    private func embyTrackValue(_ song: EmbySong, for column: BrowserColumn) -> String {
+        switch column.id {
+        case "trackNum":
+            if let disc = song.discNumber, disc > 1, let num = song.track {
+                return "\(disc)-\(num)"
+            }
+            return song.track.map { String($0) } ?? ""
+        case "artist":
+            return song.artist ?? ""
+        case "album":
+            return song.album ?? ""
+        case "albumArtist":
+            return song.albumArtist ?? song.artist ?? ""
+        case "year":
+            return song.year.map { String($0) } ?? ""
+        case "genre":
+            return song.genre ?? ""
+        case "duration":
+            return song.formattedDuration
+        case "bitrate":
+            return song.bitRate.map { "\($0)k" } ?? ""
+        case "sampleRate":
+            return song.sampleRate.map { Self.formatSampleRate($0) } ?? ""
+        case "channels":
+            return song.channels.map { Self.formatChannels($0) } ?? ""
+        case "size":
+            return Self.formatFileSize(song.size)
+        case "rating":
+            if let userRating = song.userRating, userRating > 0 {
+                return Self.formatRating(Double(userRating) / 10.0)
+            }
+            return song.isFavorite ? "★★★★★" : ""
+        case "plays":
+            return song.playCount.map { String($0) } ?? ""
+        case "discNum":
+            return song.discNumber.map { String($0) } ?? ""
+        case "dateAdded":
+            return song.created.map { Self.formatDate($0) } ?? ""
+        case "lastPlayed":
+            return ""
+        case "path":
+            return song.path?.components(separatedBy: "/").last ?? ""
+        default:
+            return ""
+        }
+    }
+
+    // MARK: - Emby Album Values
+
+    private func embyAlbumValue(_ album: EmbyAlbum, for column: BrowserColumn) -> String {
+        switch column.id {
+        case "year":
+            return album.year.map { String($0) } ?? ""
+        case "genre":
+            return album.genre ?? ""
+        case "duration":
+            return album.formattedDuration
+        case "rating":
+            return album.isFavorite ? "★★★★★" : ""
+        default:
+            return ""
+        }
+    }
+
+    // MARK: - Emby Artist Values
+
+    private func embyArtistValue(_ artist: EmbyArtist, for column: BrowserColumn) -> String {
+        switch column.id {
+        case "albums":
+            return String(artist.albumCount)
+        case "genre":
+            return ""
+        case "rating":
+            return artist.isFavorite ? "★★★★★" : ""
         default:
             return ""
         }
@@ -17285,6 +17627,24 @@ extension PlexDisplayItem {
     private static func formatStarRating(_ rating: Int) -> String {
         let clamped = min(5, max(0, rating))
         return String(repeating: "★", count: clamped) + String(repeating: "☆", count: 5 - clamped)
+    }
+
+    private static func formatSampleRate(_ hz: Int) -> String {
+        let khz = Double(hz) / 1000.0
+        if khz == Double(Int(khz)) {
+            return "\(Int(khz))k"
+        }
+        return String(format: "%.1fk", khz)
+    }
+
+    private static func formatChannels(_ count: Int) -> String {
+        switch count {
+        case 1: return "Mono"
+        case 2: return "Stereo"
+        case 6: return "5.1"
+        case 8: return "7.1"
+        default: return "\(count)ch"
+        }
     }
 
     private static let dateFormatter: DateFormatter = {

--- a/Sources/NullPlayer/Windows/PlexBrowser/PlexBrowserView.swift
+++ b/Sources/NullPlayer/Windows/PlexBrowser/PlexBrowserView.swift
@@ -41,7 +41,7 @@ enum BrowserSource: Equatable, Codable {
             return "INTERNET RADIO"
         }
     }
-    
+
     /// Short name for compact display
     var shortName: String {
         switch self {
@@ -332,6 +332,7 @@ class PlexBrowserView: NSView {
 
     /// Column being resized (id) and resize state
     private var resizingColumnId: String?
+    private var resizingColumnGroup: LibraryColumnVisibilityGroup?
     private var resizeStartX: CGFloat = 0
     private var resizeStartWidth: CGFloat = 0
     
@@ -427,26 +428,48 @@ class PlexBrowserView: NSView {
 
     private func hasArtistRows() -> Bool {
         displayItems.contains {
+            guard $0.indentLevel == 0 else { return false }
             switch $0.type {
             case .artist, .subsonicArtist, .localArtist, .jellyfinArtist, .embyArtist: return true
             default: return false
             }
         }
     }
-    
-    /// Get columns for a specific item (nil = use simple list rendering)
-    private func columnsForItem(_ item: PlexDisplayItem) -> [BrowserColumn]? {
+
+    private func columnGroup(for item: PlexDisplayItem) -> LibraryColumnVisibilityGroup? {
         switch item.type {
         case .track, .subsonicTrack, .localTrack, .jellyfinTrack, .embyTrack:
-            return visibleColumns(allColumns: BrowserColumn.allTrackColumns, visibleIds: visibleTrackColumnIds)
+            return .track
         case .album, .subsonicAlbum, .localAlbum, .jellyfinAlbum, .embyAlbum:
-            return visibleColumns(allColumns: BrowserColumn.allAlbumColumns, visibleIds: visibleAlbumColumnIds)
+            return .album
         case .artist, .subsonicArtist, .localArtist, .jellyfinArtist, .embyArtist:
-            // Only show columns for top-level artists (not nested under search results)
-            if item.indentLevel == 0 {
-                return visibleColumns(allColumns: BrowserColumn.allArtistColumns, visibleIds: visibleArtistColumnIds)
-            }
+            return item.indentLevel == 0 ? .artist : nil
+        default:
             return nil
+        }
+    }
+
+    private func currentColumnGroup() -> LibraryColumnVisibilityGroup? {
+        if hasTrackRows() { return .track }
+        if hasAlbumRows() { return .album }
+        if hasArtistRows() { return .artist }
+        return nil
+    }
+
+    /// Get columns for a specific item (nil = use simple list rendering)
+    private func columnsForItem(_ item: PlexDisplayItem) -> [BrowserColumn]? {
+        switch columnGroup(for: item) {
+        case .track:
+            return visibleColumns(allColumns: BrowserColumn.allTrackColumns, visibleIds: visibleTrackColumnIds)
+        case .album:
+            return visibleColumns(allColumns: BrowserColumn.allAlbumColumns, visibleIds: visibleAlbumColumnIds)
+        case .artist:
+            return visibleColumns(allColumns: BrowserColumn.allArtistColumns, visibleIds: visibleArtistColumnIds)
+        case nil:
+            break
+        }
+
+        switch item.type {
         case .radioStation:
             if isInternetRadioItem(item) {
                 return BrowserColumn.internetRadioColumns
@@ -458,28 +481,54 @@ class PlexBrowserView: NSView {
     }
     
     /// Get width for a column (uses stored width or default)
-    private func widthForColumn(_ column: BrowserColumn, availableWidth: CGFloat, columns: [BrowserColumn]) -> CGFloat {
+    private func columnWidthKey(_ columnId: String, group: LibraryColumnVisibilityGroup) -> String {
+        "\(group.rawValue):\(columnId)"
+    }
+
+    private func storedColumnWidth(for column: BrowserColumn, group: LibraryColumnVisibilityGroup?) -> CGFloat? {
+        guard let group else { return columnWidths[column.id] }
+        return columnWidths[columnWidthKey(column.id, group: group)]
+    }
+
+    private func setColumnWidth(_ width: CGFloat, for columnId: String, group: LibraryColumnVisibilityGroup) {
+        columnWidths[columnWidthKey(columnId, group: group)] = width
+    }
+
+    private func widthForColumn(
+        _ column: BrowserColumn,
+        availableWidth: CGFloat,
+        columns: [BrowserColumn],
+        group: LibraryColumnVisibilityGroup?
+    ) -> CGFloat {
         if column.id == "title" {
             // Title column gets remaining space
             let fixedWidth = columns.filter { $0.id != "title" }.reduce(0) { 
-                $0 + (columnWidths[$1.id] ?? $1.minWidth)
+                $0 + (storedColumnWidth(for: $1, group: group) ?? $1.minWidth)
             }
             return max(column.minWidth, availableWidth - fixedWidth - 8)
         }
-        return columnWidths[column.id] ?? column.minWidth
+        return storedColumnWidth(for: column, group: group) ?? column.minWidth
     }
     
     /// Calculate total width needed for all columns
-    private func totalColumnsWidth(columns: [BrowserColumn]) -> CGFloat {
+    private func totalColumnsWidth(columns: [BrowserColumn], group: LibraryColumnVisibilityGroup?) -> CGFloat {
         var total: CGFloat = 8  // Initial padding
         for column in columns {
             if column.id == "title" {
                 total += column.minWidth  // Title uses minWidth for total calculation
             } else {
-                total += columnWidths[column.id] ?? column.minWidth
+                total += storedColumnWidth(for: column, group: group) ?? column.minWidth
             }
         }
         return total
+    }
+
+    private func clampHorizontalScrollOffset() {
+        let columns = currentVisibleColumns()
+        let group = currentColumnGroup()
+        let availableWidth = originalWindowSize.width - Layout.leftBorder - Layout.rightBorder - Layout.scrollbarWidth - Layout.alphabetWidth
+        let maxOffset = max(0, totalColumnsWidth(columns: columns, group: group) - availableWidth)
+        horizontalScrollOffset = max(0, min(horizontalScrollOffset, maxOffset))
     }
     
     /// Save column widths to UserDefaults
@@ -490,8 +539,22 @@ class PlexBrowserView: NSView {
     /// Load column widths from UserDefaults
     private func loadColumnWidths() {
         if let saved = UserDefaults.standard.dictionary(forKey: "BrowserColumnWidths") as? [String: CGFloat] {
-            columnWidths = saved
+            columnWidths = migrateColumnWidths(saved)
         }
+    }
+
+    private func migrateColumnWidths(_ saved: [String: CGFloat]) -> [String: CGFloat] {
+        var migrated: [String: CGFloat] = [:]
+        for (key, width) in saved {
+            if key.contains(":") {
+                migrated[key] = width
+                continue
+            }
+            for group in LibraryColumnVisibilityGroup.allCases where allColumns(for: group).contains(where: { $0.id == key }) {
+                migrated[columnWidthKey(key, group: group)] = width
+            }
+        }
+        return migrated
     }
 
     private func saveVisibleColumns() {
@@ -522,7 +585,10 @@ class PlexBrowserView: NSView {
         if hasAlbumRows() {
             return visibleColumns(allColumns: BrowserColumn.allAlbumColumns, visibleIds: visibleAlbumColumnIds)
         }
-        return visibleColumns(allColumns: BrowserColumn.allArtistColumns, visibleIds: visibleArtistColumnIds)
+        if hasArtistRows() {
+            return visibleColumns(allColumns: BrowserColumn.allArtistColumns, visibleIds: visibleArtistColumnIds)
+        }
+        return []
     }
     
     /// Apply column sort to display items
@@ -610,10 +676,16 @@ class PlexBrowserView: NSView {
             
             // Try numeric comparison for numeric columns
             if sortColumn.id == "trackNum" || sortColumn.id == "year" || sortColumn.id == "plays" ||
-               sortColumn.id == "albums" || sortColumn.id == "discNum" || sortColumn.id == "channels" {
+               sortColumn.id == "albums" || sortColumn.id == "discNum" {
                 let aNum = Int(aVal.components(separatedBy: "-").last ?? aVal) ?? 0
                 let bNum = Int(bVal.components(separatedBy: "-").last ?? bVal) ?? 0
                 return ascending ? aNum < bNum : aNum > bNum
+            }
+
+            if sortColumn.id == "channels" {
+                let aChannels = LibraryColumnVisibility.channelSortValue(aVal)
+                let bChannels = LibraryColumnVisibility.channelSortValue(bVal)
+                return ascending ? aChannels < bChannels : aChannels > bChannels
             }
             
             // Duration comparison (convert to seconds)
@@ -3259,7 +3331,8 @@ class PlexBrowserView: NSView {
         let totalWidth = rect.width
         
         // Calculate total columns width to determine if horizontal scroll is needed
-        let columnsWidth = totalColumnsWidth(columns: columns)
+        let group = currentColumnGroup()
+        let columnsWidth = totalColumnsWidth(columns: columns, group: group)
         let maxHorizontalScroll = max(0, columnsWidth - totalWidth)
         
         // Clamp horizontal scroll offset
@@ -3285,7 +3358,7 @@ class PlexBrowserView: NSView {
         
         var x = rect.minX + 4 - horizontalScrollOffset
         for (index, column) in columns.enumerated() {
-            let width = widthForColumn(column, availableWidth: totalWidth, columns: columns)
+            let width = widthForColumn(column, availableWidth: totalWidth, columns: columns, group: group)
             let isCenteredRadioColumn = (browseMode == .radio && column.id == "genre") ||
                 (hasInternetRadioColumns && column.id == "rating")
             
@@ -3359,8 +3432,9 @@ class PlexBrowserView: NSView {
         let smallFont = NSFont.systemFont(ofSize: 9)
         
         var x = rect.minX + indent + 4 - horizontalScrollOffset
+        let group = columnGroup(for: item)
         for column in columns {
-            let width = widthForColumn(column, availableWidth: totalWidth, columns: columns)
+            let width = widthForColumn(column, availableWidth: totalWidth, columns: columns, group: group)
             let value = item.columnValue(for: column)
             let isCenteredRadioColumn = (browseMode == .radio && column.id == "genre") ||
                 (isInternetRadioItem(item) && column.id == "rating")
@@ -6772,8 +6846,9 @@ class PlexBrowserView: NSView {
         let indent = CGFloat(item.indentLevel) * 16
         let availableWidth = rowRect.width - indent
         var x = rowRect.minX + indent + 4 - horizontalScrollOffset
+        let group = columnGroup(for: item)
         for column in columns {
-            let width = widthForColumn(column, availableWidth: availableWidth, columns: columns)
+            let width = widthForColumn(column, availableWidth: availableWidth, columns: columns, group: group)
             if column.id == "rating" {
                 let cellRect = NSRect(x: x, y: rowRect.minY, width: width, height: rowRect.height)
                 guard cellRect.contains(skinPoint) else { return nil }
@@ -6808,13 +6883,14 @@ class PlexBrowserView: NSView {
         guard headerRect.contains(skinPoint) else { return nil }
         
         guard let columns = headerColumnsForCurrentContent() else { return nil }
+        let group = currentColumnGroup()
         
         // Check if near a column separator (within 4 pixels)
         var x = headerRect.minX + 4
         let hitMargin: CGFloat = 4
         
         for (index, column) in columns.enumerated() {
-            let width = widthForColumn(column, availableWidth: headerRect.width, columns: columns)
+            let width = widthForColumn(column, availableWidth: headerRect.width, columns: columns, group: group)
             let separatorX = x + width
             
             // Check if click is near the separator (except for last column)
@@ -6853,12 +6929,13 @@ class PlexBrowserView: NSView {
         }
         
         guard let columns = headerColumnsForCurrentContent() else { return nil }
+        let group = currentColumnGroup()
         
         // Find which column was clicked
         var x = headerRect.minX + 4
         
         for column in columns {
-            let width = widthForColumn(column, availableWidth: headerRect.width, columns: columns)
+            let width = widthForColumn(column, availableWidth: headerRect.width, columns: columns, group: group)
             if skinPoint.x >= x && skinPoint.x < x + width {
                 return column.id
             }
@@ -7079,6 +7156,7 @@ class PlexBrowserView: NSView {
         }
 
         setVisibleColumnIds(ids, for: group)
+        clampHorizontalScrollOffset()
         needsDisplay = true
     }
 
@@ -7087,8 +7165,9 @@ class PlexBrowserView: NSView {
               let group = LibraryColumnVisibilityGroup(rawValue: rawValue) else { return }
 
         setVisibleColumnIds(defaultColumnIds(for: group), for: group)
-        let columnIds = Set(allColumns(for: group).map { $0.id })
-        columnWidths = columnWidths.filter { !columnIds.contains($0.key) }
+        let prefix = "\(group.rawValue):"
+        columnWidths = columnWidths.filter { !$0.key.hasPrefix(prefix) }
+        clampHorizontalScrollOffset()
         needsDisplay = true
     }
     
@@ -7432,8 +7511,17 @@ class PlexBrowserView: NSView {
         // Check for column resize
         if let columnId = hitTestColumnResize(at: skinPoint) {
             resizingColumnId = columnId
+            resizingColumnGroup = currentColumnGroup()
             resizeStartX = skinPoint.x
-            resizeStartWidth = columnWidths[columnId] ?? BrowserColumn.findColumn(id: columnId)?.minWidth ?? 50
+            let group = resizingColumnGroup
+            let columns = currentVisibleColumns()
+            let headerWidth = originalWindowSize.width - Layout.leftBorder - Layout.rightBorder - Layout.scrollbarWidth - Layout.alphabetWidth
+            resizeStartWidth = widthForColumn(
+                BrowserColumn.findColumn(id: columnId) ?? .title,
+                availableWidth: headerWidth,
+                columns: columns,
+                group: group
+            )
             NSCursor.resizeLeftRight.push()
             return
         }
@@ -8742,13 +8830,13 @@ class PlexBrowserView: NSView {
     
     override func mouseDragged(with event: NSEvent) {
         // Handle column resize dragging
-        if let columnId = resizingColumnId {
+        if let columnId = resizingColumnId, let group = resizingColumnGroup {
             let point = convert(event.locationInWindow, from: nil)
             let skinPoint = convertToSkinCoordinates(point)
             let deltaX = skinPoint.x - resizeStartX
             let minWidth = BrowserColumn.findColumn(id: columnId)?.minWidth ?? 30
             let newWidth = max(minWidth, resizeStartWidth + deltaX)
-            columnWidths[columnId] = newWidth
+            setColumnWidth(newWidth, for: columnId, group: group)
             needsDisplay = true
             return
         }
@@ -8806,6 +8894,7 @@ class PlexBrowserView: NSView {
         // End column resizing
         if resizingColumnId != nil {
             resizingColumnId = nil
+            resizingColumnGroup = nil
             NSCursor.pop()
         }
         
@@ -8880,31 +8969,16 @@ class PlexBrowserView: NSView {
         let listHeight = originalWindowSize.height - listY - Layout.statusBarHeight
         let totalHeight = CGFloat(displayItems.count) * itemHeight
         
-        // Determine which columns are active for horizontal scroll calculation
-        let columns: [BrowserColumn]?
-        if displayItems.contains(where: { 
-            switch $0.type { case .track, .subsonicTrack, .localTrack, .jellyfinTrack: return true; default: return false }
-        }) {
-            columns = BrowserColumn.trackColumns
-        } else if displayItems.contains(where: {
-            switch $0.type { case .album, .subsonicAlbum, .localAlbum, .jellyfinAlbum: return true; default: return false }
-        }) {
-            columns = BrowserColumn.albumColumns
-        } else if displayItems.contains(where: {
-            switch $0.type { case .artist, .subsonicArtist, .localArtist, .jellyfinArtist: return true; default: return false }
-        }) {
-            columns = BrowserColumn.artistColumns
-        } else {
-            columns = nil
-        }
+        let columns = currentVisibleColumns()
+        let group = currentColumnGroup()
         
         var needsRedraw = false
         
         // Handle horizontal scrolling (shift+scroll or trackpad horizontal gesture)
-        if let cols = columns, (event.modifierFlags.contains(.shift) || abs(event.deltaX) > abs(event.deltaY)) {
+        if !columns.isEmpty, (event.modifierFlags.contains(.shift) || abs(event.deltaX) > abs(event.deltaY)) {
             let alphabetWidth = Layout.alphabetWidth
             let availableWidth = originalWindowSize.width - Layout.leftBorder - Layout.rightBorder - Layout.scrollbarWidth - alphabetWidth
-            let columnsWidth = totalColumnsWidth(columns: cols)
+            let columnsWidth = totalColumnsWidth(columns: columns, group: group)
             let maxHorizontalScroll = max(0, columnsWidth - availableWidth)
             
             if maxHorizontalScroll > 0 {
@@ -17224,7 +17298,7 @@ extension PlexDisplayItem {
         case "lastPlayed":
             return ""
         case "path":
-            return track.media.first?.parts.first?.file?.components(separatedBy: "/").last ?? ""
+            return track.media.first?.parts.first?.file ?? ""
         default:
             return ""
         }
@@ -17270,7 +17344,7 @@ extension PlexDisplayItem {
         case "lastPlayed":
             return ""
         case "path":
-            return song.path?.components(separatedBy: "/").last ?? ""
+            return song.path ?? ""
         default:
             return ""
         }
@@ -17316,7 +17390,7 @@ extension PlexDisplayItem {
         case "lastPlayed":
             return track.lastPlayed.map { Self.formatDate($0) } ?? ""
         case "path":
-            return track.url.lastPathComponent
+            return track.url.path
         default:
             return ""
         }
@@ -17465,7 +17539,7 @@ extension PlexDisplayItem {
         case "lastPlayed":
             return ""
         case "path":
-            return song.path?.components(separatedBy: "/").last ?? ""
+            return song.path ?? ""
         default:
             return ""
         }
@@ -17546,7 +17620,7 @@ extension PlexDisplayItem {
         case "lastPlayed":
             return ""
         case "path":
-            return song.path?.components(separatedBy: "/").last ?? ""
+            return song.path ?? ""
         default:
             return ""
         }

--- a/Sources/NullPlayer/Windows/Shared/ColumnVisibilityCheckboxView.swift
+++ b/Sources/NullPlayer/Windows/Shared/ColumnVisibilityCheckboxView.swift
@@ -1,0 +1,42 @@
+import AppKit
+
+final class ColumnVisibilityCheckboxView: NSView {
+    private let button: NSButton
+    private let onToggle: (Bool) -> Void
+
+    init(title: String, isChecked: Bool, isEnabled: Bool = true, onToggle: @escaping (Bool) -> Void) {
+        self.button = NSButton(checkboxWithTitle: title, target: nil, action: nil)
+        self.onToggle = onToggle
+        button.state = isChecked ? .on : .off
+        button.isEnabled = isEnabled
+        button.font = NSFont.menuFont(ofSize: 0)
+        button.sizeToFit()
+
+        let frame = NSRect(x: 0, y: 0, width: max(220, button.frame.width + 32), height: 24)
+        super.init(frame: frame)
+
+        button.target = self
+        button.action = #selector(toggleFromButton)
+        button.frame.origin = NSPoint(x: 16, y: (frame.height - button.frame.height) / 2)
+        button.autoresizingMask = [.width, .height]
+        addSubview(button)
+    }
+
+    required init?(coder: NSCoder) {
+        fatalError("init(coder:) has not been implemented")
+    }
+
+    override func mouseDown(with event: NSEvent) {
+        guard button.isEnabled else { return }
+        setChecked(button.state != .on)
+    }
+
+    @objc private func toggleFromButton() {
+        onToggle(button.state == .on)
+    }
+
+    private func setChecked(_ checked: Bool) {
+        button.state = checked ? .on : .off
+        onToggle(checked)
+    }
+}

--- a/Sources/NullPlayer/Windows/Shared/ColumnVisibilityCheckboxView.swift
+++ b/Sources/NullPlayer/Windows/Shared/ColumnVisibilityCheckboxView.swift
@@ -18,7 +18,7 @@ final class ColumnVisibilityCheckboxView: NSView {
         button.target = self
         button.action = #selector(toggleFromButton)
         button.frame.origin = NSPoint(x: 16, y: (frame.height - button.frame.height) / 2)
-        button.autoresizingMask = [.width, .height]
+        button.autoresizingMask = []
         addSubview(button)
     }
 

--- a/Sources/NullPlayer/Windows/Shared/LibraryColumnVisibility.swift
+++ b/Sources/NullPlayer/Windows/Shared/LibraryColumnVisibility.swift
@@ -73,4 +73,19 @@ enum LibraryColumnVisibility {
         }
         return []
     }
+
+    static func channelSortValue(_ label: String) -> Double {
+        switch label {
+        case "Mono": return 1
+        case "Stereo": return 2
+        case "5.1": return 6
+        case "7.1": return 8
+        default:
+            let decimalSeparator = UnicodeScalar(".")
+            let numeric = label.unicodeScalars.filter {
+                CharacterSet.decimalDigits.contains($0) || $0 == decimalSeparator
+            }
+            return Double(String(String.UnicodeScalarView(numeric))) ?? 0
+        }
+    }
 }

--- a/Sources/NullPlayer/Windows/Shared/LibraryColumnVisibility.swift
+++ b/Sources/NullPlayer/Windows/Shared/LibraryColumnVisibility.swift
@@ -1,0 +1,76 @@
+import Foundation
+
+enum LibraryColumnVisibilityGroup: String, CaseIterable {
+    case artist
+    case album
+    case track
+
+    var headerTitle: String {
+        switch self {
+        case .artist: return "Artist columns"
+        case .album: return "Album columns"
+        case .track: return "Track columns"
+        }
+    }
+
+    var resetTitle: String {
+        switch self {
+        case .artist: return "Reset Artist Columns"
+        case .album: return "Reset Album Columns"
+        case .track: return "Reset Track Columns"
+        }
+    }
+}
+
+enum LibraryColumnVisibility {
+    static func normalizedIds(_ visibleIds: [String], allIds: [String]) -> [String] {
+        let validIds = Set(allIds)
+        var normalizedIds: [String] = []
+
+        for id in visibleIds where validIds.contains(id) && !normalizedIds.contains(id) {
+            normalizedIds.append(id)
+        }
+
+        if validIds.contains("title"), !normalizedIds.contains("title") {
+            normalizedIds.insert("title", at: 0)
+        }
+
+        return normalizedIds
+    }
+
+    static func visibleColumns<Column>(
+        allColumns: [Column],
+        visibleIds: [String],
+        id: (Column) -> String
+    ) -> [Column] {
+        let normalized = normalizedIds(visibleIds, allIds: allColumns.map(id))
+        return normalized.compactMap { columnId in
+            allColumns.first { id($0) == columnId }
+        }
+    }
+
+    static func menuGroups(
+        isArtistsMode: Bool,
+        isAlbumsMode: Bool,
+        hasTrackRows: Bool,
+        hasAlbumRows: Bool,
+        hasArtistRows: Bool
+    ) -> [LibraryColumnVisibilityGroup] {
+        if isArtistsMode {
+            return [.artist, .album, .track]
+        }
+        if isAlbumsMode {
+            return [.album, .track]
+        }
+        if hasTrackRows {
+            return [.track]
+        }
+        if hasAlbumRows {
+            return [.album]
+        }
+        if hasArtistRows {
+            return [.artist]
+        }
+        return []
+    }
+}

--- a/Tests/NullPlayerAppTests/LibraryColumnVisibilityTests.swift
+++ b/Tests/NullPlayerAppTests/LibraryColumnVisibilityTests.swift
@@ -108,4 +108,12 @@ final class LibraryColumnVisibilityTests: XCTestCase {
         XCTAssertEqual(LibraryColumnVisibilityGroup.album.resetTitle, "Reset Album Columns")
         XCTAssertEqual(LibraryColumnVisibilityGroup.track.resetTitle, "Reset Track Columns")
     }
+
+    func testChannelSortValueMapsFormattedLabelsToComparableChannelCounts() {
+        XCTAssertEqual(LibraryColumnVisibility.channelSortValue("Mono"), 1)
+        XCTAssertEqual(LibraryColumnVisibility.channelSortValue("Stereo"), 2)
+        XCTAssertEqual(LibraryColumnVisibility.channelSortValue("5.1"), 6)
+        XCTAssertEqual(LibraryColumnVisibility.channelSortValue("7.1"), 8)
+        XCTAssertEqual(LibraryColumnVisibility.channelSortValue("10ch"), 10)
+    }
 }

--- a/Tests/NullPlayerAppTests/LibraryColumnVisibilityTests.swift
+++ b/Tests/NullPlayerAppTests/LibraryColumnVisibilityTests.swift
@@ -1,0 +1,111 @@
+import XCTest
+@testable import NullPlayer
+
+final class LibraryColumnVisibilityTests: XCTestCase {
+    private struct TestColumn {
+        let id: String
+    }
+
+    func testNormalizedIdsFiltersUnknownIdsDeduplicatesAndRestoresTitle() {
+        let ids = LibraryColumnVisibility.normalizedIds(
+            ["genre", "unknown", "genre", "rating"],
+            allIds: ["title", "artist", "genre", "rating"]
+        )
+
+        XCTAssertEqual(ids, ["title", "genre", "rating"])
+    }
+
+    func testNormalizedIdsPreservesExistingTitlePosition() {
+        let ids = LibraryColumnVisibility.normalizedIds(
+            ["genre", "title", "artist"],
+            allIds: ["title", "artist", "genre"]
+        )
+
+        XCTAssertEqual(ids, ["genre", "title", "artist"])
+    }
+
+    func testVisibleColumnsReturnsNormalizedColumnsInVisibleOrder() {
+        let columns = [
+            TestColumn(id: "title"),
+            TestColumn(id: "artist"),
+            TestColumn(id: "album"),
+            TestColumn(id: "rating")
+        ]
+
+        let visible = LibraryColumnVisibility.visibleColumns(
+            allColumns: columns,
+            visibleIds: ["rating", "missing", "artist", "rating"],
+            id: { $0.id }
+        )
+
+        XCTAssertEqual(visible.map(\.id), ["title", "rating", "artist"])
+    }
+
+    func testArtistsModeMenuIncludesArtistAlbumAndTrackSections() {
+        let groups = LibraryColumnVisibility.menuGroups(
+            isArtistsMode: true,
+            isAlbumsMode: false,
+            hasTrackRows: false,
+            hasAlbumRows: false,
+            hasArtistRows: true
+        )
+
+        XCTAssertEqual(groups, [.artist, .album, .track])
+    }
+
+    func testAlbumsModeMenuIncludesAlbumAndTrackSections() {
+        let groups = LibraryColumnVisibility.menuGroups(
+            isArtistsMode: false,
+            isAlbumsMode: true,
+            hasTrackRows: false,
+            hasAlbumRows: true,
+            hasArtistRows: false
+        )
+
+        XCTAssertEqual(groups, [.album, .track])
+    }
+
+    func testFallbackMenuGroupUsesCurrentRowTypePrecedence() {
+        XCTAssertEqual(
+            LibraryColumnVisibility.menuGroups(
+                isArtistsMode: false,
+                isAlbumsMode: false,
+                hasTrackRows: true,
+                hasAlbumRows: true,
+                hasArtistRows: true
+            ),
+            [.track]
+        )
+
+        XCTAssertEqual(
+            LibraryColumnVisibility.menuGroups(
+                isArtistsMode: false,
+                isAlbumsMode: false,
+                hasTrackRows: false,
+                hasAlbumRows: true,
+                hasArtistRows: true
+            ),
+            [.album]
+        )
+
+        XCTAssertEqual(
+            LibraryColumnVisibility.menuGroups(
+                isArtistsMode: false,
+                isAlbumsMode: false,
+                hasTrackRows: false,
+                hasAlbumRows: false,
+                hasArtistRows: true
+            ),
+            [.artist]
+        )
+    }
+
+    func testColumnVisibilityGroupMenuLabelsMatchUserFacingSections() {
+        XCTAssertEqual(LibraryColumnVisibilityGroup.artist.headerTitle, "Artist columns")
+        XCTAssertEqual(LibraryColumnVisibilityGroup.album.headerTitle, "Album columns")
+        XCTAssertEqual(LibraryColumnVisibilityGroup.track.headerTitle, "Track columns")
+        XCTAssertEqual(LibraryColumnVisibilityGroup.artist.resetTitle, "Reset Artist Columns")
+        XCTAssertEqual(LibraryColumnVisibilityGroup.album.resetTitle, "Reset Album Columns")
+        XCTAssertEqual(LibraryColumnVisibilityGroup.track.resetTitle, "Reset Track Columns")
+    }
+}

--- a/skills/ui-guide/SKILL.md
+++ b/skills/ui-guide/SKILL.md
@@ -194,6 +194,7 @@ When adding or refactoring top menu bar content:
 - Keep side effects (network discovery, long-running work) out of menu construction.
 - Prefer lifecycle startup for services and `menuNeedsUpdate(_:)` for state refresh when a menu opens.
 - For Sonos room selection UX, use `SonosRoomCheckboxView` when persistent-open submenu behavior is required.
+- For library-browser column visibility menus, use `ColumnVisibilityCheckboxView` for persistent-open checkbox rows. Keep column preferences mode-scoped: Modern uses `BrowserVisible*Columns`; Classic uses `ClassicBrowserVisible*Columns`.
 
 ## Dockable Center-Stack Windows
 

--- a/skills/user-guide/SKILL.md
+++ b/skills/user-guide/SKILL.md
@@ -327,6 +327,7 @@ Port of Ryan Geiss's classic Winamp visualization. ProjectM-peer engine — sele
 - **Enter**: Play Now (insert and play)
 - **Shift+Enter**: Play Next (insert after current, no auto-play if empty)
 - **Option+Enter**: Add to Queue (append, no auto-play if empty)
+- **Right-click column headers**: Configure visible columns. Artists shows Artist, Album, and Track sections; Albums shows Album and Track sections. Checkbox clicks keep the menu open; each section has its own reset.
 - **Right Arrow**: Expand item (artists, albums, playlists, shows, seasons); if already expanded, move to first child
 - **Left Arrow**: Collapse expanded item; if not expanded, jump to parent item
 - **Tab / Shift+Tab**: Cycle forward/backward through tabs (Artists → Albums → Playlists (Plists in the UI) → Movies → Shows → Search → Radio → Data)


### PR DESCRIPTION
## Summary
- add persistent column visibility settings to the classic library browser using ClassicBrowserVisible*Columns keys
- make classic and modern library header menus sectioned for Artist, Album, and Track columns, with persistent-open checkbox rows and per-section resets
- expand classic column metadata/value extraction to match modern track, album, and artist inventories; document the new behavior in the repo skills and changelog

## Tests
- swift build
- swift test

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Library browser columns configurable in both Classic and Modern modes with separate visibility per mode; Title stays locked.
  * Right-click column headers show grouped checklists for Artists, Albums, and Tracks with per-group reset and persistent column widths per group.
  * New columns and improved column values: sample rate, channel count, disc number, album-artist and full file path displayed where available.

* **Documentation**
  * Updated keyboard/menu guidance for configuring library columns.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/ad-repo/nullplayer/pull/212?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->