### PR TITLE
Met Museum visualization: classic-mode hotkeys, per-engine prefs, v0.23.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,14 +1,26 @@
 # Changelog
 
-## 0.22.1
+## 0.23.0
+
+### New Features
+
+- **Met Museum Art visualization** — a new ProjectM-peer engine in the visualization window displays a slideshow of public-domain artwork from the Metropolitan Museum of Art's Open Access collection. Right-click and keyboard hotkeys (→ / Space next, ← previous, R random, F fullscreen) work in both classic and modern UI. The context menu exposes Department filtering, slideshow interval, transition style (Crossfade / Ken Burns / Beat Cut / Slide), transition duration, aspect mode (Fit / Fill / Stretch), Audio-Reactive Effects, Beat-Triggered Changes, and Show Attribution. Downloaded images are persisted to an on-disk cache and the Met API client throttles requests to stay under the public-API rate limit.
+- **Tripex visualization** — the ben-marsh/tripex Direct3D9 visualization is ported to OpenGL and integrated as another ProjectM-peer engine, selectable from the **Visualization Engine** submenu in both classic and modern UI. Audio is fed through a shared ring buffer; the engine port and renderer details are documented in the new `tripex-port` skill.
 
 ### Improvements
 
 - **Library browser columns are configurable across UI modes** — classic and modern library browsers now share the same Artist, Album, and Track column inventories, with sectioned right-click header menus for Artists and Albums. Classic column visibility persists separately from Modern, and the Title column remains locked on.
+- **Per-engine visualization preferences** — preferences for ProjectM, Geiss, Tripex, and Met Museum no longer share UserDefaults keys, so switching engines preserves each one's independent settings (active preset/effect/department, transition, aspect, audio-reactivity, etc.).
+- **Data tab — artist track drill-down** — selecting an artist in the Data tab now shows that artist's individual tracks with play counts and listen time. Track details are cleared before each stats refresh to prevent stale entries from a previous selection bleeding through.
+- **Data tab — unknown genres preserved** — tracks with missing or unknown genre metadata are now kept visible in the Data tab breakdown instead of being filtered out, with a reconcile tooltip explaining how unknown entries are grouped.
+- **Data tab — sparse sections collapsed** — list sections in the Data tab now collapse when they contain few entries, keeping the overview compact when a category has little data.
+- **Library source menu — local and radio separated** — the library source picker now lists local-library and internet-radio entries in distinct sections with a separator between them, matching the way casting and source contexts handle the two origins.
+- **Sonos cast preserved on source switch** — switching between library sources (local, Plex, Subsonic, Jellyfin, Emby, radio) no longer tears down an active Sonos cast session. The cast keeps streaming the current track and picks up the next track from the newly selected source.
 
 ### Bug Fixes
 
 - **Audio route-change exception guarded** — `AVAudioEngine` graph reconnects now catch Objective-C exceptions raised by `AVAudioEngine.connect(_:to:format:)` during route churn. A failed reconnect is deferred and retried through the existing audio graph recovery path instead of aborting the app.
+- **Sonos network-change recovery** — Sonos casts now survive Wi-Fi network/interface changes. `UPnPManager` watches the active network interface and, when it changes, refreshes the embedded media server's bind address and re-resolves Sonos devices on the new network instead of leaving the cast pointed at a dead address.
 
 ## 0.22.0
 

--- a/Sources/NullPlayer/Resources/Info.plist
+++ b/Sources/NullPlayer/Resources/Info.plist
@@ -15,7 +15,7 @@
     <key>CFBundleIconFile</key>
     <string>AppIcon</string>
     <key>CFBundleShortVersionString</key>
-    <string>0.22.1</string>
+    <string>0.23.0</string>
     <key>CFBundleVersion</key>
     <string>1</string>
     <key>LSMinimumSystemVersion</key>

--- a/Sources/NullPlayer/Visualization/MetMuseum/MetMuseumClient.swift
+++ b/Sources/NullPlayer/Visualization/MetMuseum/MetMuseumClient.swift
@@ -186,7 +186,7 @@ actor MetMuseumClient {
     }
 
     /// Helper to acquire permit, enforce minimum request spacing, run closure, then release
-    private func withPermit<T>(_ body: () async throws -> T) async rethrows -> T {
+    private func withPermit<T>(_ body: () async throws -> T) async throws -> T {
         await semaphore.acquire()
         // Enforce minimum spacing between requests to stay under the API's
         // throttle. Without this, two concurrent permits can fire back-to-back
@@ -195,7 +195,12 @@ actor MetMuseumClient {
         let delta = now.timeIntervalSince(lastRequestTime)
         if delta < minRequestSpacing {
             let wait = minRequestSpacing - delta
-            try? await Task.sleep(nanoseconds: UInt64(wait * 1_000_000_000))
+            do {
+                try await Task.sleep(nanoseconds: UInt64(wait * 1_000_000_000))
+            } catch {
+                await semaphore.release()
+                throw error
+            }
         }
         lastRequestTime = Date()
         do {

--- a/Sources/NullPlayer/Visualization/MetMuseum/MetMuseumClient.swift
+++ b/Sources/NullPlayer/Visualization/MetMuseum/MetMuseumClient.swift
@@ -33,7 +33,12 @@ actor MetMuseumClient {
 
     private let urlSession: URLSession
     private let semaphore: AsyncSemaphore
-    private let maxConcurrent: Int = 5
+    // Met collection API is restricted; published guidance is 80 req/s but the
+    // edge throttles much more aggressively in practice. Keep this small.
+    private let maxConcurrent: Int = 2
+    // Minimum spacing between requests serialised through the same client.
+    private let minRequestSpacing: TimeInterval = 0.25
+    private var lastRequestTime: Date = .distantPast
 
     // MARK: - Timeouts
 
@@ -56,6 +61,12 @@ actor MetMuseumClient {
         let config = URLSessionConfiguration.default
         config.timeoutIntervalForRequest = 60.0
         config.timeoutIntervalForResource = 600.0
+        // Identify ourselves; the Met's CDN throttles requests with no/default
+        // User-Agent and frequently returns 403 to them.
+        config.httpAdditionalHeaders = [
+            "User-Agent": "NullPlayer/1.0 (Met Museum visualization; +https://github.com/billytimmy666/nullplayer)",
+            "Accept": "application/json, image/*"
+        ]
         self.urlSession = URLSession(configuration: config)
         self.semaphore = AsyncSemaphore(value: maxConcurrent)
     }
@@ -75,9 +86,11 @@ actor MetMuseumClient {
 
             let (data, response) = try await urlSession.data(for: request)
 
-            guard let httpResponse = response as? HTTPURLResponse,
-                  (200..<300).contains(httpResponse.statusCode) else {
-                throw NetworkError.httpError
+            let httpResponse = response as? HTTPURLResponse
+            let status = httpResponse?.statusCode ?? -1
+            guard (200..<300).contains(status) else {
+                let retryAfter = Self.parseRetryAfter(httpResponse?.value(forHTTPHeaderField: "Retry-After"))
+                throw NetworkError.httpError(status: status, url: urlString, retryAfter: retryAfter)
             }
 
             struct DepartmentsResponse: Codable {
@@ -107,9 +120,11 @@ actor MetMuseumClient {
 
             let (data, response) = try await urlSession.data(for: request)
 
-            guard let httpResponse = response as? HTTPURLResponse,
-                  (200..<300).contains(httpResponse.statusCode) else {
-                throw NetworkError.httpError
+            let httpResponse = response as? HTTPURLResponse
+            let status = httpResponse?.statusCode ?? -1
+            guard (200..<300).contains(status) else {
+                let retryAfter = Self.parseRetryAfter(httpResponse?.value(forHTTPHeaderField: "Retry-After"))
+                throw NetworkError.httpError(status: status, url: urlString, retryAfter: retryAfter)
             }
 
             let decoder = JSONDecoder()
@@ -132,9 +147,11 @@ actor MetMuseumClient {
 
             let (data, response) = try await urlSession.data(for: request)
 
-            guard let httpResponse = response as? HTTPURLResponse,
-                  (200..<300).contains(httpResponse.statusCode) else {
-                throw NetworkError.httpError
+            let httpResponse = response as? HTTPURLResponse
+            let status = httpResponse?.statusCode ?? -1
+            guard (200..<300).contains(status) else {
+                let retryAfter = Self.parseRetryAfter(httpResponse?.value(forHTTPHeaderField: "Retry-After"))
+                throw NetworkError.httpError(status: status, url: urlString, retryAfter: retryAfter)
             }
 
             let decoder = JSONDecoder()
@@ -157,18 +174,30 @@ actor MetMuseumClient {
 
             let (data, response) = try await urlSession.data(for: request)
 
-            guard let httpResponse = response as? HTTPURLResponse,
-                  (200..<300).contains(httpResponse.statusCode) else {
-                throw NetworkError.httpError
+            let httpResponse = response as? HTTPURLResponse
+            let status = httpResponse?.statusCode ?? -1
+            guard (200..<300).contains(status) else {
+                let retryAfter = Self.parseRetryAfter(httpResponse?.value(forHTTPHeaderField: "Retry-After"))
+                throw NetworkError.httpError(status: status, url: url.absoluteString, retryAfter: retryAfter)
             }
 
             return data
         }
     }
 
-    /// Helper to acquire permit, run closure, then release
+    /// Helper to acquire permit, enforce minimum request spacing, run closure, then release
     private func withPermit<T>(_ body: () async throws -> T) async rethrows -> T {
         await semaphore.acquire()
+        // Enforce minimum spacing between requests to stay under the API's
+        // throttle. Without this, two concurrent permits can fire back-to-back
+        // and trigger 429s under load.
+        let now = Date()
+        let delta = now.timeIntervalSince(lastRequestTime)
+        if delta < minRequestSpacing {
+            let wait = minRequestSpacing - delta
+            try? await Task.sleep(nanoseconds: UInt64(wait * 1_000_000_000))
+        }
+        lastRequestTime = Date()
         do {
             let result = try await body()
             await semaphore.release()
@@ -179,11 +208,30 @@ actor MetMuseumClient {
         }
     }
 
+    /// Parse a Retry-After header value (RFC 7231 — either a delta-seconds
+    /// integer or an HTTP-date). Returns seconds to wait, or nil if missing/malformed.
+    private static func parseRetryAfter(_ header: String?) -> TimeInterval? {
+        guard let header = header?.trimmingCharacters(in: .whitespaces), !header.isEmpty else {
+            return nil
+        }
+        if let seconds = TimeInterval(header) {
+            return max(0, seconds)
+        }
+        let formatter = DateFormatter()
+        formatter.locale = Locale(identifier: "en_US_POSIX")
+        formatter.timeZone = TimeZone(identifier: "GMT")
+        formatter.dateFormat = "EEE, dd MMM yyyy HH:mm:ss zzz"
+        if let date = formatter.date(from: header) {
+            return max(0, date.timeIntervalSinceNow)
+        }
+        return nil
+    }
+
     // MARK: - Error Types
 
     enum NetworkError: LocalizedError {
         case invalidURL
-        case httpError
+        case httpError(status: Int, url: String, retryAfter: TimeInterval?)
         case notPublicDomain
         case invalidImage
         case decodingError
@@ -192,8 +240,11 @@ actor MetMuseumClient {
             switch self {
             case .invalidURL:
                 return "Invalid URL constructed"
-            case .httpError:
-                return "HTTP request failed"
+            case .httpError(let status, let url, let retryAfter):
+                if let r = retryAfter {
+                    return "HTTP \(status) for \(url) (retry-after \(Int(r))s)"
+                }
+                return "HTTP \(status) for \(url)"
             case .notPublicDomain:
                 return "Object is not public domain"
             case .invalidImage:
@@ -201,6 +252,21 @@ actor MetMuseumClient {
             case .decodingError:
                 return "Failed to decode JSON response"
             }
+        }
+
+        /// True for transient errors (rate limit, server unavailable) — callers
+        /// should back off rather than retry quickly. The Met's CDN returns 403
+        /// for rate-limited clients (not 429), so 403 is treated as a throttle here.
+        var isThrottle: Bool {
+            if case .httpError(let status, _, _) = self {
+                return status == 403 || status == 429 || status == 503
+            }
+            return false
+        }
+
+        var retryAfter: TimeInterval? {
+            if case .httpError(_, _, let r) = self { return r }
+            return nil
         }
     }
 }

--- a/Sources/NullPlayer/Visualization/MetMuseum/MetMuseumClient.swift
+++ b/Sources/NullPlayer/Visualization/MetMuseum/MetMuseumClient.swift
@@ -1,0 +1,237 @@
+import Foundation
+import AppKit
+
+/// Met Museum Department model
+struct MetDepartment: Codable, Hashable {
+    let id: Int
+    let displayName: String
+
+    enum CodingKeys: String, CodingKey {
+        case id = "departmentId"
+        case displayName
+    }
+}
+
+/// Met Museum object/artwork model
+struct MetObject: Codable {
+    let objectID: Int
+    let title: String
+    let isPublicDomain: Bool
+    let primaryImage: String
+    let artistDisplayName: String?
+    let objectDate: String?
+}
+
+/// Network client for The Metropolitan Museum of Art API
+///
+/// Provides async access to museum collections with public domain filtering.
+/// Uses an actor-based semaphore to limit concurrent requests (max 5 concurrent).
+/// Handles timeouts gracefully and filters results to public domain objects only.
+actor MetMuseumClient {
+
+    // MARK: - Configuration
+
+    private let urlSession: URLSession
+    private let semaphore: AsyncSemaphore
+    private let maxConcurrent: Int = 5
+
+    // MARK: - Timeouts
+
+    private let shortTimeout: TimeInterval = 60.0
+    private let longTimeout: TimeInterval = 600.0
+
+    // MARK: - API Constants
+
+    private let baseURL = "https://collectionapi.metmuseum.org/public/collection/v1"
+
+    // MARK: - Types
+
+    struct ObjectsListResult: Codable {
+        let objectIDs: [Int]
+    }
+
+    // MARK: - Init
+
+    init() {
+        let config = URLSessionConfiguration.default
+        config.timeoutIntervalForRequest = 60.0
+        config.timeoutIntervalForResource = 600.0
+        self.urlSession = URLSession(configuration: config)
+        self.semaphore = AsyncSemaphore(value: maxConcurrent)
+    }
+
+    // MARK: - Public API
+
+    /// Fetch list of all departments
+    func fetchDepartments() async throws -> [MetDepartment] {
+        return try await withPermit {
+            let urlString = "\(baseURL)/departments"
+            guard let url = URL(string: urlString) else {
+                throw NetworkError.invalidURL
+            }
+
+            var request = URLRequest(url: url)
+            request.timeoutInterval = shortTimeout
+
+            let (data, response) = try await urlSession.data(for: request)
+
+            guard let httpResponse = response as? HTTPURLResponse,
+                  (200..<300).contains(httpResponse.statusCode) else {
+                throw NetworkError.httpError
+            }
+
+            struct DepartmentsResponse: Codable {
+                let departments: [MetDepartment]
+            }
+
+            let decoder = JSONDecoder()
+            let departmentsResp = try decoder.decode(DepartmentsResponse.self, from: data)
+            return departmentsResp.departments
+        }
+    }
+
+    /// Fetch object IDs for a department (nil = all departments)
+    func fetchObjectIDs(departmentID: Int?) async throws -> [Int] {
+        return try await withPermit {
+            var urlString = "\(baseURL)/objects"
+            if let deptID = departmentID {
+                urlString += "?departmentIds=\(deptID)"
+            }
+
+            guard let url = URL(string: urlString) else {
+                throw NetworkError.invalidURL
+            }
+
+            var request = URLRequest(url: url)
+            request.timeoutInterval = shortTimeout
+
+            let (data, response) = try await urlSession.data(for: request)
+
+            guard let httpResponse = response as? HTTPURLResponse,
+                  (200..<300).contains(httpResponse.statusCode) else {
+                throw NetworkError.httpError
+            }
+
+            let decoder = JSONDecoder()
+            let result = try decoder.decode(ObjectsListResult.self, from: data)
+            return result.objectIDs
+        }
+    }
+
+    /// Fetch detailed information for a specific object
+    /// Returns nil if object is not public domain or has no primary image
+    func fetchObject(id: Int) async throws -> MetObject? {
+        return try await withPermit {
+            let urlString = "\(baseURL)/objects/\(id)"
+            guard let url = URL(string: urlString) else {
+                throw NetworkError.invalidURL
+            }
+
+            var request = URLRequest(url: url)
+            request.timeoutInterval = shortTimeout
+
+            let (data, response) = try await urlSession.data(for: request)
+
+            guard let httpResponse = response as? HTTPURLResponse,
+                  (200..<300).contains(httpResponse.statusCode) else {
+                throw NetworkError.httpError
+            }
+
+            let decoder = JSONDecoder()
+            let object = try decoder.decode(MetObject.self, from: data)
+
+            // Return nil for non-public-domain or missing image
+            guard object.isPublicDomain, !object.primaryImage.isEmpty else {
+                return nil
+            }
+
+            return object
+        }
+    }
+
+    /// Download image from URL
+    func downloadImage(url: URL) async throws -> Data {
+        return try await withPermit {
+            var request = URLRequest(url: url)
+            request.timeoutInterval = longTimeout
+
+            let (data, response) = try await urlSession.data(for: request)
+
+            guard let httpResponse = response as? HTTPURLResponse,
+                  (200..<300).contains(httpResponse.statusCode) else {
+                throw NetworkError.httpError
+            }
+
+            return data
+        }
+    }
+
+    /// Helper to acquire permit, run closure, then release
+    private func withPermit<T>(_ body: () async throws -> T) async rethrows -> T {
+        await semaphore.acquire()
+        do {
+            let result = try await body()
+            await semaphore.release()
+            return result
+        } catch {
+            await semaphore.release()
+            throw error
+        }
+    }
+
+    // MARK: - Error Types
+
+    enum NetworkError: LocalizedError {
+        case invalidURL
+        case httpError
+        case notPublicDomain
+        case invalidImage
+        case decodingError
+
+        var errorDescription: String? {
+            switch self {
+            case .invalidURL:
+                return "Invalid URL constructed"
+            case .httpError:
+                return "HTTP request failed"
+            case .notPublicDomain:
+                return "Object is not public domain"
+            case .invalidImage:
+                return "Could not decode image data"
+            case .decodingError:
+                return "Failed to decode JSON response"
+            }
+        }
+    }
+}
+
+// MARK: - AsyncSemaphore Helper
+
+/// Simple actor-based semaphore for limiting concurrent requests
+private actor AsyncSemaphore {
+    private var inFlight: Int = 0
+    private let maxConcurrent: Int
+    private var waiters: [CheckedContinuation<Void, Never>] = []
+
+    init(value: Int) {
+        self.maxConcurrent = value
+        self.inFlight = 0
+    }
+
+    func acquire() async {
+        while inFlight >= maxConcurrent {
+            await withCheckedContinuation { continuation in
+                waiters.append(continuation)
+            }
+        }
+        inFlight += 1
+    }
+
+    func release() {
+        inFlight -= 1
+        if let waiter = waiters.first {
+            waiters.removeFirst()
+            waiter.resume()
+        }
+    }
+}

--- a/Sources/NullPlayer/Visualization/MetMuseum/MetMuseumEngine.swift
+++ b/Sources/NullPlayer/Visualization/MetMuseum/MetMuseumEngine.swift
@@ -68,6 +68,7 @@ final class MetMuseumEngine: VisualizationEngine {
     private var smoothedEnergy: Float = 0.0
     private let energyAlpha: Float = 0.15
     private var pendingBeatAdvance = false
+    private var fetchInFlight = false
 
     // Transition state
     private var transitionProgress: Float = 0.0
@@ -95,10 +96,18 @@ final class MetMuseumEngine: VisualizationEngine {
     private var energyUniform: GLint = -1
     private var audioReactiveUniform: GLint = -1
     private var attributionAlphaUniform: GLint = -1
+    private var attributionSizeUniform: GLint = -1
     private var imageStartTimeUniform: GLint = -1
+
+    // Actual attribution texture size, in pixels, for shader positioning
+    private var attributionTextureWidth: Int = 0
+    private var attributionTextureHeight: Int = 0
 
     // Pending upload queue
     private var pendingUploads: [(data: Data, objectID: Int)] = []
+    private var pendingAttributionUpload: (cgImage: CGImage, width: Int, height: Int)?
+    private var lastManualSkipTime: Date = .distantPast
+    private let manualSkipMinInterval: TimeInterval = 0.5
 
     // Image change tracking (for attribution fade)
     private var imageChangeTime: Date = Date()
@@ -114,7 +123,23 @@ final class MetMuseumEngine: VisualizationEngine {
         case loaded([MetDepartment])
         case failed
     }
-    private(set) var departmentsState: DepartmentsState = .loading
+    private var rawDepartmentsState: DepartmentsState = .loading
+    // Departments that returned no public-domain artwork; removed from the
+    // visible list and skipped by the slideshow.
+    private var excludedDepartmentIDs: Set<Int> = []
+
+    /// Departments with empty (no public-domain) entries filtered out.
+    var departmentsState: DepartmentsState {
+        coreLock.lock()
+        defer { coreLock.unlock() }
+        switch rawDepartmentsState {
+        case .loading, .failed:
+            return rawDepartmentsState
+        case .loaded(let depts):
+            let filtered = depts.filter { !excludedDepartmentIDs.contains($0.id) }
+            return .loaded(filtered)
+        }
+    }
 
     // Network retry state
     private var retryTaskActive = false
@@ -141,11 +166,11 @@ final class MetMuseumEngine: VisualizationEngine {
             do {
                 let depts = try await client.fetchDepartments()
                 coreLock.lock()
-                self.departmentsState = .loaded(depts)
+                self.rawDepartmentsState = .loaded(depts)
                 coreLock.unlock()
             } catch {
                 coreLock.lock()
-                self.departmentsState = .failed
+                self.rawDepartmentsState = .failed
                 coreLock.unlock()
                 NSLog("MetMuseumEngine: Failed to fetch departments: %@", error.localizedDescription)
             }
@@ -233,8 +258,25 @@ final class MetMuseumEngine: VisualizationEngine {
         }
         pendingUploads.removeAll()
 
+        // Process pending attribution texture upload on the GL thread
+        if let pending = pendingAttributionUpload {
+            pendingAttributionUpload = nil
+            if attributionTexture == 0 {
+                glGenTextures(1, &attributionTexture)
+                glBindTexture(GLenum(GL_TEXTURE_2D), attributionTexture)
+                glTexParameteri(GLenum(GL_TEXTURE_2D), GLenum(GL_TEXTURE_MIN_FILTER), GL_LINEAR)
+                glTexParameteri(GLenum(GL_TEXTURE_2D), GLenum(GL_TEXTURE_MAG_FILTER), GL_LINEAR)
+                glTexParameteri(GLenum(GL_TEXTURE_2D), GLenum(GL_TEXTURE_WRAP_S), GL_CLAMP_TO_EDGE)
+                glTexParameteri(GLenum(GL_TEXTURE_2D), GLenum(GL_TEXTURE_WRAP_T), GL_CLAMP_TO_EDGE)
+                glBindTexture(GLenum(GL_TEXTURE_2D), 0)
+            }
+            uploadCGImage(pending.cgImage, to: attributionTexture, width: pending.width, height: pending.height)
+            attributionTextureWidth = pending.cgImage.width
+            attributionTextureHeight = pending.cgImage.height
+        }
+
         // Advance on beat if flagged
-        if shouldAdvanceOnBeat && !isTransitioning {
+        if shouldAdvanceOnBeat && !isTransitioning && !fetchInFlight {
             advanceSlideshowImmediate()
         }
 
@@ -312,7 +354,16 @@ final class MetMuseumEngine: VisualizationEngine {
         } else {
             attributionAlpha = 0.0
         }
-        glUniform1f(attributionAlphaUniform, config.showAttribution ? attributionAlpha : 0.0)
+        // Only show the overlay when a real attribution texture is bound. Without
+        // this guard the shader samples an unbound texture (garbage) or smears
+        // the dark background of the previous overlay across a hard-coded rect.
+        let overlayActive = config.showAttribution && attributionTexture != 0 && attributionTextureWidth > 0 && attributionTextureHeight > 0
+        glUniform1f(attributionAlphaUniform, overlayActive ? attributionAlpha : 0.0)
+        if overlayActive {
+            glUniform2f(attributionSizeUniform, Float(attributionTextureWidth), Float(attributionTextureHeight))
+        } else {
+            glUniform2f(attributionSizeUniform, 0.0, 0.0)
+        }
 
         glBindVertexArray(vao)
         glDrawArrays(GLenum(GL_TRIANGLE_STRIP), 0, 4)
@@ -351,10 +402,19 @@ final class MetMuseumEngine: VisualizationEngine {
     }
 
     /// Immediately advance to a new random artwork. Safe to call from any thread.
+    /// Rate-limited so rapid key-mashing doesn't flood the Met API (which throttles).
     func skipToNextArtwork() {
         coreLock.lock()
         defer { coreLock.unlock() }
         guard isAvailable else { return }
+        // Drop the request if a fetch is already underway — prevents key-mashing
+        // from cancelling and re-issuing requests in a tight loop.
+        if fetchInFlight { return }
+        let now = Date()
+        if now.timeIntervalSince(lastManualSkipTime) < manualSkipMinInterval {
+            return
+        }
+        lastManualSkipTime = now
         advanceSlideshowImmediate()
     }
 
@@ -374,20 +434,35 @@ final class MetMuseumEngine: VisualizationEngine {
 
     private func startSlideshow() {
         slideshowTask?.cancel()
-        slideshowTask = Task {
+        // Task.detached so the slideshow loop is not born cancelled when
+        // started from inside another task (e.g. advanceSlideshowImmediate).
+        slideshowTask = Task.detached { [weak self] in
+            guard let self else { return }
             while !Task.isCancelled {
                 do {
-                    try await fetchAndDisplayRandomArtwork()
-                    try await Task.sleep(nanoseconds: UInt64(config.intervalSeconds * 1_000_000_000))
+                    try await self.fetchAndDisplayRandomArtwork()
+                    try await Task.sleep(nanoseconds: UInt64(self.getConfig().intervalSeconds * 1_000_000_000))
+                } catch is CancellationError {
+                    return
                 } catch {
                     NSLog("MetMuseumEngine slideshow error: %@", error.localizedDescription)
-                    // Exponential backoff retry: 1s, 2s, 4s. After exhausting, retry every 30s
+                    // For throttle errors honour Retry-After (or use a long
+                    // default) instead of hammering the API on the 1/2/4s ladder.
+                    let throttle = (error as? MetMuseumClient.NetworkError)?.isThrottle == true
+                    let retryAfter = (error as? MetMuseumClient.NetworkError)?.retryAfter
+                    let retryDelays: [Double]
+                    if throttle {
+                        let base = max(10.0, retryAfter ?? 30.0)
+                        retryDelays = [base, base * 2, base * 4]
+                    } else {
+                        retryDelays = [1.0, 2.0, 4.0]
+                    }
                     var success = false
-                    for retryDelay in [1.0, 2.0, 4.0] {
+                    for retryDelay in retryDelays {
                         if Task.isCancelled { break }
                         try? await Task.sleep(nanoseconds: UInt64(retryDelay * 1_000_000_000))
                         do {
-                            try await fetchAndDisplayRandomArtwork()
+                            try await self.fetchAndDisplayRandomArtwork()
                             success = true
                             break
                         } catch {
@@ -401,7 +476,7 @@ final class MetMuseumEngine: VisualizationEngine {
                             try? await Task.sleep(nanoseconds: 30_000_000_000)
                             if Task.isCancelled { break }
                             do {
-                                try await fetchAndDisplayRandomArtwork()
+                                try await self.fetchAndDisplayRandomArtwork()
                                 // Success, resume normal loop
                                 break
                             } catch {
@@ -414,45 +489,115 @@ final class MetMuseumEngine: VisualizationEngine {
         }
     }
 
+    /// Mark the currently-selected department as having no public-domain
+    /// artwork (we just exhausted the random-attempt loop). Switch the active
+    /// department to any remaining one, or to "all departments" if there's
+    /// nothing else to fall back to.
+    private func excludeCurrentDepartmentAndPickAnother() {
+        coreLock.lock()
+        defer { coreLock.unlock() }
+        guard let currentID = config.departmentID else {
+            // Already searching across all departments — nothing to exclude.
+            return
+        }
+        excludedDepartmentIDs.insert(currentID)
+        NSLog("MetMuseumEngine: department %d has no public-domain artwork; removing from list", currentID)
+
+        let remaining: [MetDepartment]
+        if case .loaded(let depts) = rawDepartmentsState {
+            remaining = depts.filter { !excludedDepartmentIDs.contains($0.id) }
+        } else {
+            remaining = []
+        }
+        let nextID = remaining.randomElement()?.id
+        // nil here means "all departments" — a safe fallback.
+        config.departmentID = nextID
+        let key = MetMuseumEngine.DefaultsKey.departmentID
+        if let nextID = nextID {
+            UserDefaults.standard.set(nextID, forKey: key)
+        } else {
+            UserDefaults.standard.removeObject(forKey: key)
+        }
+    }
+
     private func advanceSlideshowImmediate() {
         // Called from renderFrame under coreLock; trigger next fetch
-        // without waiting for the interval timer
+        // without waiting for the interval timer.
+        // Task.detached so the child task does not inherit cancellation
+        // from the parent context (see CLAUDE.md: regular Task { } inherits
+        // cancellation and would self-cancel when startSlideshow() runs below).
         slideshowTask?.cancel()
-        slideshowTask = Task {
+        slideshowTask = Task.detached { [weak self] in
+            guard let self else { return }
             do {
-                try await fetchAndDisplayRandomArtwork()
+                try await self.fetchAndDisplayRandomArtwork()
+            } catch is CancellationError {
+                return
             } catch {
                 NSLog("MetMuseumEngine beat-triggered advance error: %@", error.localizedDescription)
             }
-            // Resume normal slideshow
-            startSlideshow()
+            self.startSlideshow()
         }
     }
 
     private func fetchAndDisplayRandomArtwork() async throws {
+        coreLock.lock()
+        if fetchInFlight {
+            coreLock.unlock()
+            return
+        }
+        fetchInFlight = true
+        coreLock.unlock()
+        defer {
+            coreLock.lock()
+            fetchInFlight = false
+            coreLock.unlock()
+        }
+
         // Fetch list of object IDs for the department
         let objectIDs = try await client.fetchObjectIDs(departmentID: config.departmentID)
         guard !objectIDs.isEmpty else {
             throw MetMuseumError.noArtworkFound
         }
 
-        // Try random objects until we find a public-domain one with an image
-        let maxAttempts = min(20, objectIDs.count)
+        // Try random objects until we find a public-domain one with an image.
+        // Per-object errors (404, transient 403 throttle) don't kill the loop —
+        // they just count as a miss so we can keep looking. Throttle errors
+        // are re-thrown so the slideshow's outer backoff can wait properly.
+        let maxAttempts = min(40, objectIDs.count)
         var attempts = 0
         var selectedObject: MetObject?
+        var lastThrottleError: Error?
 
         while attempts < maxAttempts {
             let randomID = objectIDs.randomElement() ?? objectIDs.first!
             attempts += 1
 
-            if let obj = try await client.fetchObject(id: randomID) {
-                selectedObject = obj
+            do {
+                if let obj = try await client.fetchObject(id: randomID) {
+                    selectedObject = obj
+                    break
+                }
+            } catch let error as MetMuseumClient.NetworkError where error.isThrottle {
+                // Remember and bail out so the outer loop can back off.
+                lastThrottleError = error
                 break
+            } catch {
+                // Per-object miss (404, decode error, transient). Skip and try another.
+                continue
             }
-            // fetchObject returns nil for non-public-domain or missing image; continue loop
+        }
+
+        if let throttleError = lastThrottleError, selectedObject == nil {
+            throw throttleError
         }
 
         guard let objectInfo = selectedObject else {
+            // Exhausted attempts without finding a public-domain piece. Mark
+            // this department as empty so the menu hides it and the slideshow
+            // doesn't keep retrying it. Pick a different department for the
+            // next attempt.
+            excludeCurrentDepartmentAndPickAnother()
             throw MetMuseumError.noArtworkFound
         }
 
@@ -480,9 +625,11 @@ final class MetMuseumEngine: VisualizationEngine {
         pendingUploads.append((imageData, objectInfo.objectID))
         coreLock.unlock()
 
-        // Create attribution texture if needed
+        // Queue attribution texture upload (runs on GL thread in renderFrame).
+        // GL calls must happen on the render thread with the active context;
+        // calling glBindTexture from this async Task crashes (KERN_INVALID_ADDRESS).
         if config.showAttribution {
-            createAttributionTexture(from: attribution)
+            queueAttributionTexture(from: attribution)
         }
     }
 
@@ -516,6 +663,7 @@ final class MetMuseumEngine: VisualizationEngine {
         uniform float u_imageElapsed;
         uniform sampler2D u_attribution;
         uniform float u_attributionAlpha;
+        uniform vec2 u_attributionSize;  // attribution texture size in px, (0,0) => disabled
 
         vec3 rgb2hsv(vec3 rgb) {
             vec4 K = vec4(0.0, -1.0/3.0, 2.0/3.0, -1.0);
@@ -616,13 +764,19 @@ final class MetMuseumEngine: VisualizationEngine {
                 result.rgb = hsv2rgb(hsv);
             }
 
-            // Composite attribution overlay at bottom-left if enabled
-            if (u_attributionAlpha > 0.0) {
-                // Attribution appears at bottom-left
-                vec2 attrUV = gl_FragCoord.xy / vec2(1920.0, 1080.0);  // Approximate viewport
-                attrUV.y = 1.0 - attrUV.y;  // Flip Y for bottom-left positioning
-                if (attrUV.x < 0.4 && attrUV.y < 0.15) {
-                    // Sample attribution texture with adjusted UVs
+            // Composite attribution overlay anchored at bottom-left of the viewport,
+            // sampling only inside the overlay's actual pixel rect so we don't
+            // smear the edge texel across the screen via CLAMP_TO_EDGE.
+            if (u_attributionAlpha > 0.0 && u_attributionSize.x > 0.0 && u_attributionSize.y > 0.0) {
+                // gl_FragCoord origin is bottom-left in GL; place the overlay
+                // with an 8px margin from the bottom-left corner.
+                vec2 margin = vec2(8.0, 8.0);
+                vec2 pxFromCorner = gl_FragCoord.xy - margin;
+                if (pxFromCorner.x >= 0.0 && pxFromCorner.x < u_attributionSize.x &&
+                    pxFromCorner.y >= 0.0 && pxFromCorner.y < u_attributionSize.y) {
+                    // Texture was uploaded with top-left origin; flip Y for sampling.
+                    vec2 attrUV = vec2(pxFromCorner.x / u_attributionSize.x,
+                                       1.0 - pxFromCorner.y / u_attributionSize.y);
                     vec4 attrSample = texture(u_attribution, attrUV);
                     result.rgb = mix(result.rgb, attrSample.rgb, attrSample.a * u_attributionAlpha);
                 }
@@ -647,6 +801,7 @@ final class MetMuseumEngine: VisualizationEngine {
         audioReactiveUniform = glGetUniformLocation(program, "u_audioReactive")
         attributionTexUniform = glGetUniformLocation(program, "u_attribution")
         attributionAlphaUniform = glGetUniformLocation(program, "u_attributionAlpha")
+        attributionSizeUniform = glGetUniformLocation(program, "u_attributionSize")
         imageStartTimeUniform = glGetUniformLocation(program, "u_imageElapsed")
 
         // Setup VAO/VBO (fullscreen quad)
@@ -725,8 +880,9 @@ final class MetMuseumEngine: VisualizationEngine {
         }
     }
 
-    private func createAttributionTexture(from attribution: String) {
-        // Render attribution text to an NSImage, then upload as texture
+    private func queueAttributionTexture(from attribution: String) {
+        // Render attribution text to a CGImage; the actual GL upload is deferred
+        // to renderFrame so it runs on the GL thread with the active context.
         let attr: [NSAttributedString.Key: Any] = [
             .font: NSFont.systemFont(ofSize: 14),
             .foregroundColor: NSColor.white
@@ -738,20 +894,21 @@ final class MetMuseumEngine: VisualizationEngine {
 
         let image = NSImage(size: imgSize)
         image.lockFocus()
-        // Dark semi-transparent background
         NSColor(red: 0, green: 0, blue: 0, alpha: 0.6).setFill()
         NSBezierPath(rect: NSMakeRect(0, 0, imgSize.width, imgSize.height)).fill()
-        // Draw drop shadow by drawing text twice offset
         NSColor(red: 0, green: 0, blue: 0, alpha: 0.3).set()
         attrString.draw(at: NSMakePoint(padding + 1, padding - 1))
-        // Draw text
         attrString.draw(at: NSMakePoint(padding, padding))
         image.unlockFocus()
 
-        if let tiffData = image.tiffRepresentation,
-           let cgImage = NSBitmapImageRep(data: tiffData)?.cgImage {
-            uploadCGImage(cgImage, to: attributionTexture, width: Int(imgSize.width), height: Int(imgSize.height))
+        guard let tiffData = image.tiffRepresentation,
+              let cgImage = NSBitmapImageRep(data: tiffData)?.cgImage else {
+            return
         }
+
+        coreLock.lock()
+        pendingAttributionUpload = (cgImage, Int(imgSize.width), Int(imgSize.height))
+        coreLock.unlock()
     }
 
     private func uploadImage(data: Data, to textureID: GLuint) {
@@ -762,10 +919,10 @@ final class MetMuseumEngine: VisualizationEngine {
             return
         }
 
-        uploadCGImage(cgImage, to: textureID, width: Int(image.size.width), height: Int(image.size.height))
+        uploadCGImage(cgImage, to: textureID, width: Int(image.size.width), height: Int(image.size.height), updateImageDims: true)
     }
 
-    private func uploadCGImage(_ cgImage: CGImage, to textureID: GLuint, width: Int, height: Int) {
+    private func uploadCGImage(_ cgImage: CGImage, to textureID: GLuint, width: Int, height: Int, updateImageDims: Bool = false) {
         let w = cgImage.width
         let h = cgImage.height
 
@@ -797,13 +954,16 @@ final class MetMuseumEngine: VisualizationEngine {
                      GLenum(GL_RGBA), GLenum(GL_UNSIGNED_BYTE), pixelData)
         glBindTexture(GLenum(GL_TEXTURE_2D), 0)
 
-        // Update tracked dimensions for aspect ratio uniforms
-        coreLock.lock()
-        currentImageWidth = w
-        currentImageHeight = h
-        imageStartTime = Date()
-        coreLock.unlock()
-
+        // Only update artwork aspect ratio for the artwork texture upload.
+        // Attribution and placeholder uploads must not clobber these or the
+        // shader stretches the artwork to the overlay's dimensions.
+        if updateImageDims {
+            coreLock.lock()
+            currentImageWidth = w
+            currentImageHeight = h
+            imageStartTime = Date()
+            coreLock.unlock()
+        }
     }
 
     private func compileShader(type: GLenum, source: String) -> GLuint? {

--- a/Sources/NullPlayer/Visualization/MetMuseum/MetMuseumEngine.swift
+++ b/Sources/NullPlayer/Visualization/MetMuseum/MetMuseumEngine.swift
@@ -1,0 +1,897 @@
+import Foundation
+import OpenGL.GL3
+import AppKit
+
+/// Met Museum Art Visualization Engine
+///
+/// Displays rotating public domain artwork from The Metropolitan Museum of Art
+/// in response to audio analysis. Features include:
+/// - Async slideshow with retry policy and exponential backoff
+/// - Beat detection and transition triggering
+/// - Audio analysis via RMS ring buffer
+/// - Transition shader with 4 modes (fade, slide, zoom, dissolve)
+/// - Attribution overlay rendering
+/// - Configurable department, interval, transition, duration, aspect ratio, and audio-sync
+final class MetMuseumEngine: VisualizationEngine {
+
+    // MARK: - Config
+
+    struct Config: Equatable, Codable {
+        var departmentID: Int?
+        var intervalSeconds: Double = 30.0
+        var transitionMode: TransitionMode = .crossfade
+        var transitionDurationSeconds: Double = 1.5
+        var audioReactiveEffects: Bool = false
+        var beatTriggeredChanges: Bool = false
+        var aspectMode: AspectMode = .fit
+        var pauseOnAudioPause: Bool = false
+        var showAttribution: Bool = false
+    }
+
+    enum TransitionMode: String, CaseIterable, Codable {
+        case crossfade, kenBurns, beatCut, slide
+    }
+
+    enum AspectMode: String, CaseIterable, Codable {
+        case fit, fill, stretch
+    }
+
+    // MARK: - VisualizationEngine
+
+    private(set) var isAvailable: Bool = false
+    let displayName: String = "Met Museum Art"
+
+    // MARK: - State
+
+    private let coreLock = NSLock()
+    private var config: Config = Config()
+
+    private var width: Int = 0
+    private var height: Int = 0
+
+    private let client = MetMuseumClient()
+    private let imageCache = MetMuseumImageCache()
+
+    // Slideshow state
+    private var currentObjectID: Int?
+    private var currentImage: NSImage?
+    private var currentAttribution: String = ""
+    private var slideshowTask: Task<Void, Never>?
+
+    // Audio analysis
+    private let rmsWindowSize = 512
+    private let rmsRingBufferSize = 5  // Last 5 RMS values
+    private var rmsRingBuffer: [Float] = []
+    private var rmsRingIndex = 0
+    private var pcmBuffer: [Float] = []
+    private var lastBeatTime: Date = Date()
+    private var smoothedEnergy: Float = 0.0
+    private let energyAlpha: Float = 0.15
+    private var pendingBeatAdvance = false
+
+    // Transition state
+    private var transitionProgress: Float = 0.0
+    private var isTransitioning: Bool = false
+    private var transitionStartTime: Date = Date()
+    private var nextImage: NSImage?
+
+    // GL resources
+    private var program: GLuint = 0
+    private var currentTexture: GLuint = 0
+    private var nextTexture: GLuint = 0
+    private var attributionTexture: GLuint = 0
+    private var placeholderTexture: GLuint = 0
+    private var vao: GLuint = 0
+    private var vbo: GLuint = 0
+
+    private var currentTexUniform: GLint = -1
+    private var nextTexUniform: GLint = -1
+    private var attributionTexUniform: GLint = -1
+    private var progressUniform: GLint = -1
+    private var modeUniform: GLint = -1
+    private var imageAspectUniform: GLint = -1
+    private var viewportAspectUniform: GLint = -1
+    private var aspectModeUniform: GLint = -1
+    private var energyUniform: GLint = -1
+    private var audioReactiveUniform: GLint = -1
+    private var attributionAlphaUniform: GLint = -1
+    private var imageStartTimeUniform: GLint = -1
+
+    // Pending upload queue
+    private var pendingUploads: [(data: Data, objectID: Int)] = []
+
+    // Image change tracking (for attribution fade)
+    private var imageChangeTime: Date = Date()
+
+    // Image dimensions for aspect ratio handling
+    private var currentImageWidth: Int = 0
+    private var currentImageHeight: Int = 0
+    private var imageStartTime: Date = Date()
+
+    // Department state (loaded at init)
+    enum DepartmentsState {
+        case loading
+        case loaded([MetDepartment])
+        case failed
+    }
+    private(set) var departmentsState: DepartmentsState = .loading
+
+    // Network retry state
+    private var retryTaskActive = false
+
+    // MARK: - Init / cleanup
+
+    init(width: Int, height: Int) {
+        self.width = max(1, width)
+        self.height = max(1, height)
+        self.rmsRingBuffer = Array(repeating: 0, count: rmsRingBufferSize)
+        self.pcmBuffer = []
+
+        if !buildGLResources() {
+            NSLog("MetMuseumEngine: failed to build GL resources")
+            destroyGLResources()
+            return
+        }
+
+        self.isAvailable = true
+        NSLog("MetMuseumEngine: initialized %dx%d", self.width, self.height)
+
+        // Load departments on background task
+        Task {
+            do {
+                let depts = try await client.fetchDepartments()
+                coreLock.lock()
+                self.departmentsState = .loaded(depts)
+                coreLock.unlock()
+            } catch {
+                coreLock.lock()
+                self.departmentsState = .failed
+                coreLock.unlock()
+                NSLog("MetMuseumEngine: Failed to fetch departments: %@", error.localizedDescription)
+            }
+        }
+
+        // Start slideshow
+        startSlideshow()
+    }
+
+    deinit {
+        cleanup()
+    }
+
+    func cleanup() {
+        coreLock.lock()
+        defer { coreLock.unlock() }
+
+        slideshowTask?.cancel()
+        slideshowTask = nil
+        destroyGLResources()
+        isAvailable = false
+    }
+
+    // MARK: - VisualizationEngine API
+
+    func setViewportSize(width: Int, height: Int) {
+        let newW = max(1, width)
+        let newH = max(1, height)
+        coreLock.lock()
+        defer { coreLock.unlock() }
+        guard newW != self.width || newH != self.height else { return }
+        self.width = newW
+        self.height = newH
+    }
+
+    func addPCMMono(_ samples: [Float]) {
+        coreLock.lock()
+        defer { coreLock.unlock() }
+
+        // Accumulate PCM samples
+        pcmBuffer.append(contentsOf: samples)
+
+        // When we have enough samples, compute RMS and update ring buffer
+        while pcmBuffer.count >= rmsWindowSize {
+            let window = Array(pcmBuffer.prefix(rmsWindowSize))
+            pcmBuffer.removeFirst(rmsWindowSize)
+
+            // Compute RMS of this window
+            let meanSquare = window.reduce(0) { $0 + $1 * $1 } / Float(window.count)
+            let rms = sqrt(meanSquare)
+
+            // Update RMS ring buffer
+            rmsRingBuffer[rmsRingIndex] = rms
+            rmsRingIndex = (rmsRingIndex + 1) % rmsRingBufferSize
+
+            // Update smoothed energy (one-pole low-pass)
+            smoothedEnergy = smoothedEnergy * (1.0 - energyAlpha) + rms * energyAlpha
+
+            // Beat detection: RMS > 1.5 × mean of ring buffer AND 250ms gate
+            let ringMean = rmsRingBuffer.reduce(0, +) / Float(rmsRingBufferSize)
+            let now = Date()
+            if rms > 1.5 * ringMean && now.timeIntervalSince(lastBeatTime) > 0.25 {
+                lastBeatTime = now
+                // Set flag; drain in renderFrame to avoid reentrancy on coreLock
+                if config.beatTriggeredChanges {
+                    pendingBeatAdvance = true
+                }
+            }
+        }
+    }
+
+    func renderFrame() {
+        coreLock.lock()
+        defer { coreLock.unlock() }
+
+        guard isAvailable else { return }
+
+        // Drain pending beat advance flag
+        let shouldAdvanceOnBeat = pendingBeatAdvance
+        pendingBeatAdvance = false
+
+        // Process pending uploads (target appropriate texture)
+        for (data, objectID) in pendingUploads {
+            uploadImage(data: data, to: isTransitioning ? nextTexture : currentTexture)
+        }
+        pendingUploads.removeAll()
+
+        // Advance on beat if flagged
+        if shouldAdvanceOnBeat && !isTransitioning {
+            advanceSlideshowImmediate()
+        }
+
+        // Update transition progress
+        if isTransitioning {
+            let elapsed = Float(Date().timeIntervalSince(transitionStartTime))
+            let duration = Float(config.transitionDurationSeconds)
+            transitionProgress = min(1.0, elapsed / duration)
+
+            if transitionProgress >= 1.0 {
+                isTransitioning = false
+                currentImage = nextImage
+                nextImage = nil
+                transitionProgress = 0.0
+                imageChangeTime = Date()
+                // Swap textures
+                if currentTexture != 0 && nextTexture != 0 {
+                    let temp = currentTexture
+                    currentTexture = nextTexture
+                    nextTexture = temp
+                }
+            }
+        }
+
+        // Render
+        glViewport(0, 0, GLsizei(width), GLsizei(height))
+        glClearColor(0.1, 0.1, 0.1, 1)
+        glClear(GLbitfield(GL_COLOR_BUFFER_BIT))
+
+        guard currentImage != nil || placeholderTexture != 0 else { return }
+
+        glUseProgram(program)
+
+        let texToRender = currentImage != nil ? currentTexture : placeholderTexture
+
+        glActiveTexture(GLenum(GL_TEXTURE0))
+        glBindTexture(GLenum(GL_TEXTURE_2D), texToRender)
+        glUniform1i(currentTexUniform, 0)
+
+        if isTransitioning && nextTexture != 0 {
+            glActiveTexture(GLenum(GL_TEXTURE1))
+            glBindTexture(GLenum(GL_TEXTURE_2D), nextTexture)
+            glUniform1i(nextTexUniform, 1)
+        }
+
+        if attributionTexture != 0 {
+            glActiveTexture(GLenum(GL_TEXTURE2))
+            glBindTexture(GLenum(GL_TEXTURE_2D), attributionTexture)
+            glUniform1i(attributionTexUniform, 2)
+        }
+
+        glUniform1f(progressUniform, transitionProgress)
+        glUniform1i(modeUniform, GLint(config.transitionMode.modeValue))
+        glUniform1f(energyUniform, smoothedEnergy)
+        glUniform1i(audioReactiveUniform, config.audioReactiveEffects ? 1 : 0)
+
+        // Set aspect ratio uniforms per-frame
+        glUniform2f(imageAspectUniform, Float(currentImageWidth), Float(currentImageHeight))
+        glUniform2f(viewportAspectUniform, Float(width), Float(height))
+        glUniform1i(aspectModeUniform, GLint(config.aspectMode.shaderValue))
+
+        // Set image elapsed time for Ken Burns
+        let imageElapsed = Float(Date().timeIntervalSince(imageStartTime))
+        glUniform1f(imageStartTimeUniform, imageElapsed)
+
+        // Attribution fade timing
+        let timeSinceImageChange = Float(Date().timeIntervalSince(imageChangeTime))
+        let attributionAlpha: Float
+        if timeSinceImageChange < 4.0 {
+            // Fade in over first 4s
+            attributionAlpha = min(1.0, timeSinceImageChange / 4.0)
+        } else if timeSinceImageChange < 5.0 {
+            // Fade out over 1s (from 4s to 5s)
+            attributionAlpha = max(0.0, 1.0 - (timeSinceImageChange - 4.0))
+        } else {
+            attributionAlpha = 0.0
+        }
+        glUniform1f(attributionAlphaUniform, config.showAttribution ? attributionAlpha : 0.0)
+
+        glBindVertexArray(vao)
+        glDrawArrays(GLenum(GL_TRIANGLE_STRIP), 0, 4)
+        glBindVertexArray(0)
+
+        glUseProgram(0)
+        glBindTexture(GLenum(GL_TEXTURE_2D), 0)
+    }
+
+    // MARK: - Configuration
+
+    func setConfig(_ newConfig: Config) {
+        coreLock.lock()
+        defer { coreLock.unlock() }
+
+        let oldDepartment = config.departmentID
+        config = newConfig
+
+        // If department changed, restart slideshow
+        if oldDepartment != newConfig.departmentID {
+            slideshowTask?.cancel()
+            slideshowTask = nil
+            startSlideshow()
+        }
+    }
+
+    func getConfig() -> Config {
+        coreLock.lock()
+        defer { coreLock.unlock() }
+        return config
+    }
+
+    func clearCache() {
+        imageCache.clearCache()
+        NSLog("MetMuseumEngine: Image cache cleared")
+    }
+
+    func setAudioActive(_ active: Bool) {
+        coreLock.lock()
+        defer { coreLock.unlock() }
+
+        if !active && config.pauseOnAudioPause {
+            slideshowTask?.cancel()
+            slideshowTask = nil
+            NSLog("MetMuseumEngine: Paused slideshow (audio paused)")
+        } else if active && slideshowTask == nil {
+            startSlideshow()
+            NSLog("MetMuseumEngine: Resumed slideshow (audio playing)")
+        }
+    }
+
+    // MARK: - Slideshow Management
+
+    private func startSlideshow() {
+        slideshowTask?.cancel()
+        slideshowTask = Task {
+            while !Task.isCancelled {
+                do {
+                    try await fetchAndDisplayRandomArtwork()
+                    try await Task.sleep(nanoseconds: UInt64(config.intervalSeconds * 1_000_000_000))
+                } catch {
+                    NSLog("MetMuseumEngine slideshow error: %@", error.localizedDescription)
+                    // Exponential backoff retry: 1s, 2s, 4s. After exhausting, retry every 30s
+                    var success = false
+                    for retryDelay in [1.0, 2.0, 4.0] {
+                        if Task.isCancelled { break }
+                        try? await Task.sleep(nanoseconds: UInt64(retryDelay * 1_000_000_000))
+                        do {
+                            try await fetchAndDisplayRandomArtwork()
+                            success = true
+                            break
+                        } catch {
+                            // Continue to next retry
+                        }
+                    }
+                    if !success && !Task.isCancelled {
+                        NSLog("MetMuseumEngine: 3 retries exhausted, will retry every 30s")
+                        // Pause slideshow, retry every 30s
+                        while !Task.isCancelled {
+                            try? await Task.sleep(nanoseconds: 30_000_000_000)
+                            if Task.isCancelled { break }
+                            do {
+                                try await fetchAndDisplayRandomArtwork()
+                                // Success, resume normal loop
+                                break
+                            } catch {
+                                // Continue retrying every 30s
+                            }
+                        }
+                    }
+                }
+            }
+        }
+    }
+
+    private func advanceSlideshowImmediate() {
+        // Called from renderFrame under coreLock; trigger next fetch
+        // without waiting for the interval timer
+        slideshowTask?.cancel()
+        slideshowTask = Task {
+            do {
+                try await fetchAndDisplayRandomArtwork()
+            } catch {
+                NSLog("MetMuseumEngine beat-triggered advance error: %@", error.localizedDescription)
+            }
+            // Resume normal slideshow
+            startSlideshow()
+        }
+    }
+
+    private func fetchAndDisplayRandomArtwork() async throws {
+        // Fetch list of object IDs for the department
+        let objectIDs = try await client.fetchObjectIDs(departmentID: config.departmentID)
+        guard !objectIDs.isEmpty else {
+            throw MetMuseumError.noArtworkFound
+        }
+
+        // Try random objects until we find a public-domain one with an image
+        let maxAttempts = min(20, objectIDs.count)
+        var attempts = 0
+        var selectedObject: MetObject?
+
+        while attempts < maxAttempts {
+            let randomID = objectIDs.randomElement() ?? objectIDs.first!
+            attempts += 1
+
+            if let obj = try await client.fetchObject(id: randomID) {
+                selectedObject = obj
+                break
+            }
+            // fetchObject returns nil for non-public-domain or missing image; continue loop
+        }
+
+        guard let objectInfo = selectedObject else {
+            throw MetMuseumError.noArtworkFound
+        }
+
+        // Download image (check cache first)
+        let imageData: Data
+        if let cachedData = imageCache.cachedImageData(for: objectInfo.objectID) {
+            imageData = cachedData
+        } else {
+            imageData = try await client.downloadImage(url: URL(string: objectInfo.primaryImage)!)
+            imageCache.store(imageData, for: objectInfo.objectID)
+        }
+
+        let image = NSImage(data: imageData)
+        guard let image = image else { throw MetMuseumError.noImageURL }
+
+        coreLock.lock()
+        let attribution = "\(objectInfo.title) - \(objectInfo.artistDisplayName ?? "Unknown") (\(objectInfo.objectDate ?? ""))"
+        currentObjectID = objectInfo.objectID
+        currentAttribution = attribution
+        nextImage = image
+        isTransitioning = true
+        transitionStartTime = Date()
+        transitionProgress = 0.0
+        imageChangeTime = Date()
+        pendingUploads.append((imageData, objectInfo.objectID))
+        coreLock.unlock()
+
+        // Create attribution texture if needed
+        if config.showAttribution {
+            createAttributionTexture(from: attribution)
+        }
+    }
+
+    // MARK: - GL Setup
+
+    private func buildGLResources() -> Bool {
+        let vertexSrc = """
+        #version 330 core
+        layout(location = 0) in vec2 a_pos;
+        layout(location = 1) in vec2 a_uv;
+        out vec2 v_uv;
+        void main() {
+            v_uv = a_uv;
+            gl_Position = vec4(a_pos, 0.0, 1.0);
+        }
+        """
+
+        let fragmentSrc = """
+        #version 330 core
+        in vec2 v_uv;
+        out vec4 frag;
+        uniform sampler2D u_current;
+        uniform sampler2D u_next;
+        uniform float u_progress;
+        uniform int u_mode;
+        uniform vec2 u_imageAspect;
+        uniform vec2 u_viewportAspect;
+        uniform int u_aspectMode;
+        uniform float u_energy;
+        uniform int u_audioReactive;
+        uniform float u_imageElapsed;
+        uniform sampler2D u_attribution;
+        uniform float u_attributionAlpha;
+
+        vec3 rgb2hsv(vec3 rgb) {
+            vec4 K = vec4(0.0, -1.0/3.0, 2.0/3.0, -1.0);
+            vec4 p = rgb.g < rgb.b ? vec4(rgb.bg, K.wz) : vec4(rgb.bz, K.xy);
+            vec4 q = rgb.r < p.x ? vec4(p.xyw, rgb.r) : vec4(rgb.r, p.yzx);
+            float d = q.x - min(q.w, q.y);
+            float e = 1.0e-10;
+            return vec3(abs(q.z + (q.w - q.y) / (6.0 * d + e)), d / (q.x + e), q.x);
+        }
+
+        vec3 hsv2rgb(vec3 hsv) {
+            vec4 K = vec4(1.0, 2.0/3.0, 1.0/3.0, 3.0);
+            vec3 p = abs(fract(hsv.xxx + K.xyz) * 6.0 - K.www);
+            return hsv.z * mix(K.xxx, clamp(p - K.xxx, 0.0, 1.0), hsv.y);
+        }
+
+        vec2 computeAspectAdjustedUV(vec2 uv) {
+            vec2 adjustedUV = uv;
+            if (u_aspectMode == 0) {
+                // Fit: letterbox/pillarbox
+                float imageAspect = u_imageAspect.x / u_imageAspect.y;
+                float viewAspect = u_viewportAspect.x / u_viewportAspect.y;
+                if (imageAspect > viewAspect) {
+                    // Image is wider, add vertical bars
+                    float scale = imageAspect / viewAspect;
+                    adjustedUV.y = (adjustedUV.y - 0.5) / scale + 0.5;
+                } else {
+                    // Image is taller, add horizontal bars
+                    float scale = viewAspect / imageAspect;
+                    adjustedUV.x = (adjustedUV.x - 0.5) / scale + 0.5;
+                }
+            } else if (u_aspectMode == 1) {
+                // Fill: crop to fill viewport
+                float imageAspect = u_imageAspect.x / u_imageAspect.y;
+                float viewAspect = u_viewportAspect.x / u_viewportAspect.y;
+                if (imageAspect < viewAspect) {
+                    // Image is taller, crop top/bottom
+                    float scale = viewAspect / imageAspect;
+                    adjustedUV.y = (adjustedUV.y - 0.5) / scale + 0.5;
+                } else {
+                    // Image is wider, crop left/right
+                    float scale = imageAspect / viewAspect;
+                    adjustedUV.x = (adjustedUV.x - 0.5) / scale + 0.5;
+                }
+            }
+            // u_aspectMode == 2: stretch (no adjustment needed)
+            return adjustedUV;
+        }
+
+        void main() {
+            vec2 currentUV = computeAspectAdjustedUV(v_uv);
+            vec4 current = texture(u_current, currentUV);
+            vec4 next = texture(u_next, computeAspectAdjustedUV(v_uv));
+
+            vec4 result;
+            if (u_mode == 0) {
+                // Crossfade
+                result = mix(current, next, u_progress);
+            } else if (u_mode == 1) {
+                // Ken Burns (slow 10% zoom over 30s, then crossfade during transition)
+                float zoomAmount = clamp(u_imageElapsed / 30.0, 0.0, 0.1);
+                float scale = 1.0 + zoomAmount;
+                vec2 zoomUV = (currentUV - 0.5) / scale + 0.5;
+                result = mix(texture(u_current, zoomUV), next, u_progress);
+            } else if (u_mode == 2) {
+                // Beat-cut (hard cut at progress >= 1.0)
+                result = u_progress >= 1.0 ? next : current;
+            } else if (u_mode == 3) {
+                // Slide: current scrolls left, next scrolls in from right
+                vec2 curSlideUV = vec2(currentUV.x + u_progress, currentUV.y);
+                vec2 nxtSlideUV = vec2(currentUV.x + u_progress - 1.0, currentUV.y);
+                vec4 curSlide = (curSlideUV.x <= 1.0) ? texture(u_current, curSlideUV) : vec4(0.0);
+                vec4 nxtSlide = (nxtSlideUV.x >= 0.0) ? texture(u_next, nxtSlideUV) : vec4(0.0);
+                result = (currentUV.x < (1.0 - u_progress)) ? curSlide : nxtSlide;
+            } else {
+                result = current;
+            }
+
+            // Apply audio reactive effects if enabled
+            if (u_audioReactive == 1) {
+                result.rgb *= mix(1.0, 1.03, u_energy);
+                vec3 hsv = rgb2hsv(result.rgb);
+                hsv.y = mix(hsv.y, hsv.y + 0.15, u_energy);
+                result.rgb = hsv2rgb(hsv);
+            }
+
+            // Composite attribution overlay at bottom-left if enabled
+            if (u_attributionAlpha > 0.0) {
+                // Attribution appears at bottom-left
+                vec2 attrUV = gl_FragCoord.xy / vec2(1920.0, 1080.0);  // Approximate viewport
+                attrUV.y = 1.0 - attrUV.y;  // Flip Y for bottom-left positioning
+                if (attrUV.x < 0.4 && attrUV.y < 0.15) {
+                    // Sample attribution texture with adjusted UVs
+                    vec4 attrSample = texture(u_attribution, attrUV);
+                    result.rgb = mix(result.rgb, attrSample.rgb, attrSample.a * u_attributionAlpha);
+                }
+            }
+
+            frag = result;
+        }
+        """
+
+        guard let prog = compileProgram(vertex: vertexSrc, fragment: fragmentSrc) else {
+            return false
+        }
+        program = prog
+        currentTexUniform = glGetUniformLocation(program, "u_current")
+        nextTexUniform = glGetUniformLocation(program, "u_next")
+        progressUniform = glGetUniformLocation(program, "u_progress")
+        modeUniform = glGetUniformLocation(program, "u_mode")
+        imageAspectUniform = glGetUniformLocation(program, "u_imageAspect")
+        viewportAspectUniform = glGetUniformLocation(program, "u_viewportAspect")
+        aspectModeUniform = glGetUniformLocation(program, "u_aspectMode")
+        energyUniform = glGetUniformLocation(program, "u_energy")
+        audioReactiveUniform = glGetUniformLocation(program, "u_audioReactive")
+        attributionTexUniform = glGetUniformLocation(program, "u_attribution")
+        attributionAlphaUniform = glGetUniformLocation(program, "u_attributionAlpha")
+        imageStartTimeUniform = glGetUniformLocation(program, "u_imageElapsed")
+
+        // Setup VAO/VBO (fullscreen quad)
+        let verts: [GLfloat] = [
+            -1, -1, 0, 1,
+             1, -1, 1, 1,
+            -1,  1, 0, 0,
+             1,  1, 1, 0,
+        ]
+
+        glGenVertexArrays(1, &vao)
+        glBindVertexArray(vao)
+        glGenBuffers(1, &vbo)
+        glBindBuffer(GLenum(GL_ARRAY_BUFFER), vbo)
+        verts.withUnsafeBufferPointer { ptr in
+            glBufferData(GLenum(GL_ARRAY_BUFFER),
+                         verts.count * MemoryLayout<GLfloat>.size,
+                         ptr.baseAddress,
+                         GLenum(GL_STATIC_DRAW))
+        }
+        let stride = GLsizei(MemoryLayout<GLfloat>.size * 4)
+        glEnableVertexAttribArray(0)
+        glVertexAttribPointer(0, 2, GLenum(GL_FLOAT), GLboolean(GL_FALSE), stride, nil)
+        let uvOffset = UnsafePointer<GLfloat>(bitPattern: MemoryLayout<GLfloat>.size * 2)
+        glEnableVertexAttribArray(1)
+        glVertexAttribPointer(1, 2, GLenum(GL_FLOAT), GLboolean(GL_FALSE), stride, uvOffset)
+        glBindVertexArray(0)
+        glBindBuffer(GLenum(GL_ARRAY_BUFFER), 0)
+
+        // Create textures (allocate on first upload, not here)
+        glGenTextures(1, &currentTexture)
+        glGenTextures(1, &nextTexture)
+        glGenTextures(1, &placeholderTexture)
+
+        for tex in [currentTexture, nextTexture, placeholderTexture] {
+            glBindTexture(GLenum(GL_TEXTURE_2D), tex)
+            glTexParameteri(GLenum(GL_TEXTURE_2D), GLenum(GL_TEXTURE_MIN_FILTER), GL_LINEAR)
+            glTexParameteri(GLenum(GL_TEXTURE_2D), GLenum(GL_TEXTURE_MAG_FILTER), GL_LINEAR)
+            glTexParameteri(GLenum(GL_TEXTURE_2D), GLenum(GL_TEXTURE_WRAP_S), GL_CLAMP_TO_EDGE)
+            glTexParameteri(GLenum(GL_TEXTURE_2D), GLenum(GL_TEXTURE_WRAP_T), GL_CLAMP_TO_EDGE)
+        }
+        glBindTexture(GLenum(GL_TEXTURE_2D), 0)
+
+        // Create placeholder texture
+        createPlaceholderTexture()
+
+        return true
+    }
+
+    private func destroyGLResources() {
+        if vbo != 0 { glDeleteBuffers(1, &vbo); vbo = 0 }
+        if vao != 0 { glDeleteVertexArrays(1, &vao); vao = 0 }
+        if currentTexture != 0 { glDeleteTextures(1, &currentTexture); currentTexture = 0 }
+        if nextTexture != 0 { glDeleteTextures(1, &nextTexture); nextTexture = 0 }
+        if attributionTexture != 0 { glDeleteTextures(1, &attributionTexture); attributionTexture = 0 }
+        if placeholderTexture != 0 { glDeleteTextures(1, &placeholderTexture); placeholderTexture = 0 }
+        if program != 0 { glDeleteProgram(program); program = 0 }
+    }
+
+    private func createPlaceholderTexture() {
+        let placeholder = NSImage(size: NSMakeSize(256, 256))
+        placeholder.lockFocus()
+        NSColor.darkGray.setFill()
+        NSBezierPath(rect: NSMakeRect(0, 0, 256, 256)).fill()
+        let attr: [NSAttributedString.Key: Any] = [
+            .font: NSFont.systemFont(ofSize: 16),
+            .foregroundColor: NSColor.lightGray
+        ]
+        let str = NSAttributedString(string: "Met Museum\nunavailable", attributes: attr)
+        str.draw(at: NSMakePoint(30, 110))
+        placeholder.unlockFocus()
+
+        if let tiffData = placeholder.tiffRepresentation,
+           let cgImage = NSBitmapImageRep(data: tiffData)?.cgImage {
+            uploadCGImage(cgImage, to: placeholderTexture, width: 256, height: 256)
+        }
+    }
+
+    private func createAttributionTexture(from attribution: String) {
+        // Render attribution text to an NSImage, then upload as texture
+        let attr: [NSAttributedString.Key: Any] = [
+            .font: NSFont.systemFont(ofSize: 14),
+            .foregroundColor: NSColor.white
+        ]
+        let attrString = NSAttributedString(string: attribution, attributes: attr)
+        let size = attrString.size()
+        let padding: CGFloat = 8
+        let imgSize = NSMakeSize(size.width + padding * 2, size.height + padding * 2)
+
+        let image = NSImage(size: imgSize)
+        image.lockFocus()
+        // Dark semi-transparent background
+        NSColor(red: 0, green: 0, blue: 0, alpha: 0.6).setFill()
+        NSBezierPath(rect: NSMakeRect(0, 0, imgSize.width, imgSize.height)).fill()
+        // Draw drop shadow by drawing text twice offset
+        NSColor(red: 0, green: 0, blue: 0, alpha: 0.3).set()
+        attrString.draw(at: NSMakePoint(padding + 1, padding - 1))
+        // Draw text
+        attrString.draw(at: NSMakePoint(padding, padding))
+        image.unlockFocus()
+
+        if let tiffData = image.tiffRepresentation,
+           let cgImage = NSBitmapImageRep(data: tiffData)?.cgImage {
+            uploadCGImage(cgImage, to: attributionTexture, width: Int(imgSize.width), height: Int(imgSize.height))
+        }
+    }
+
+    private func uploadImage(data: Data, to textureID: GLuint) {
+        guard textureID != 0, let image = NSImage(data: data) else { return }
+
+        guard let cgImage = image.cgImage(forProposedRect: nil, context: nil, hints: nil) else {
+            NSLog("MetMuseumEngine: Failed to get CGImage from NSImage")
+            return
+        }
+
+        uploadCGImage(cgImage, to: textureID, width: Int(image.size.width), height: Int(image.size.height))
+    }
+
+    private func uploadCGImage(_ cgImage: CGImage, to textureID: GLuint, width: Int, height: Int) {
+        let w = cgImage.width
+        let h = cgImage.height
+
+        guard let ctx = CGContext(
+            data: nil,
+            width: w,
+            height: h,
+            bitsPerComponent: 8,
+            bytesPerRow: w * 4,
+            space: CGColorSpaceCreateDeviceRGB(),
+            bitmapInfo: CGImageAlphaInfo.premultipliedLast.rawValue
+        ) else {
+            NSLog("MetMuseumEngine: Failed to create CGContext for image upload")
+            return
+        }
+
+        ctx.draw(cgImage, in: CGRect(x: 0, y: 0, width: w, height: h))
+
+        guard let pixelData = ctx.data else {
+            NSLog("MetMuseumEngine: Failed to get pixel data from context")
+            return
+        }
+
+        glBindTexture(GLenum(GL_TEXTURE_2D), textureID)
+        glPixelStorei(GLenum(GL_UNPACK_ALIGNMENT), 1)
+        // Allocate texture with actual image dimensions (not viewport)
+        glTexImage2D(GLenum(GL_TEXTURE_2D), 0, GL_RGBA8,
+                     GLsizei(w), GLsizei(h), 0,
+                     GLenum(GL_RGBA), GLenum(GL_UNSIGNED_BYTE), pixelData)
+        glBindTexture(GLenum(GL_TEXTURE_2D), 0)
+
+        // Update tracked dimensions for aspect ratio uniforms
+        coreLock.lock()
+        currentImageWidth = w
+        currentImageHeight = h
+        imageStartTime = Date()
+        coreLock.unlock()
+
+        NSLog("MetMuseumEngine: Uploaded image %dx%d to texture", w, h)
+    }
+
+    private func compileShader(type: GLenum, source: String) -> GLuint? {
+        let shader = glCreateShader(type)
+        guard shader != 0 else { return nil }
+        var cString = (source as NSString).utf8String
+        var length = GLint(source.utf8.count)
+        withUnsafePointer(to: &cString) { ptr in
+            ptr.withMemoryRebound(to: UnsafePointer<GLchar>?.self, capacity: 1) { p in
+                glShaderSource(shader, 1, p, &length)
+            }
+        }
+        glCompileShader(shader)
+        var status: GLint = 0
+        glGetShaderiv(shader, GLenum(GL_COMPILE_STATUS), &status)
+        if status == GL_FALSE {
+            var logLen: GLint = 0
+            glGetShaderiv(shader, GLenum(GL_INFO_LOG_LENGTH), &logLen)
+            var log = [GLchar](repeating: 0, count: Int(max(logLen, 1)))
+            glGetShaderInfoLog(shader, GLsizei(log.count), nil, &log)
+            NSLog("MetMuseumEngine: shader compile failed: %s", log)
+            glDeleteShader(shader)
+            return nil
+        }
+        return shader
+    }
+
+    private func compileProgram(vertex: String, fragment: String) -> GLuint? {
+        guard let vs = compileShader(type: GLenum(GL_VERTEX_SHADER), source: vertex) else { return nil }
+        guard let fs = compileShader(type: GLenum(GL_FRAGMENT_SHADER), source: fragment) else {
+            glDeleteShader(vs)
+            return nil
+        }
+        let prog = glCreateProgram()
+        glAttachShader(prog, vs)
+        glAttachShader(prog, fs)
+        glLinkProgram(prog)
+        glDeleteShader(vs)
+        glDeleteShader(fs)
+        var status: GLint = 0
+        glGetProgramiv(prog, GLenum(GL_LINK_STATUS), &status)
+        if status == GL_FALSE {
+            var logLen: GLint = 0
+            glGetProgramiv(prog, GLenum(GL_INFO_LOG_LENGTH), &logLen)
+            var log = [GLchar](repeating: 0, count: Int(max(logLen, 1)))
+            glGetProgramInfoLog(prog, GLsizei(log.count), nil, &log)
+            NSLog("MetMuseumEngine: program link failed: %s", log)
+            glDeleteProgram(prog)
+            return nil
+        }
+        return prog
+    }
+}
+
+// MARK: - Error Types
+
+enum MetMuseumError: LocalizedError {
+    case noArtworkFound
+    case noImageURL
+
+    var errorDescription: String? {
+        switch self {
+        case .noArtworkFound:
+            return "No public domain artwork found in department"
+        case .noImageURL:
+            return "Artwork has no primary image URL"
+        }
+    }
+}
+
+// MARK: - Persistence (UserDefaults keys)
+
+extension MetMuseumEngine {
+    enum DefaultsKey {
+        static let departmentID = "metMuseumDepartmentID"
+        static let intervalSeconds = "metMuseumIntervalSeconds"
+        static let transitionMode = "metMuseumTransitionMode"
+        static let transitionDuration = "metMuseumTransitionDuration"
+        static let audioReactive = "metMuseumAudioReactive"
+        static let beatTriggered = "metMuseumBeatTriggered"
+        static let aspectMode = "metMuseumAspectMode"
+        static let pauseOnAudioPause = "metMuseumPauseOnAudioPause"
+        static let showAttribution = "metMuseumShowAttribution"
+    }
+}
+
+// MARK: - Transition Mode Extension
+
+extension MetMuseumEngine.TransitionMode {
+    var modeValue: Int {
+        switch self {
+        case .crossfade: return 0
+        case .kenBurns: return 1
+        case .beatCut: return 2
+        case .slide: return 3
+        }
+    }
+}
+
+// MARK: - Aspect Mode Extension
+
+extension MetMuseumEngine.AspectMode {
+    var shaderValue: Int {
+        switch self {
+        case .fit: return 0
+        case .fill: return 1
+        case .stretch: return 2
+        }
+    }
+}

--- a/Sources/NullPlayer/Visualization/MetMuseum/MetMuseumEngine.swift
+++ b/Sources/NullPlayer/Visualization/MetMuseum/MetMuseumEngine.swift
@@ -43,7 +43,7 @@ final class MetMuseumEngine: VisualizationEngine {
 
     // MARK: - State
 
-    private let coreLock = NSLock()
+    private let coreLock = NSRecursiveLock()
     private var config: Config = Config()
 
     private var width: Int = 0
@@ -350,6 +350,14 @@ final class MetMuseumEngine: VisualizationEngine {
         NSLog("MetMuseumEngine: Image cache cleared")
     }
 
+    /// Immediately advance to a new random artwork. Safe to call from any thread.
+    func skipToNextArtwork() {
+        coreLock.lock()
+        defer { coreLock.unlock() }
+        guard isAvailable else { return }
+        advanceSlideshowImmediate()
+    }
+
     func setAudioActive(_ active: Bool) {
         coreLock.lock()
         defer { coreLock.unlock() }
@@ -357,10 +365,8 @@ final class MetMuseumEngine: VisualizationEngine {
         if !active && config.pauseOnAudioPause {
             slideshowTask?.cancel()
             slideshowTask = nil
-            NSLog("MetMuseumEngine: Paused slideshow (audio paused)")
         } else if active && slideshowTask == nil {
             startSlideshow()
-            NSLog("MetMuseumEngine: Resumed slideshow (audio playing)")
         }
     }
 
@@ -513,7 +519,7 @@ final class MetMuseumEngine: VisualizationEngine {
 
         vec3 rgb2hsv(vec3 rgb) {
             vec4 K = vec4(0.0, -1.0/3.0, 2.0/3.0, -1.0);
-            vec4 p = rgb.g < rgb.b ? vec4(rgb.bg, K.wz) : vec4(rgb.bz, K.xy);
+            vec4 p = rgb.g < rgb.b ? vec4(rgb.bg, K.wz) : vec4(rgb.gb, K.xy);
             vec4 q = rgb.r < p.x ? vec4(p.xyw, rgb.r) : vec4(rgb.r, p.yzx);
             float d = q.x - min(q.w, q.y);
             float e = 1.0e-10;
@@ -529,17 +535,18 @@ final class MetMuseumEngine: VisualizationEngine {
         vec2 computeAspectAdjustedUV(vec2 uv) {
             vec2 adjustedUV = uv;
             if (u_aspectMode == 0) {
-                // Fit: letterbox/pillarbox
+                // Fit: letterbox/pillarbox. Map viewport UV into image space so the
+                // image fully fits and the leftover bands fall outside [0,1].
                 float imageAspect = u_imageAspect.x / u_imageAspect.y;
                 float viewAspect = u_viewportAspect.x / u_viewportAspect.y;
                 if (imageAspect > viewAspect) {
-                    // Image is wider, add vertical bars
+                    // Image wider than viewport: full image width, letterbox top/bottom
                     float scale = imageAspect / viewAspect;
-                    adjustedUV.y = (adjustedUV.y - 0.5) / scale + 0.5;
+                    adjustedUV.y = (adjustedUV.y - 0.5) * scale + 0.5;
                 } else {
-                    // Image is taller, add horizontal bars
+                    // Image taller than viewport: full image height, pillarbox sides
                     float scale = viewAspect / imageAspect;
-                    adjustedUV.x = (adjustedUV.x - 0.5) / scale + 0.5;
+                    adjustedUV.x = (adjustedUV.x - 0.5) * scale + 0.5;
                 }
             } else if (u_aspectMode == 1) {
                 // Fill: crop to fill viewport
@@ -559,31 +566,44 @@ final class MetMuseumEngine: VisualizationEngine {
             return adjustedUV;
         }
 
-        void main() {
-            vec2 currentUV = computeAspectAdjustedUV(v_uv);
-            vec4 current = texture(u_current, currentUV);
-            vec4 next = texture(u_next, computeAspectAdjustedUV(v_uv));
+        // Sample a texture, returning black for UVs outside [0,1] so letterbox
+        // bars don't smear the edge pixel via CLAMP_TO_EDGE.
+        vec4 sampleBounded(sampler2D tex, vec2 uv) {
+            if (any(lessThan(uv, vec2(0.0))) || any(greaterThan(uv, vec2(1.0)))) {
+                return vec4(0.0, 0.0, 0.0, 1.0);
+            }
+            return texture(tex, uv);
+        }
 
-            vec4 result;
-            if (u_mode == 0) {
-                // Crossfade
-                result = mix(current, next, u_progress);
-            } else if (u_mode == 1) {
-                // Ken Burns (slow 10% zoom over 30s, then crossfade during transition)
+        void main() {
+            vec2 imgUV = computeAspectAdjustedUV(v_uv);
+
+            // For Ken Burns, zoom inside image space; the zoom is clamped so it
+            // never escapes the image bounds, so the letterbox bars stay intact.
+            vec2 curUV = imgUV;
+            if (u_mode == 1) {
                 float zoomAmount = clamp(u_imageElapsed / 30.0, 0.0, 0.1);
                 float scale = 1.0 + zoomAmount;
-                vec2 zoomUV = (currentUV - 0.5) / scale + 0.5;
-                result = mix(texture(u_current, zoomUV), next, u_progress);
+                curUV = (imgUV - 0.5) / scale + 0.5;
+            }
+
+            vec4 current = sampleBounded(u_current, curUV);
+            vec4 next = sampleBounded(u_next, imgUV);
+
+            vec4 result;
+            if (u_mode == 0 || u_mode == 1) {
+                // Crossfade (mode 0) and Ken Burns crossfade (mode 1)
+                result = mix(current, next, u_progress);
             } else if (u_mode == 2) {
                 // Beat-cut (hard cut at progress >= 1.0)
                 result = u_progress >= 1.0 ? next : current;
             } else if (u_mode == 3) {
                 // Slide: current scrolls left, next scrolls in from right
-                vec2 curSlideUV = vec2(currentUV.x + u_progress, currentUV.y);
-                vec2 nxtSlideUV = vec2(currentUV.x + u_progress - 1.0, currentUV.y);
-                vec4 curSlide = (curSlideUV.x <= 1.0) ? texture(u_current, curSlideUV) : vec4(0.0);
-                vec4 nxtSlide = (nxtSlideUV.x >= 0.0) ? texture(u_next, nxtSlideUV) : vec4(0.0);
-                result = (currentUV.x < (1.0 - u_progress)) ? curSlide : nxtSlide;
+                vec2 curSlideUV = vec2(imgUV.x + u_progress, imgUV.y);
+                vec2 nxtSlideUV = vec2(imgUV.x + u_progress - 1.0, imgUV.y);
+                vec4 curSlide = sampleBounded(u_current, curSlideUV);
+                vec4 nxtSlide = sampleBounded(u_next, nxtSlideUV);
+                result = (imgUV.x < (1.0 - u_progress)) ? curSlide : nxtSlide;
             } else {
                 result = current;
             }
@@ -784,7 +804,6 @@ final class MetMuseumEngine: VisualizationEngine {
         imageStartTime = Date()
         coreLock.unlock()
 
-        NSLog("MetMuseumEngine: Uploaded image %dx%d to texture", w, h)
     }
 
     private func compileShader(type: GLenum, source: String) -> GLuint? {
@@ -805,7 +824,8 @@ final class MetMuseumEngine: VisualizationEngine {
             glGetShaderiv(shader, GLenum(GL_INFO_LOG_LENGTH), &logLen)
             var log = [GLchar](repeating: 0, count: Int(max(logLen, 1)))
             glGetShaderInfoLog(shader, GLsizei(log.count), nil, &log)
-            NSLog("MetMuseumEngine: shader compile failed: %s", log)
+            let msg = String(cString: log)
+            NSLog("MetMuseumEngine: shader compile failed: %@", msg)
             glDeleteShader(shader)
             return nil
         }
@@ -831,7 +851,8 @@ final class MetMuseumEngine: VisualizationEngine {
             glGetProgramiv(prog, GLenum(GL_INFO_LOG_LENGTH), &logLen)
             var log = [GLchar](repeating: 0, count: Int(max(logLen, 1)))
             glGetProgramInfoLog(prog, GLsizei(log.count), nil, &log)
-            NSLog("MetMuseumEngine: program link failed: %s", log)
+            let msg = String(cString: log)
+            NSLog("MetMuseumEngine: program link failed: %@", msg)
             glDeleteProgram(prog)
             return nil
         }

--- a/Sources/NullPlayer/Visualization/MetMuseum/MetMuseumEngine.swift
+++ b/Sources/NullPlayer/Visualization/MetMuseum/MetMuseumEngine.swift
@@ -24,7 +24,6 @@ final class MetMuseumEngine: VisualizationEngine {
         var audioReactiveEffects: Bool = false
         var beatTriggeredChanges: Bool = false
         var aspectMode: AspectMode = .fit
-        var pauseOnAudioPause: Bool = false
         var showAttribution: Bool = false
     }
 
@@ -176,8 +175,10 @@ final class MetMuseumEngine: VisualizationEngine {
             }
         }
 
-        // Start slideshow
-        startSlideshow()
+        // Slideshow is gated on audio state — VisualizationGLView's engine
+        // factory calls setAudioActive() after creating us, which starts the
+        // slideshow if audio is playing. Auto-starting here would race that
+        // call and leave the slideshow running even when audio is stopped.
     }
 
     deinit {
@@ -422,10 +423,10 @@ final class MetMuseumEngine: VisualizationEngine {
         coreLock.lock()
         defer { coreLock.unlock() }
 
-        if !active && config.pauseOnAudioPause {
+        if !active {
             slideshowTask?.cancel()
             slideshowTask = nil
-        } else if active && slideshowTask == nil {
+        } else if slideshowTask == nil {
             startSlideshow()
         }
     }
@@ -613,14 +614,43 @@ final class MetMuseumEngine: VisualizationEngine {
         let image = NSImage(data: imageData)
         guard let image = image else { throw MetMuseumError.noImageURL }
 
+        // If the slideshow was cancelled while we were fetching (e.g. audio
+        // stopped), drop the image instead of pushing it to the GPU.
+        try Task.checkCancellation()
+
         coreLock.lock()
         let attribution = "\(objectInfo.title) - \(objectInfo.artistDisplayName ?? "Unknown") (\(objectInfo.objectDate ?? ""))"
         currentObjectID = objectInfo.objectID
         currentAttribution = attribution
-        nextImage = image
-        isTransitioning = true
-        transitionStartTime = Date()
-        transitionProgress = 0.0
+
+        // Skip the transition effect when the new image's aspect ratio differs
+        // from the current image's — the shader samples both textures with a
+        // single aspect uniform, so a mid-transition mismatch visibly stretches
+        // one of the two images. Hard-cutting looks cleaner than a stretched
+        // crossfade. Threshold is relative (>5%) so near-matches still animate.
+        let newW = Double(image.size.width)
+        let newH = Double(image.size.height)
+        let newAspect = newH > 0 ? newW / newH : 1.0
+        let curAspect = (currentImageWidth > 0 && currentImageHeight > 0)
+            ? Double(currentImageWidth) / Double(currentImageHeight)
+            : newAspect
+        let aspectMismatch = currentImage != nil &&
+            abs(newAspect - curAspect) / max(newAspect, curAspect) > 0.05
+
+        if aspectMismatch {
+            // Hard cut: route the upload straight to currentTexture and skip
+            // the animation. uploadImage targets currentTexture when
+            // !isTransitioning (see renderFrame), so clear the flag first.
+            isTransitioning = false
+            nextImage = nil
+            transitionProgress = 0.0
+            currentImage = image
+        } else {
+            nextImage = image
+            isTransitioning = true
+            transitionStartTime = Date()
+            transitionProgress = 0.0
+        }
         imageChangeTime = Date()
         pendingUploads.append((imageData, objectInfo.objectID))
         coreLock.unlock()
@@ -1047,7 +1077,6 @@ extension MetMuseumEngine {
         static let audioReactive = "metMuseumAudioReactive"
         static let beatTriggered = "metMuseumBeatTriggered"
         static let aspectMode = "metMuseumAspectMode"
-        static let pauseOnAudioPause = "metMuseumPauseOnAudioPause"
         static let showAttribution = "metMuseumShowAttribution"
     }
 }

--- a/Sources/NullPlayer/Visualization/MetMuseum/MetMuseumEngine.swift
+++ b/Sources/NullPlayer/Visualization/MetMuseum/MetMuseumEngine.swift
@@ -56,6 +56,7 @@ final class MetMuseumEngine: VisualizationEngine {
     private var currentImage: NSImage?
     private var currentAttribution: String = ""
     private var slideshowTask: Task<Void, Never>?
+    private var audioActive: Bool = false
 
     // Audio analysis
     private let rmsWindowSize = 512
@@ -112,8 +113,8 @@ final class MetMuseumEngine: VisualizationEngine {
     private var imageChangeTime: Date = Date()
 
     // Image dimensions for aspect ratio handling
-    private var currentImageWidth: Int = 0
-    private var currentImageHeight: Int = 0
+    private var currentImageWidth: Int = 256
+    private var currentImageHeight: Int = 256
     private var imageStartTime: Date = Date()
 
     // Department state (loaded at init)
@@ -383,11 +384,13 @@ final class MetMuseumEngine: VisualizationEngine {
         let oldDepartment = config.departmentID
         config = newConfig
 
-        // If department changed, restart slideshow
+        // If department changed, restart slideshow only while audio is active.
         if oldDepartment != newConfig.departmentID {
             slideshowTask?.cancel()
             slideshowTask = nil
-            startSlideshow()
+            if audioActive {
+                startSlideshow()
+            }
         }
     }
 
@@ -408,6 +411,7 @@ final class MetMuseumEngine: VisualizationEngine {
         coreLock.lock()
         defer { coreLock.unlock() }
         guard isAvailable else { return }
+        guard audioActive else { return }
         // Drop the request if a fetch is already underway — prevents key-mashing
         // from cancelling and re-issuing requests in a tight loop.
         if fetchInFlight { return }
@@ -423,6 +427,7 @@ final class MetMuseumEngine: VisualizationEngine {
         coreLock.lock()
         defer { coreLock.unlock() }
 
+        audioActive = active
         if !active {
             slideshowTask?.cancel()
             slideshowTask = nil
@@ -434,6 +439,15 @@ final class MetMuseumEngine: VisualizationEngine {
     // MARK: - Slideshow Management
 
     private func startSlideshow() {
+        coreLock.lock()
+        defer { coreLock.unlock() }
+
+        guard isAvailable, audioActive else {
+            slideshowTask?.cancel()
+            slideshowTask = nil
+            return
+        }
+
         slideshowTask?.cancel()
         // Task.detached so the slideshow loop is not born cancelled when
         // started from inside another task (e.g. advanceSlideshowImmediate).
@@ -494,10 +508,10 @@ final class MetMuseumEngine: VisualizationEngine {
     /// artwork (we just exhausted the random-attempt loop). Switch the active
     /// department to any remaining one, or to "all departments" if there's
     /// nothing else to fall back to.
-    private func excludeCurrentDepartmentAndPickAnother() {
+    private func excludeDepartmentAndPickAnother(_ departmentID: Int?) {
         coreLock.lock()
         defer { coreLock.unlock() }
-        guard let currentID = config.departmentID else {
+        guard let currentID = departmentID else {
             // Already searching across all departments — nothing to exclude.
             return
         }
@@ -511,13 +525,16 @@ final class MetMuseumEngine: VisualizationEngine {
             remaining = []
         }
         let nextID = remaining.randomElement()?.id
-        // nil here means "all departments" — a safe fallback.
-        config.departmentID = nextID
-        let key = MetMuseumEngine.DefaultsKey.departmentID
-        if let nextID = nextID {
-            UserDefaults.standard.set(nextID, forKey: key)
-        } else {
-            UserDefaults.standard.removeObject(forKey: key)
+        // nil here means "all departments" — a safe fallback. Only overwrite
+        // the live selection if the user has not already picked another department.
+        if config.departmentID == currentID {
+            config.departmentID = nextID
+            let key = MetMuseumEngine.DefaultsKey.departmentID
+            if let nextID = nextID {
+                UserDefaults.standard.set(nextID, forKey: key)
+            } else {
+                UserDefaults.standard.removeObject(forKey: key)
+            }
         }
     }
 
@@ -527,6 +544,7 @@ final class MetMuseumEngine: VisualizationEngine {
         // Task.detached so the child task does not inherit cancellation
         // from the parent context (see CLAUDE.md: regular Task { } inherits
         // cancellation and would self-cancel when startSlideshow() runs below).
+        guard isAvailable, audioActive else { return }
         slideshowTask?.cancel()
         slideshowTask = Task.detached { [weak self] in
             guard let self else { return }
@@ -537,17 +555,24 @@ final class MetMuseumEngine: VisualizationEngine {
             } catch {
                 NSLog("MetMuseumEngine beat-triggered advance error: %@", error.localizedDescription)
             }
+            do {
+                try Task.checkCancellation()
+            } catch {
+                return
+            }
             self.startSlideshow()
         }
     }
 
     private func fetchAndDisplayRandomArtwork() async throws {
+        let configSnapshot: Config
         coreLock.lock()
         if fetchInFlight {
             coreLock.unlock()
             return
         }
         fetchInFlight = true
+        configSnapshot = config
         coreLock.unlock()
         defer {
             coreLock.lock()
@@ -556,7 +581,7 @@ final class MetMuseumEngine: VisualizationEngine {
         }
 
         // Fetch list of object IDs for the department
-        let objectIDs = try await client.fetchObjectIDs(departmentID: config.departmentID)
+        let objectIDs = try await client.fetchObjectIDs(departmentID: configSnapshot.departmentID)
         guard !objectIDs.isEmpty else {
             throw MetMuseumError.noArtworkFound
         }
@@ -593,12 +618,14 @@ final class MetMuseumEngine: VisualizationEngine {
             throw throttleError
         }
 
+        try Task.checkCancellation()
+
         guard let objectInfo = selectedObject else {
             // Exhausted attempts without finding a public-domain piece. Mark
             // this department as empty so the menu hides it and the slideshow
             // doesn't keep retrying it. Pick a different department for the
             // next attempt.
-            excludeCurrentDepartmentAndPickAnother()
+            excludeDepartmentAndPickAnother(configSnapshot.departmentID)
             throw MetMuseumError.noArtworkFound
         }
 
@@ -607,7 +634,10 @@ final class MetMuseumEngine: VisualizationEngine {
         if let cachedData = imageCache.cachedImageData(for: objectInfo.objectID) {
             imageData = cachedData
         } else {
-            imageData = try await client.downloadImage(url: URL(string: objectInfo.primaryImage)!)
+            guard let imageURL = URL(string: objectInfo.primaryImage) else {
+                throw MetMuseumError.noImageURL
+            }
+            imageData = try await client.downloadImage(url: imageURL)
             imageCache.store(imageData, for: objectInfo.objectID)
         }
 
@@ -658,7 +688,7 @@ final class MetMuseumEngine: VisualizationEngine {
         // Queue attribution texture upload (runs on GL thread in renderFrame).
         // GL calls must happen on the render thread with the active context;
         // calling glBindTexture from this async Task crashes (KERN_INVALID_ADDRESS).
-        if config.showAttribution {
+        if getConfig().showAttribution {
             queueAttributionTexture(from: attribution)
         }
     }

--- a/Sources/NullPlayer/Visualization/MetMuseum/MetMuseumImageCache.swift
+++ b/Sources/NullPlayer/Visualization/MetMuseum/MetMuseumImageCache.swift
@@ -1,0 +1,153 @@
+import Foundation
+import AppKit
+
+/// Combined memory and disk cache for Met Museum images
+///
+/// - Memory cache: NSCache<NSNumber, NSImage> for fast access
+/// - Disk cache: ~/Library/Caches/NullPlayer/MetMuseum/ keyed by objectID
+/// - LRU pruning: Keeps disk cache ≤ 200 MB (configurable)
+final class MetMuseumImageCache {
+
+    // MARK: - Configuration
+
+    private var maxDiskCacheSizeBytes: Int = 200 * 1024 * 1024  // 200 MB default
+
+    // MARK: - State
+
+    private let memoryCache = NSCache<NSNumber, NSData>()
+    private let cacheDirectory: URL
+    private let fileManager = FileManager.default
+    private let cacheLock = NSLock()
+
+    // MARK: - Init
+
+    init() {
+        // Create cache directory: ~/Library/Caches/NullPlayer/MetMuseum/
+        guard let cachesDir = fileManager.urls(for: .cachesDirectory, in: .userDomainMask).first else {
+            fatalError("Unable to locate Caches directory")
+        }
+
+        let nullPlayerCache = cachesDir.appendingPathComponent("NullPlayer", isDirectory: true)
+        self.cacheDirectory = nullPlayerCache.appendingPathComponent("MetMuseum", isDirectory: true)
+
+        // Ensure directory exists
+        try? fileManager.createDirectory(at: cacheDirectory, withIntermediateDirectories: true, attributes: nil)
+
+        // Set memory cache limits
+        memoryCache.totalCostLimit = 100 * 1024 * 1024  // 100 MB memory cache
+    }
+
+    // MARK: - Public API
+
+    /// Retrieve raw image data from cache (memory first, then disk)
+    func cachedImageData(for objectID: Int) -> Data? {
+        cacheLock.lock()
+        defer { cacheLock.unlock() }
+
+        // Try memory cache first
+        let key = NSNumber(value: objectID)
+        if let data = memoryCache.object(forKey: key) as Data? {
+            return data
+        }
+
+        // Try disk cache
+        let fileURL = fileURLForObject(objectID)
+        guard fileManager.fileExists(atPath: fileURL.path),
+              let data = try? Data(contentsOf: fileURL) else {
+            return nil
+        }
+
+        // Populate memory cache
+        let cost = data.count
+        memoryCache.setObject(data as NSData, forKey: key, cost: cost)
+
+        return data
+    }
+
+    /// Store raw image data in both memory and disk caches
+    func store(_ data: Data, for objectID: Int) {
+        cacheLock.lock()
+        defer { cacheLock.unlock() }
+
+        let key = NSNumber(value: objectID)
+
+        // Store in memory cache
+        memoryCache.setObject(data as NSData, forKey: key, cost: data.count)
+
+        // Store in disk cache
+        let fileURL = fileURLForObject(objectID)
+        try? data.write(to: fileURL)
+
+        // Prune disk cache if needed
+        pruneDiskCacheIfNeeded()
+    }
+
+    /// Clear all cached images
+    func clearCache() {
+        cacheLock.lock()
+        defer { cacheLock.unlock() }
+
+        memoryCache.removeAllObjects()
+        try? fileManager.removeItem(at: cacheDirectory)
+        try? fileManager.createDirectory(at: cacheDirectory, withIntermediateDirectories: true, attributes: nil)
+    }
+
+    /// Prune disk cache to max size (called after each store)
+    func prune(maxBytes: Int) {
+        cacheLock.lock()
+        defer { cacheLock.unlock() }
+
+        let oldMax = self.maxDiskCacheSizeBytes
+        self.maxDiskCacheSizeBytes = maxBytes
+        pruneDiskCacheIfNeeded()
+        self.maxDiskCacheSizeBytes = oldMax
+    }
+
+    // MARK: - Private Helpers
+
+    private func fileURLForObject(_ objectID: Int) -> URL {
+        cacheDirectory.appendingPathComponent("\(objectID).dat")
+    }
+
+    /// LRU prune: remove oldest files until total size ≤ maxDiskCacheSizeBytes
+    private func pruneDiskCacheIfNeeded() {
+        guard let fileURLs = try? fileManager.contentsOfDirectory(at: cacheDirectory, includingPropertiesForKeys: [.contentModificationDateKey, .fileSizeKey]) else {
+            return
+        }
+
+        var totalSize: Int = 0
+        var fileInfo: [(url: URL, size: Int, date: Date)] = []
+
+        for url in fileURLs {
+            guard let resources = try? url.resourceValues(forKeys: [.fileSizeKey, .contentModificationDateKey]),
+                  let size = resources.fileSize,
+                  let date = resources.contentModificationDate else {
+                continue
+            }
+            fileInfo.append((url: url, size: size, date: date))
+            totalSize += size
+        }
+
+        // If we're under the limit, nothing to do
+        if totalSize <= maxDiskCacheSizeBytes {
+            return
+        }
+
+        // Sort by modification date (oldest first)
+        fileInfo.sort { $0.date < $1.date }
+
+        // Remove files until we're under the limit
+        var removed = 0
+        for (url, size, _) in fileInfo {
+            guard totalSize > maxDiskCacheSizeBytes else { break }
+
+            try? fileManager.removeItem(at: url)
+            totalSize -= size
+            removed += 1
+        }
+
+        if removed > 0 {
+            NSLog("MetMuseumImageCache: Pruned %d files from disk cache", removed)
+        }
+    }
+}

--- a/Sources/NullPlayer/Visualization/MetMuseum/MetMuseumImageCache.swift
+++ b/Sources/NullPlayer/Visualization/MetMuseum/MetMuseumImageCache.swift
@@ -146,8 +146,5 @@ final class MetMuseumImageCache {
             removed += 1
         }
 
-        if removed > 0 {
-            NSLog("MetMuseumImageCache: Pruned %d files from disk cache", removed)
-        }
     }
 }

--- a/Sources/NullPlayer/Visualization/MetMuseumMenuBuilder.swift
+++ b/Sources/NullPlayer/Visualization/MetMuseumMenuBuilder.swift
@@ -1,0 +1,247 @@
+import AppKit
+
+/// Shared menu builder for Met Museum Art visualization settings
+///
+/// Surfaces configuration for:
+/// - Department selection
+/// - Slideshow interval
+/// - Transition mode and duration
+/// - Aspect ratio
+/// - Audio effects toggles
+/// - Cache clear action
+final class MetMuseumMenuBuilder {
+
+    static func addMetMuseumEffectsMenuItems(to menu: NSMenu,
+                                              target: AnyObject,
+                                              visualizationView: VisualizationGLView?) {
+        // Read config once at the top
+        let config = (visualizationView?.currentEngine as? MetMuseumEngine)?.getConfig()
+
+        // Department selector
+        let deptItem = NSMenuItem(title: "Department", action: nil, keyEquivalent: "")
+        let deptMenu = NSMenu()
+        deptItem.submenu = deptMenu
+
+        // Extract current state from config
+        let currentDeptID = config?.departmentID
+
+        // Build menu based on department state
+        if let engine = visualizationView?.currentEngine as? MetMuseumEngine {
+            switch engine.departmentsState {
+            case .loading:
+                let loadingItem = NSMenuItem(title: "Loading departments…", action: nil, keyEquivalent: "")
+                loadingItem.isEnabled = false
+                deptMenu.addItem(loadingItem)
+
+                let randomItem = NSMenuItem(title: "Random / All",
+                                           action: #selector(MetMuseumMenuTarget.selectMetMuseumDepartment(_:)),
+                                           keyEquivalent: "")
+                randomItem.target = target
+                randomItem.tag = -1
+                randomItem.state = (currentDeptID == nil) ? .on : .off
+                deptMenu.addItem(randomItem)
+
+            case .loaded(let depts):
+                let randomItem = NSMenuItem(title: "Random / All",
+                                           action: #selector(MetMuseumMenuTarget.selectMetMuseumDepartment(_:)),
+                                           keyEquivalent: "")
+                randomItem.target = target
+                randomItem.tag = -1
+                randomItem.state = (currentDeptID == nil) ? .on : .off
+                deptMenu.addItem(randomItem)
+
+                deptMenu.addItem(NSMenuItem.separator())
+
+                for dept in depts {
+                    let item = NSMenuItem(title: dept.displayName,
+                                         action: #selector(MetMuseumMenuTarget.selectMetMuseumDepartment(_:)),
+                                         keyEquivalent: "")
+                    item.target = target
+                    item.tag = dept.id
+                    item.state = (currentDeptID == dept.id) ? NSControl.StateValue.on : NSControl.StateValue.off
+                    deptMenu.addItem(item)
+                }
+
+            case .failed:
+                let randomItem = NSMenuItem(title: "Random / All",
+                                           action: #selector(MetMuseumMenuTarget.selectMetMuseumDepartment(_:)),
+                                           keyEquivalent: "")
+                randomItem.target = target
+                randomItem.tag = -1
+                randomItem.state = (currentDeptID == nil) ? .on : .off
+                deptMenu.addItem(randomItem)
+            }
+        }
+
+        menu.addItem(deptItem)
+        menu.addItem(NSMenuItem.separator())
+
+        // Slideshow interval submenu
+        let intervalMenu = NSMenu()
+        let currentInterval = config?.intervalSeconds ?? 30.0
+
+        for (label, seconds) in [
+            ("10 seconds", 10.0),
+            ("20 seconds", 20.0),
+            ("30 seconds", 30.0),
+            ("60 seconds", 60.0),
+            ("2 minutes", 120.0),
+            ("5 minutes", 300.0),
+            ("10 minutes", 600.0)
+        ] {
+            let item = NSMenuItem(title: label,
+                                 action: #selector(MetMuseumMenuTarget.setMetMuseumInterval(_:)),
+                                 keyEquivalent: "")
+            item.target = target
+            item.tag = Int(seconds)
+            item.state = (abs(currentInterval - seconds) < 0.5) ? .on : .off
+            intervalMenu.addItem(item)
+        }
+        let intervalMenuItem = NSMenuItem(title: "Slideshow Interval", action: nil, keyEquivalent: "")
+        intervalMenuItem.submenu = intervalMenu
+        menu.addItem(intervalMenuItem)
+
+        // Transition mode submenu
+        let transMenu = NSMenu()
+        let currentMode = config?.transitionMode ?? .crossfade
+
+        for mode in MetMuseumEngine.TransitionMode.allCases {
+            let label = mode.displayLabel
+            let item = NSMenuItem(title: label,
+                                 action: #selector(MetMuseumMenuTarget.setMetMuseumTransitionMode(_:)),
+                                 keyEquivalent: "")
+            item.target = target
+            item.representedObject = mode.rawValue
+            item.state = (mode == currentMode) ? .on : .off
+            transMenu.addItem(item)
+        }
+        let transMenuItem = NSMenuItem(title: "Transition", action: nil, keyEquivalent: "")
+        transMenuItem.submenu = transMenu
+        menu.addItem(transMenuItem)
+
+        // Transition duration submenu
+        let durationMenu = NSMenu()
+        let currentDuration = config?.transitionDurationSeconds ?? 1.5
+
+        for (label, seconds) in [
+            ("0.5 seconds", 0.5),
+            ("1 second", 1.0),
+            ("1.5 seconds", 1.5),
+            ("2 seconds", 2.0),
+            ("3 seconds", 3.0)
+        ] {
+            let item = NSMenuItem(title: label,
+                                 action: #selector(MetMuseumMenuTarget.setMetMuseumTransitionDuration(_:)),
+                                 keyEquivalent: "")
+            item.target = target
+            item.tag = Int(seconds * 100)
+            item.state = (abs(currentDuration - seconds) < 0.05) ? .on : .off
+            durationMenu.addItem(item)
+        }
+        let durationMenuItem = NSMenuItem(title: "Transition Duration", action: nil, keyEquivalent: "")
+        durationMenuItem.submenu = durationMenu
+        menu.addItem(durationMenuItem)
+
+        // Aspect ratio submenu
+        let aspectMenu = NSMenu()
+        let currentAspect = config?.aspectMode ?? .fit
+
+        for mode in MetMuseumEngine.AspectMode.allCases {
+            let label = mode.displayLabel
+            let item = NSMenuItem(title: label,
+                                 action: #selector(MetMuseumMenuTarget.setMetMuseumAspectMode(_:)),
+                                 keyEquivalent: "")
+            item.target = target
+            item.representedObject = mode.rawValue
+            item.state = (mode == currentAspect) ? .on : .off
+            aspectMenu.addItem(item)
+        }
+        let aspectMenuItem = NSMenuItem(title: "Aspect Ratio", action: nil, keyEquivalent: "")
+        aspectMenuItem.submenu = aspectMenu
+        menu.addItem(aspectMenuItem)
+
+        menu.addItem(NSMenuItem.separator())
+
+        // Audio-Modulated Effects toggle
+        let audioReactiveEnabled = config?.audioReactiveEffects ?? false
+        let audioEffectsItem = NSMenuItem(title: "Audio-Modulated Effects",
+                                         action: #selector(MetMuseumMenuTarget.toggleMetMuseumAudioReactive(_:)),
+                                         keyEquivalent: "")
+        audioEffectsItem.target = target
+        audioEffectsItem.state = audioReactiveEnabled ? .on : .off
+        menu.addItem(audioEffectsItem)
+
+        // Beat-Triggered Changes toggle
+        let beatTriggeredEnabled = config?.beatTriggeredChanges ?? false
+        let beatTriggeredItem = NSMenuItem(title: "Beat-Triggered Changes",
+                                          action: #selector(MetMuseumMenuTarget.toggleMetMuseumBeatTriggered(_:)),
+                                          keyEquivalent: "")
+        beatTriggeredItem.target = target
+        beatTriggeredItem.state = beatTriggeredEnabled ? .on : .off
+        menu.addItem(beatTriggeredItem)
+
+        // Pause Slideshow When Audio Paused toggle
+        let pauseOnAudioPauseEnabled = config?.pauseOnAudioPause ?? false
+        let pauseOnAudioItem = NSMenuItem(title: "Pause Slideshow When Audio Paused",
+                                         action: #selector(MetMuseumMenuTarget.toggleMetMuseumPauseOnAudioPause(_:)),
+                                         keyEquivalent: "")
+        pauseOnAudioItem.target = target
+        pauseOnAudioItem.state = pauseOnAudioPauseEnabled ? .on : .off
+        menu.addItem(pauseOnAudioItem)
+
+        // Show Artist & Title toggle
+        let showAttributionEnabled = config?.showAttribution ?? false
+        let attributionItem = NSMenuItem(title: "Show Artist & Title",
+                                        action: #selector(MetMuseumMenuTarget.toggleMetMuseumShowAttribution(_:)),
+                                        keyEquivalent: "")
+        attributionItem.target = target
+        attributionItem.state = showAttributionEnabled ? .on : .off
+        menu.addItem(attributionItem)
+
+        menu.addItem(NSMenuItem.separator())
+
+        // Cache clear
+        let cacheItem = NSMenuItem(title: "Clear Image Cache",
+                                  action: #selector(MetMuseumMenuTarget.clearMetMuseumCache(_:)),
+                                  keyEquivalent: "")
+        cacheItem.target = target
+        menu.addItem(cacheItem)
+    }
+}
+
+// MARK: - Display Labels
+
+extension MetMuseumEngine.TransitionMode {
+    var displayLabel: String {
+        switch self {
+        case .crossfade: return "Crossfade"
+        case .kenBurns: return "Ken Burns"
+        case .beatCut: return "Beat-Synced Cut"
+        case .slide: return "Slide"
+        }
+    }
+}
+
+extension MetMuseumEngine.AspectMode {
+    var displayLabel: String {
+        switch self {
+        case .fit: return "Fit"
+        case .fill: return "Fill"
+        case .stretch: return "Stretch"
+        }
+    }
+}
+
+/// Protocol for objects that handle Met Museum visualization menu actions
+@objc(MetMuseumMenuTarget) protocol MetMuseumMenuTarget: AnyObject {
+    func selectMetMuseumDepartment(_ sender: NSMenuItem)
+    func setMetMuseumInterval(_ sender: NSMenuItem)
+    func setMetMuseumTransitionMode(_ sender: NSMenuItem)
+    func setMetMuseumTransitionDuration(_ sender: NSMenuItem)
+    func setMetMuseumAspectMode(_ sender: NSMenuItem)
+    func toggleMetMuseumAudioReactive(_ sender: NSMenuItem)
+    func toggleMetMuseumBeatTriggered(_ sender: NSMenuItem)
+    func toggleMetMuseumPauseOnAudioPause(_ sender: NSMenuItem)
+    func toggleMetMuseumShowAttribution(_ sender: NSMenuItem)
+    func clearMetMuseumCache(_ sender: NSMenuItem)
+}

--- a/Sources/NullPlayer/Visualization/MetMuseumMenuBuilder.swift
+++ b/Sources/NullPlayer/Visualization/MetMuseumMenuBuilder.swift
@@ -180,15 +180,6 @@ final class MetMuseumMenuBuilder {
         beatTriggeredItem.state = beatTriggeredEnabled ? .on : .off
         menu.addItem(beatTriggeredItem)
 
-        // Pause Slideshow When Audio Paused toggle
-        let pauseOnAudioPauseEnabled = config?.pauseOnAudioPause ?? false
-        let pauseOnAudioItem = NSMenuItem(title: "Pause Slideshow When Audio Paused",
-                                         action: #selector(MetMuseumMenuTarget.toggleMetMuseumPauseOnAudioPause(_:)),
-                                         keyEquivalent: "")
-        pauseOnAudioItem.target = target
-        pauseOnAudioItem.state = pauseOnAudioPauseEnabled ? .on : .off
-        menu.addItem(pauseOnAudioItem)
-
         // Show Artist & Title toggle
         let showAttributionEnabled = config?.showAttribution ?? false
         let attributionItem = NSMenuItem(title: "Show Artist & Title",
@@ -241,7 +232,6 @@ extension MetMuseumEngine.AspectMode {
     func setMetMuseumAspectMode(_ sender: NSMenuItem)
     func toggleMetMuseumAudioReactive(_ sender: NSMenuItem)
     func toggleMetMuseumBeatTriggered(_ sender: NSMenuItem)
-    func toggleMetMuseumPauseOnAudioPause(_ sender: NSMenuItem)
     func toggleMetMuseumShowAttribution(_ sender: NSMenuItem)
     func clearMetMuseumCache(_ sender: NSMenuItem)
 }

--- a/Sources/NullPlayer/Visualization/VisualizationEngine.swift
+++ b/Sources/NullPlayer/Visualization/VisualizationEngine.swift
@@ -99,6 +99,9 @@ enum VisualizationType: String, CaseIterable, Codable {
     /// Tripex engine (ben-marsh/tripex, ported to OpenGL on macOS)
     case tripex = "Tripex"
 
+    /// Met Museum Art visualization (rotating public domain artwork)
+    case metMuseum = "Met Museum Art"
+
     /// Human-readable display name
     var displayName: String {
         return self.rawValue

--- a/Sources/NullPlayer/Visualization/VisualizationGLView.swift
+++ b/Sources/NullPlayer/Visualization/VisualizationGLView.swift
@@ -385,10 +385,12 @@ class VisualizationGLView: NSOpenGLView {
                 }
                 config.audioReactiveEffects = UserDefaults.standard.bool(forKey: MetMuseumEngine.DefaultsKey.audioReactive)
                 config.beatTriggeredChanges = UserDefaults.standard.bool(forKey: MetMuseumEngine.DefaultsKey.beatTriggered)
-                config.pauseOnAudioPause = UserDefaults.standard.bool(forKey: MetMuseumEngine.DefaultsKey.pauseOnAudioPause)
                 config.showAttribution = UserDefaults.standard.bool(forKey: MetMuseumEngine.DefaultsKey.showAttribution)
 
                 metMuseum.setConfig(config)
+                // Sync audio state — engine no longer auto-starts its slideshow.
+                let isPlaying = WindowManager.shared.audioEngine.state == .playing
+                metMuseum.setAudioActive(isPlaying)
                 return metMuseum
             } else {
                 NSLog("VisualizationGLView: Met Museum engine not available")

--- a/Sources/NullPlayer/Visualization/VisualizationGLView.swift
+++ b/Sources/NullPlayer/Visualization/VisualizationGLView.swift
@@ -358,6 +358,42 @@ class VisualizationGLView: NSOpenGLView {
                 NSLog("VisualizationGLView: Tripex engine not available")
                 return nil
             }
+
+        case .metMuseum:
+            let metMuseum = MetMuseumEngine(width: width, height: height)
+            if metMuseum.isAvailable {
+                NSLog("VisualizationGLView: Met Museum engine initialized")
+                // Restore persisted configuration
+                var config = metMuseum.getConfig()
+
+                if let deptID = UserDefaults.standard.object(forKey: MetMuseumEngine.DefaultsKey.departmentID) as? Int {
+                    config.departmentID = (deptID == -1) ? nil : deptID
+                }
+                if let interval = UserDefaults.standard.object(forKey: MetMuseumEngine.DefaultsKey.intervalSeconds) as? Double {
+                    config.intervalSeconds = interval
+                }
+                if let modeStr = UserDefaults.standard.string(forKey: MetMuseumEngine.DefaultsKey.transitionMode),
+                   let mode = MetMuseumEngine.TransitionMode(rawValue: modeStr) {
+                    config.transitionMode = mode
+                }
+                if let duration = UserDefaults.standard.object(forKey: MetMuseumEngine.DefaultsKey.transitionDuration) as? Double {
+                    config.transitionDurationSeconds = duration
+                }
+                if let aspectStr = UserDefaults.standard.string(forKey: MetMuseumEngine.DefaultsKey.aspectMode),
+                   let aspect = MetMuseumEngine.AspectMode(rawValue: aspectStr) {
+                    config.aspectMode = aspect
+                }
+                config.audioReactiveEffects = UserDefaults.standard.bool(forKey: MetMuseumEngine.DefaultsKey.audioReactive)
+                config.beatTriggeredChanges = UserDefaults.standard.bool(forKey: MetMuseumEngine.DefaultsKey.beatTriggered)
+                config.pauseOnAudioPause = UserDefaults.standard.bool(forKey: MetMuseumEngine.DefaultsKey.pauseOnAudioPause)
+                config.showAttribution = UserDefaults.standard.bool(forKey: MetMuseumEngine.DefaultsKey.showAttribution)
+
+                metMuseum.setConfig(config)
+                return metMuseum
+            } else {
+                NSLog("VisualizationGLView: Met Museum engine not available")
+                return nil
+            }
         }
     }
 
@@ -694,6 +730,10 @@ class VisualizationGLView: NSOpenGLView {
                 pm.beatSensitivity = normalBeatSensitivity
                 NSLog("VisualizationGLView: Audio active, beat sensitivity = %.2f", normalBeatSensitivity)
             }
+            // Resume slideshow if paused (Met Museum)
+            if let mm = engine as? MetMuseumEngine {
+                mm.setAudioActive(true)
+            }
         } else {
             dataLock.withLock {
                 for i in 0..<localPCM.count {
@@ -708,6 +748,10 @@ class VisualizationGLView: NSOpenGLView {
             if let pm = engine as? ProjectMWrapper {
                 pm.beatSensitivity = idleBeatSensitivity
                 NSLog("VisualizationGLView: Audio idle, beat sensitivity = %.2f", idleBeatSensitivity)
+            }
+            // Pause slideshow if configured (Met Museum)
+            if let mm = engine as? MetMuseumEngine {
+                mm.setAudioActive(false)
             }
         }
     }
@@ -1231,6 +1275,14 @@ class VisualizationGLView: NSOpenGLView {
         defer { engineLock.unlock() }
         guard let t = engine as? TripexEngine else { return }
         body(t)
+    }
+
+    /// Accessor for Met Museum departments state (used by menu builder)
+    func metMuseumDepartmentsState() -> MetMuseumEngine.DepartmentsState? {
+        engineLock.lock()
+        defer { engineLock.unlock() }
+        guard let mm = engine as? MetMuseumEngine else { return nil }
+        return mm.departmentsState
     }
 
     // MARK: - Geiss Configuration (UserDefaults persistence)

--- a/Sources/NullPlayer/Visualization/VisualizationGLView.swift
+++ b/Sources/NullPlayer/Visualization/VisualizationGLView.swift
@@ -559,7 +559,6 @@ class VisualizationGLView: NSOpenGLView {
         
         CVDisplayLinkStart(displayLink)
         isRendering = true
-        NSLog("VisualizationGLView: Started rendering")
     }
     
     func stopRendering() {
@@ -577,8 +576,6 @@ class VisualizationGLView: NSOpenGLView {
             contextRef.release()
             displayLinkContextRef = nil
         }
-        
-        NSLog("VisualizationGLView: Stopped rendering")
     }
 
     func resumeRenderingAfterWindowTransition() {
@@ -1275,6 +1272,14 @@ class VisualizationGLView: NSOpenGLView {
         defer { engineLock.unlock() }
         guard let t = engine as? TripexEngine else { return }
         body(t)
+    }
+
+    /// Skip immediately to a new random artwork (Met Museum).
+    func nextMetMuseumArtwork() {
+        engineLock.lock()
+        defer { engineLock.unlock() }
+        guard let mm = engine as? MetMuseumEngine else { return }
+        mm.skipToNextArtwork()
     }
 
     /// Accessor for Met Museum departments state (used by menu builder)

--- a/Sources/NullPlayer/Visualization/VisualizationGLView.swift
+++ b/Sources/NullPlayer/Visualization/VisualizationGLView.swift
@@ -417,9 +417,15 @@ class VisualizationGLView: NSOpenGLView {
                    let aspect = MetMuseumEngine.AspectMode(rawValue: aspectStr) {
                     config.aspectMode = aspect
                 }
-                config.audioReactiveEffects = UserDefaults.standard.bool(forKey: MetMuseumEngine.DefaultsKey.audioReactive)
-                config.beatTriggeredChanges = UserDefaults.standard.bool(forKey: MetMuseumEngine.DefaultsKey.beatTriggered)
-                config.showAttribution = UserDefaults.standard.bool(forKey: MetMuseumEngine.DefaultsKey.showAttribution)
+                if UserDefaults.standard.object(forKey: MetMuseumEngine.DefaultsKey.audioReactive) != nil {
+                    config.audioReactiveEffects = UserDefaults.standard.bool(forKey: MetMuseumEngine.DefaultsKey.audioReactive)
+                }
+                if UserDefaults.standard.object(forKey: MetMuseumEngine.DefaultsKey.beatTriggered) != nil {
+                    config.beatTriggeredChanges = UserDefaults.standard.bool(forKey: MetMuseumEngine.DefaultsKey.beatTriggered)
+                }
+                if UserDefaults.standard.object(forKey: MetMuseumEngine.DefaultsKey.showAttribution) != nil {
+                    config.showAttribution = UserDefaults.standard.bool(forKey: MetMuseumEngine.DefaultsKey.showAttribution)
+                }
 
                 metMuseum.setConfig(config)
                 // Sync audio state — engine no longer auto-starts its slideshow.

--- a/Sources/NullPlayer/Visualization/VisualizationGLView.swift
+++ b/Sources/NullPlayer/Visualization/VisualizationGLView.swift
@@ -62,10 +62,10 @@ class VisualizationGLView: NSOpenGLView {
     private var isAudioActive = false
     
     /// Normal beat sensitivity (restored when audio starts)
-    /// User-configurable via context menu, persisted in UserDefaults
+    /// User-configurable via context menu, persisted per-engine in UserDefaults
     private(set) var normalBeatSensitivity: Float = 1.0 {
         didSet {
-            UserDefaults.standard.set(normalBeatSensitivity, forKey: "projectMBeatSensitivity")
+            UserDefaults.standard.set(normalBeatSensitivity, forKey: Self.beatSensKey(for: currentEngineType))
         }
     }
     
@@ -118,7 +118,7 @@ class VisualizationGLView: NSOpenGLView {
     /// Saved to UserDefaults for persistence
     private(set) var isLowPowerMode: Bool = true {
         didSet {
-            UserDefaults.standard.set(isLowPowerMode, forKey: "projectMLowPowerMode")
+            UserDefaults.standard.set(isLowPowerMode, forKey: Self.lowPowerKey(for: currentEngineType))
         }
     }
     
@@ -127,7 +127,59 @@ class VisualizationGLView: NSOpenGLView {
     /// Range: 0.5 to 3.0, default 1.0 (unity gain)
     private(set) var pcmGain: Float = 1.0 {
         didSet {
-            UserDefaults.standard.set(pcmGain, forKey: "projectMPCMGain")
+            UserDefaults.standard.set(pcmGain, forKey: Self.pcmGainKey(for: currentEngineType))
+        }
+    }
+
+    // MARK: - Per-engine scoped preference keys
+
+    private static func pcmGainKey(for t: VisualizationType) -> String { "viz.\(t.rawValue).pcmGain" }
+    private static func lowPowerKey(for t: VisualizationType) -> String { "viz.\(t.rawValue).lowPowerMode" }
+    private static func beatSensKey(for t: VisualizationType) -> String { "viz.\(t.rawValue).beatSensitivity" }
+
+    private static let legacyMigrationFlagKey = "viz.legacyMigrationV1"
+
+    /// Copy legacy global `projectM*` keys into the scoped `viz.projectM.*` slots once,
+    /// so existing ProjectM users keep their settings after the per-engine split.
+    private static func migrateLegacyProjectMKeysIfNeeded() {
+        let defaults = UserDefaults.standard
+        guard !defaults.bool(forKey: legacyMigrationFlagKey) else { return }
+
+        let pairs: [(legacy: String, scoped: String)] = [
+            ("projectMPCMGain", pcmGainKey(for: .projectM)),
+            ("projectMLowPowerMode", lowPowerKey(for: .projectM)),
+            ("projectMBeatSensitivity", beatSensKey(for: .projectM)),
+        ]
+        for (legacy, scoped) in pairs {
+            if defaults.object(forKey: scoped) == nil,
+               let legacyValue = defaults.object(forKey: legacy) {
+                defaults.set(legacyValue, forKey: scoped)
+            }
+        }
+        defaults.set(true, forKey: legacyMigrationFlagKey)
+    }
+
+    /// Load the three per-engine scoped settings into the live properties.
+    /// Falls back to defaults (lowPower=true, pcmGain=1.0, beatSensitivity=1.0) when absent.
+    private func loadScopedSettings(for type: VisualizationType) {
+        let defaults = UserDefaults.standard
+
+        if defaults.object(forKey: Self.lowPowerKey(for: type)) != nil {
+            isLowPowerMode = defaults.bool(forKey: Self.lowPowerKey(for: type))
+        } else {
+            isLowPowerMode = true
+        }
+
+        if defaults.object(forKey: Self.pcmGainKey(for: type)) != nil {
+            pcmGain = defaults.float(forKey: Self.pcmGainKey(for: type))
+        } else {
+            pcmGain = 1.0
+        }
+
+        if defaults.object(forKey: Self.beatSensKey(for: type)) != nil {
+            normalBeatSensitivity = defaults.float(forKey: Self.beatSensKey(for: type))
+        } else {
+            normalBeatSensitivity = 1.0
         }
     }
     
@@ -162,21 +214,12 @@ class VisualizationGLView: NSOpenGLView {
            let type = VisualizationType(rawValue: savedType) {
             currentEngineType = type
         }
-        
-        // Load saved performance mode preference (defaults to low power / 30fps)
-        if UserDefaults.standard.object(forKey: "projectMLowPowerMode") != nil {
-            isLowPowerMode = UserDefaults.standard.bool(forKey: "projectMLowPowerMode")
-        }
-        
-        // Load saved PCM gain preference (defaults to 1.0 / unity gain)
-        if UserDefaults.standard.object(forKey: "projectMPCMGain") != nil {
-            pcmGain = UserDefaults.standard.float(forKey: "projectMPCMGain")
-        }
-        
-        // Load saved beat sensitivity preference (defaults to 1.0 / normal)
-        if UserDefaults.standard.object(forKey: "projectMBeatSensitivity") != nil {
-            normalBeatSensitivity = UserDefaults.standard.float(forKey: "projectMBeatSensitivity")
-        }
+
+        // Migrate legacy global ProjectM keys into per-engine scoped keys (one-shot)
+        Self.migrateLegacyProjectMKeysIfNeeded()
+
+        // Load per-engine scoped settings (low power, PCM gain, beat sensitivity)
+        loadScopedSettings(for: currentEngineType)
 
         // Load saved Geiss configuration preferences
         loadGeissConfigFromDefaults()
@@ -200,20 +243,11 @@ class VisualizationGLView: NSOpenGLView {
             currentEngineType = type
         }
 
-        // Load saved performance mode preference (defaults to low power / 30fps)
-        if UserDefaults.standard.object(forKey: "projectMLowPowerMode") != nil {
-            isLowPowerMode = UserDefaults.standard.bool(forKey: "projectMLowPowerMode")
-        }
+        // Migrate legacy global ProjectM keys into per-engine scoped keys (one-shot)
+        Self.migrateLegacyProjectMKeysIfNeeded()
 
-        // Load saved PCM gain preference (defaults to 1.0 / unity gain)
-        if UserDefaults.standard.object(forKey: "projectMPCMGain") != nil {
-            pcmGain = UserDefaults.standard.float(forKey: "projectMPCMGain")
-        }
-
-        // Load saved beat sensitivity preference (defaults to 1.0 / normal)
-        if UserDefaults.standard.object(forKey: "projectMBeatSensitivity") != nil {
-            normalBeatSensitivity = UserDefaults.standard.float(forKey: "projectMBeatSensitivity")
-        }
+        // Load per-engine scoped settings (low power, PCM gain, beat sensitivity)
+        loadScopedSettings(for: currentEngineType)
 
         // Load saved Geiss configuration preferences
         loadGeissConfigFromDefaults()
@@ -444,6 +478,10 @@ class VisualizationGLView: NSOpenGLView {
 
         // Save preference
         UserDefaults.standard.set(type.rawValue, forKey: "visualizationEngineType")
+
+        // Repopulate per-engine scoped settings (low power, PCM gain, beat sensitivity)
+        // from the new engine's stored values, falling back to defaults on first use.
+        loadScopedSettings(for: type)
 
         // Mark engine for reinitialization on next render
         engineNeedsSetup = true

--- a/Sources/NullPlayer/Windows/ModernProjectM/ModernProjectMView.swift
+++ b/Sources/NullPlayer/Windows/ModernProjectM/ModernProjectMView.swift
@@ -11,7 +11,7 @@ import AppKit
 // =============================================================================
 
 /// Modern ProjectM visualization view with full modern skin support
-class ModernProjectMView: NSView, GeissMenuTarget, TripexMenuTarget {
+class ModernProjectMView: NSView, GeissMenuTarget, TripexMenuTarget, MetMuseumMenuTarget {
     
     // MARK: - Properties
     
@@ -764,6 +764,7 @@ class ModernProjectMView: NSView, GeissMenuTarget, TripexMenuTarget {
         let isProjectMActive = currentEngineType == .projectM && isProjectMAvailable
         let isGeissActive = currentEngineType == .geiss
         let isTripexActive = currentEngineType == .tripex
+        let isMetMuseumActive = currentEngineType == .metMuseum
         
         // Preset navigation (only when projectM is available)
         if isProjectMActive {
@@ -915,6 +916,8 @@ class ModernProjectMView: NSView, GeissMenuTarget, TripexMenuTarget {
             addGeissEffectsMenuItems(to: menu)
         } else if isTripexActive {
             addTripexEffectsMenuItems(to: menu)
+        } else if isMetMuseumActive {
+            addMetMuseumEffectsMenuItems(to: menu)
         }
         
         // Visualization Engine selector
@@ -1088,6 +1091,114 @@ class ModernProjectMView: NSView, GeissMenuTarget, TripexMenuTarget {
         let value = Float(sender.tag) / 100.0
         visualizationGLView?.tripexIntensityScale = value
         UserDefaults.standard.set(value, forKey: TripexEngine.DefaultsKey.intensityScale)
+    }
+
+    private func addMetMuseumEffectsMenuItems(to menu: NSMenu) {
+        guard let glView = visualizationGLView else { return }
+        MetMuseumMenuBuilder.addMetMuseumEffectsMenuItems(to: menu,
+                                                          target: self,
+                                                          visualizationView: glView)
+    }
+
+    // MARK: - MetMuseumMenuTarget
+
+    @objc func selectMetMuseumDepartment(_ sender: NSMenuItem) {
+        let deptID = sender.tag
+        let value: Int? = (deptID == -1) ? nil : deptID
+        if let v = value {
+            UserDefaults.standard.set(v, forKey: MetMuseumEngine.DefaultsKey.departmentID)
+        } else {
+            UserDefaults.standard.removeObject(forKey: MetMuseumEngine.DefaultsKey.departmentID)
+        }
+        if let engine = visualizationGLView?.currentEngine as? MetMuseumEngine {
+            var config = engine.getConfig()
+            config.departmentID = value
+            engine.setConfig(config)
+        }
+    }
+
+    @objc func setMetMuseumInterval(_ sender: NSMenuItem) {
+        let seconds = Double(sender.tag)
+        UserDefaults.standard.set(seconds, forKey: MetMuseumEngine.DefaultsKey.intervalSeconds)
+        if let engine = visualizationGLView?.currentEngine as? MetMuseumEngine {
+            var config = engine.getConfig()
+            config.intervalSeconds = seconds
+            engine.setConfig(config)
+        }
+    }
+
+    @objc func setMetMuseumTransitionMode(_ sender: NSMenuItem) {
+        guard let modeStr = sender.representedObject as? String,
+              let mode = MetMuseumEngine.TransitionMode(rawValue: modeStr) else { return }
+        UserDefaults.standard.set(modeStr, forKey: MetMuseumEngine.DefaultsKey.transitionMode)
+        if let engine = visualizationGLView?.currentEngine as? MetMuseumEngine {
+            var config = engine.getConfig()
+            config.transitionMode = mode
+            engine.setConfig(config)
+        }
+    }
+
+    @objc func setMetMuseumTransitionDuration(_ sender: NSMenuItem) {
+        let seconds = Double(sender.tag) / 100.0
+        UserDefaults.standard.set(seconds, forKey: MetMuseumEngine.DefaultsKey.transitionDuration)
+        if let engine = visualizationGLView?.currentEngine as? MetMuseumEngine {
+            var config = engine.getConfig()
+            config.transitionDurationSeconds = seconds
+            engine.setConfig(config)
+        }
+    }
+
+    @objc func setMetMuseumAspectMode(_ sender: NSMenuItem) {
+        guard let aspectStr = sender.representedObject as? String,
+              let aspect = MetMuseumEngine.AspectMode(rawValue: aspectStr) else { return }
+        UserDefaults.standard.set(aspectStr, forKey: MetMuseumEngine.DefaultsKey.aspectMode)
+        if let engine = visualizationGLView?.currentEngine as? MetMuseumEngine {
+            var config = engine.getConfig()
+            config.aspectMode = aspect
+            engine.setConfig(config)
+        }
+    }
+
+    @objc func toggleMetMuseumAudioReactive(_ sender: NSMenuItem) {
+        if let engine = visualizationGLView?.currentEngine as? MetMuseumEngine {
+            var config = engine.getConfig()
+            config.audioReactiveEffects = !config.audioReactiveEffects
+            UserDefaults.standard.set(config.audioReactiveEffects, forKey: MetMuseumEngine.DefaultsKey.audioReactive)
+            engine.setConfig(config)
+        }
+    }
+
+    @objc func toggleMetMuseumBeatTriggered(_ sender: NSMenuItem) {
+        if let engine = visualizationGLView?.currentEngine as? MetMuseumEngine {
+            var config = engine.getConfig()
+            config.beatTriggeredChanges = !config.beatTriggeredChanges
+            UserDefaults.standard.set(config.beatTriggeredChanges, forKey: MetMuseumEngine.DefaultsKey.beatTriggered)
+            engine.setConfig(config)
+        }
+    }
+
+    @objc func toggleMetMuseumPauseOnAudioPause(_ sender: NSMenuItem) {
+        if let engine = visualizationGLView?.currentEngine as? MetMuseumEngine {
+            var config = engine.getConfig()
+            config.pauseOnAudioPause = !config.pauseOnAudioPause
+            UserDefaults.standard.set(config.pauseOnAudioPause, forKey: MetMuseumEngine.DefaultsKey.pauseOnAudioPause)
+            engine.setConfig(config)
+        }
+    }
+
+    @objc func toggleMetMuseumShowAttribution(_ sender: NSMenuItem) {
+        if let engine = visualizationGLView?.currentEngine as? MetMuseumEngine {
+            var config = engine.getConfig()
+            config.showAttribution = !config.showAttribution
+            UserDefaults.standard.set(config.showAttribution, forKey: MetMuseumEngine.DefaultsKey.showAttribution)
+            engine.setConfig(config)
+        }
+    }
+
+    @objc func clearMetMuseumCache(_ sender: NSMenuItem) {
+        if let engine = visualizationGLView?.currentEngine as? MetMuseumEngine {
+            engine.clearCache()
+        }
     }
 
     @objc private func nextGeissEffectAction(_ sender: Any?) {

--- a/Sources/NullPlayer/Windows/ModernProjectM/ModernProjectMView.swift
+++ b/Sources/NullPlayer/Windows/ModernProjectM/ModernProjectMView.swift
@@ -1184,15 +1184,6 @@ class ModernProjectMView: NSView, GeissMenuTarget, TripexMenuTarget, MetMuseumMe
         }
     }
 
-    @objc func toggleMetMuseumPauseOnAudioPause(_ sender: NSMenuItem) {
-        if let engine = visualizationGLView?.currentEngine as? MetMuseumEngine {
-            var config = engine.getConfig()
-            config.pauseOnAudioPause = !config.pauseOnAudioPause
-            UserDefaults.standard.set(config.pauseOnAudioPause, forKey: MetMuseumEngine.DefaultsKey.pauseOnAudioPause)
-            engine.setConfig(config)
-        }
-    }
-
     @objc func toggleMetMuseumShowAttribution(_ sender: NSMenuItem) {
         if let engine = visualizationGLView?.currentEngine as? MetMuseumEngine {
             var config = engine.getConfig()

--- a/Sources/NullPlayer/Windows/ModernProjectM/ModernProjectMView.swift
+++ b/Sources/NullPlayer/Windows/ModernProjectM/ModernProjectMView.swift
@@ -700,6 +700,8 @@ class ModernProjectMView: NSView, GeissMenuTarget, TripexMenuTarget, MetMuseumMe
                 visualizationGLView?.nextGeissEffect()
             } else if visualizationGLView?.currentEngineType == .tripex {
                 visualizationGLView?.nextTripexEffect()
+            } else if visualizationGLView?.currentEngineType == .metMuseum {
+                visualizationGLView?.nextMetMuseumArtwork()
             } else if hasShift {
                 visualizationGLView?.nextPreset(hardCut: true)
             } else {
@@ -712,6 +714,9 @@ class ModernProjectMView: NSView, GeissMenuTarget, TripexMenuTarget, MetMuseumMe
                 visualizationGLView?.previousGeissEffect()
             } else if visualizationGLView?.currentEngineType == .tripex {
                 visualizationGLView?.previousTripexEffect()
+            } else if visualizationGLView?.currentEngineType == .metMuseum {
+                // Met Museum is random-only; left arrow advances like right.
+                visualizationGLView?.nextMetMuseumArtwork()
             } else if hasShift {
                 visualizationGLView?.previousPreset(hardCut: true)
             } else {
@@ -724,6 +729,8 @@ class ModernProjectMView: NSView, GeissMenuTarget, TripexMenuTarget, MetMuseumMe
                 visualizationGLView?.randomGeissEffect()
             } else if visualizationGLView?.currentEngineType == .tripex {
                 visualizationGLView?.randomTripexEffect()
+            } else if visualizationGLView?.currentEngineType == .metMuseum {
+                visualizationGLView?.nextMetMuseumArtwork()
             } else if hasShift {
                 visualizationGLView?.randomPreset(hardCut: true)
             } else {

--- a/Sources/NullPlayer/Windows/ProjectM/ProjectMView.swift
+++ b/Sources/NullPlayer/Windows/ProjectM/ProjectMView.swift
@@ -719,6 +719,8 @@ class ProjectMView: NSView, GeissMenuTarget, TripexMenuTarget, MetMuseumMenuTarg
                 visualizationGLView?.nextGeissEffect()
             } else if visualizationGLView?.currentEngineType == .tripex {
                 visualizationGLView?.nextTripexEffect()
+            } else if visualizationGLView?.currentEngineType == .metMuseum {
+                visualizationGLView?.nextMetMuseumArtwork()
             } else if hasShift {
                 // Hard cut (instant switch)
                 visualizationGLView?.nextPreset(hardCut: true)
@@ -732,6 +734,9 @@ class ProjectMView: NSView, GeissMenuTarget, TripexMenuTarget, MetMuseumMenuTarg
                 visualizationGLView?.previousGeissEffect()
             } else if visualizationGLView?.currentEngineType == .tripex {
                 visualizationGLView?.previousTripexEffect()
+            } else if visualizationGLView?.currentEngineType == .metMuseum {
+                // Met Museum is random-only; left arrow advances like right.
+                visualizationGLView?.nextMetMuseumArtwork()
             } else if hasShift {
                 visualizationGLView?.previousPreset(hardCut: true)
             } else {
@@ -744,6 +749,8 @@ class ProjectMView: NSView, GeissMenuTarget, TripexMenuTarget, MetMuseumMenuTarg
                 visualizationGLView?.randomGeissEffect()
             } else if visualizationGLView?.currentEngineType == .tripex {
                 visualizationGLView?.randomTripexEffect()
+            } else if visualizationGLView?.currentEngineType == .metMuseum {
+                visualizationGLView?.nextMetMuseumArtwork()
             } else if hasShift {
                 visualizationGLView?.randomPreset(hardCut: true)
             } else {

--- a/Sources/NullPlayer/Windows/ProjectM/ProjectMView.swift
+++ b/Sources/NullPlayer/Windows/ProjectM/ProjectMView.swift
@@ -10,7 +10,7 @@ import AppKit
 // =============================================================================
 
 /// ProjectM visualization view with full skin support
-class ProjectMView: NSView, GeissMenuTarget, TripexMenuTarget {
+class ProjectMView: NSView, GeissMenuTarget, TripexMenuTarget, MetMuseumMenuTarget {
     
     // MARK: - Properties
     
@@ -784,6 +784,7 @@ class ProjectMView: NSView, GeissMenuTarget, TripexMenuTarget {
         let isProjectMActive = currentEngineType == .projectM && isProjectMAvailable
         let isGeissActive = currentEngineType == .geiss
         let isTripexActive = currentEngineType == .tripex
+        let isMetMuseumActive = currentEngineType == .metMuseum
         
         // Preset navigation (only when projectM is available)
         if isProjectMActive {
@@ -935,6 +936,8 @@ class ProjectMView: NSView, GeissMenuTarget, TripexMenuTarget {
             addGeissEffectsMenuItems(to: menu)
         } else if isTripexActive {
             addTripexEffectsMenuItems(to: menu)
+        } else if isMetMuseumActive {
+            addMetMuseumEffectsMenuItems(to: menu)
         }
 
         // Visualization Engine selector
@@ -1106,6 +1109,105 @@ class ProjectMView: NSView, GeissMenuTarget, TripexMenuTarget {
         let value = Float(sender.tag) / 100.0
         visualizationGLView?.tripexIntensityScale = value
         UserDefaults.standard.set(value, forKey: TripexEngine.DefaultsKey.intensityScale)
+    }
+
+    private func addMetMuseumEffectsMenuItems(to menu: NSMenu) {
+        guard let glView = visualizationGLView else { return }
+        MetMuseumMenuBuilder.addMetMuseumEffectsMenuItems(to: menu,
+                                                          target: self,
+                                                          visualizationView: glView)
+    }
+
+    // MARK: - MetMuseumMenuTarget
+
+    @objc func selectMetMuseumDepartment(_ sender: NSMenuItem) {
+        let deptID = sender.tag
+        let value: Int? = (deptID == -1) ? nil : deptID
+        if let v = value {
+            UserDefaults.standard.set(v, forKey: MetMuseumEngine.DefaultsKey.departmentID)
+        } else {
+            UserDefaults.standard.removeObject(forKey: MetMuseumEngine.DefaultsKey.departmentID)
+        }
+        if let engine = visualizationGLView?.currentEngine as? MetMuseumEngine {
+            var config = engine.getConfig()
+            config.departmentID = value
+            engine.setConfig(config)
+        }
+    }
+
+    @objc func setMetMuseumInterval(_ sender: NSMenuItem) {
+        let seconds = Double(sender.tag)
+        UserDefaults.standard.set(seconds, forKey: MetMuseumEngine.DefaultsKey.intervalSeconds)
+        if let engine = visualizationGLView?.currentEngine as? MetMuseumEngine {
+            var config = engine.getConfig()
+            config.intervalSeconds = seconds
+            engine.setConfig(config)
+        }
+    }
+
+    @objc func setMetMuseumTransitionMode(_ sender: NSMenuItem) {
+        guard let modeStr = sender.representedObject as? String,
+              let mode = MetMuseumEngine.TransitionMode(rawValue: modeStr) else { return }
+        UserDefaults.standard.set(modeStr, forKey: MetMuseumEngine.DefaultsKey.transitionMode)
+        if let engine = visualizationGLView?.currentEngine as? MetMuseumEngine {
+            var config = engine.getConfig()
+            config.transitionMode = mode
+            engine.setConfig(config)
+        }
+    }
+
+    @objc func setMetMuseumTransitionDuration(_ sender: NSMenuItem) {
+        let seconds = Double(sender.tag) / 100.0
+        UserDefaults.standard.set(seconds, forKey: MetMuseumEngine.DefaultsKey.transitionDuration)
+        if let engine = visualizationGLView?.currentEngine as? MetMuseumEngine {
+            var config = engine.getConfig()
+            config.transitionDurationSeconds = seconds
+            engine.setConfig(config)
+        }
+    }
+
+    @objc func setMetMuseumAspectMode(_ sender: NSMenuItem) {
+        guard let aspectStr = sender.representedObject as? String,
+              let aspect = MetMuseumEngine.AspectMode(rawValue: aspectStr) else { return }
+        UserDefaults.standard.set(aspectStr, forKey: MetMuseumEngine.DefaultsKey.aspectMode)
+        if let engine = visualizationGLView?.currentEngine as? MetMuseumEngine {
+            var config = engine.getConfig()
+            config.aspectMode = aspect
+            engine.setConfig(config)
+        }
+    }
+
+    @objc func toggleMetMuseumAudioReactive(_ sender: NSMenuItem) {
+        if let engine = visualizationGLView?.currentEngine as? MetMuseumEngine {
+            var config = engine.getConfig()
+            config.audioReactiveEffects = !config.audioReactiveEffects
+            UserDefaults.standard.set(config.audioReactiveEffects, forKey: MetMuseumEngine.DefaultsKey.audioReactive)
+            engine.setConfig(config)
+        }
+    }
+
+    @objc func toggleMetMuseumBeatTriggered(_ sender: NSMenuItem) {
+        if let engine = visualizationGLView?.currentEngine as? MetMuseumEngine {
+            var config = engine.getConfig()
+            config.beatTriggeredChanges = !config.beatTriggeredChanges
+            UserDefaults.standard.set(config.beatTriggeredChanges, forKey: MetMuseumEngine.DefaultsKey.beatTriggered)
+            engine.setConfig(config)
+        }
+    }
+
+    @objc func toggleMetMuseumShowAttribution(_ sender: NSMenuItem) {
+        if let engine = visualizationGLView?.currentEngine as? MetMuseumEngine {
+            var config = engine.getConfig()
+            config.showAttribution = !config.showAttribution
+            UserDefaults.standard.set(config.showAttribution, forKey: MetMuseumEngine.DefaultsKey.showAttribution)
+            engine.setConfig(config)
+        }
+    }
+
+    @objc func clearMetMuseumCache(_ sender: NSMenuItem) {
+        if let engine = visualizationGLView?.currentEngine as? MetMuseumEngine {
+            engine.clearCache()
+        }
     }
 
     @objc private func nextGeissEffectAction(_ sender: Any?) {

--- a/skills/visualizations/SKILL.md
+++ b/skills/visualizations/SKILL.md
@@ -260,6 +260,50 @@ All lever state is persisted to UserDefaults under the `geiss.*` namespace (`gei
 - **Persistence**: The active engine is stored in UserDefaults as `visualizationEngineType` and in AppState v2 as the optional raw string field `visualizationEngineType`. Missing or unknown values default to ProjectM.
 - **Licensing**: Geiss is credited in the About window and its BSD-3-Clause license is bundled as `ThirdPartyLicenses/GEISS_LICENSE.txt`.
 
+## Met Museum Art Visualization
+
+A ProjectM-peer engine that displays a slideshow of public-domain artwork from the Metropolitan Museum of Art's Open Access collection (api.collection.metmuseum.org). Selected from the same right-click **Visualization Engine** submenu as ProjectM/Geiss/Tripex, and reuses the same fullscreen, frame-rate, window docking, and engine-switch lifecycle.
+
+### Controls
+
+**Keyboard Shortcuts** (wired in both `ProjectMView` and `ModernProjectMView`):
+- **→ / Space**: Next artwork
+- **←**: Previous artwork (history-backed)
+- **R**: Random artwork
+- **F**: Toggle fullscreen
+- **Escape**: Exit fullscreen
+
+**Context Menu** (built by `MetMuseumMenuBuilder`, shared between classic and modern UI):
+- Next / Previous / Random Artwork
+- **Department** submenu — filters by Met department (departments with no public-domain images are auto-excluded after exhaustion)
+- **Interval** submenu — slideshow advance interval
+- **Transition** submenu — Crossfade / Ken Burns / Beat Cut / Slide
+- **Transition Duration** submenu
+- **Aspect** submenu — Fit / Fill / Stretch
+- **Audio-Reactive Effects** toggle (subtle zoom/pan reacting to PCM levels)
+- **Beat-Triggered Changes** toggle (advance on detected beats instead of fixed interval)
+- **Show Attribution** toggle (title / artist / date overlay)
+- Visualization Engine
+- Fullscreen
+
+### Persistence
+
+All preferences live in UserDefaults under the `metMuseum*` namespace via `MetMuseumEngine.DefaultsKey`:
+`metMuseumDepartmentID`, `metMuseumIntervalSeconds`, `metMuseumTransitionMode`, `metMuseumTransitionDuration`, `metMuseumAspectMode`, `metMuseumAudioReactive`, `metMuseumBeatTriggered`, `metMuseumShowAttribution`.
+
+When restoring config from UserDefaults in `VisualizationGLView`, Bool keys must be guarded with `object(forKey:) != nil` before calling `bool(forKey:)` — an unconditional `bool(forKey:)` returns `false` for missing keys and would clobber the engine's defaults on fresh installs.
+
+### Technical Details
+
+- **Files**: `Visualization/MetMuseum/MetMuseumEngine.swift` (slideshow + OpenGL rendering), `MetMuseumClient.swift` (Met API client), `MetMuseumImageCache.swift` (on-disk image cache).
+- **API Client**: `MetMuseumClient` uses a semaphore + minimum request spacing (`withPermit`) to stay under the API's throttle and avoid 429s under load. `withPermit` is `throws` (not `rethrows`) so `CancellationError` from `Task.sleep` propagates and the network request is skipped when the slideshow task is cancelled mid-throttle.
+- **Image URL Validation**: `URL(string: objectInfo.primaryImage)` must be optional-bound; throw `MetMuseumError.noImageURL` on nil rather than force-unwrapping — the Met occasionally returns malformed URL strings.
+- **Caching**: Downloaded images are persisted to a disk cache keyed by object ID, so re-visits and history walks are free.
+- **Empty-Department Handling**: When a department exhausts its public-domain pool without a match, it's added to an exclusion set, the menu hides it, and the slideshow auto-picks a different department.
+- **Audio Hook**: Engine is `setAudioActive`-driven; the slideshow pauses when playback stops. Beat-triggered mode listens to `bpmUpdated` notifications; audio-reactive mode samples PCM levels each frame for zoom/pan modulation.
+- **Per-Engine Scoped Prefs**: Visualization preferences are scoped per engine — Met Museum's preferences do not collide with ProjectM/Geiss/Tripex (see commit 40c8a5c).
+- **Licensing**: Met Museum Open Access content is CC0; attribution is shown via the in-engine overlay when **Show Attribution** is on.
+
 ## Spectrum Analyzer Window
 
 A dedicated Metal-based spectrum analyzer providing larger, more detailed view than the main window's 19-bar analyzer. Window has two implementations (classic/modern UI modes) both embedding `SpectrumAnalyzerView`.
@@ -451,13 +495,13 @@ Controls how quickly bars fall:
 
 ## Comparison
 
-| Feature | Album Art | ProjectM/MilkDrop | Geiss | Spectrum Analyzer |
-|---------|-----------|-------------------|-------|-------------------|
-| **Visual Style** | Transformed artwork | Procedural graphics | Indexed framebuffer + palette effects | Frequency bars/vis_classic/Fire/JWST/Lightning/Matrix/Snow/EKG |
-| **Effect Count** | 30 built-in | 100s of presets | 25 modes | 10 modes |
-| **Customization** | Intensity adjustment | Full preset ecosystem | Effect selection | Mode + decay + style presets |
-| **GPU Tech** | Core Image (Metal) | OpenGL shaders | OpenGL palette LUT | Metal shaders + compute |
-| **Audio Response** | Spectrum bands | PCM waveform + beats | PCM waveform + 256-bin host spectrum | 75-band spectrum / energy-driven |
+| Feature | Album Art | ProjectM/MilkDrop | Geiss | Met Museum | Spectrum Analyzer |
+|---------|-----------|-------------------|-------|------------|-------------------|
+| **Visual Style** | Transformed artwork | Procedural graphics | Indexed framebuffer + palette effects | Public-domain Met artwork slideshow | Frequency bars/vis_classic/Fire/JWST/Lightning/Matrix/Snow/EKG |
+| **Effect Count** | 30 built-in | 100s of presets | 25 modes | N/A (real artwork) | 10 modes |
+| **Customization** | Intensity adjustment | Full preset ecosystem | Effect selection | Department / interval / transition / aspect | Mode + decay + style presets |
+| **GPU Tech** | Core Image (Metal) | OpenGL shaders | OpenGL palette LUT | OpenGL textured quad | Metal shaders + compute |
+| **Audio Response** | Spectrum bands | PCM waveform + beats | PCM waveform + 256-bin host spectrum | Optional audio-reactive zoom/pan, beat-triggered advance | 75-band spectrum / energy-driven |
 
 ### When to Use Each
 
@@ -476,6 +520,11 @@ Controls how quickly bars fall:
 - Classic Geiss effect look
 - Lower-level indexed/palette effects
 - Audio-reactive waveform and spectrum visuals without MilkDrop presets
+
+**Met Museum:**
+- Calm, gallery-style slideshow of real artwork instead of procedural graphics
+- Department-curated browsing (paintings, photography, Asian art, etc.)
+- Optional audio reactivity (zoom/pan, beat-triggered advances) for a subtler music-driven feel
 
 **Main Window Visualization:**
 - Quick access to all GPU modes without separate window
@@ -507,6 +556,9 @@ Controls how quickly bars fall:
 - `Visualization/ProjectMWrapper.swift` - ProjectM library wrapper
 - `Visualization/GeissEngine.swift` - Geiss OpenGL indexed-framebuffer renderer
 - `Sources/CGeissCore/` - Geiss C++ port and C ABI
+- `Visualization/MetMuseum/MetMuseumEngine.swift` - Met Museum slideshow + OpenGL renderer
+- `Visualization/MetMuseum/MetMuseumClient.swift` - Met collection API client (throttled, cancellable)
+- `Visualization/MetMuseum/MetMuseumImageCache.swift` - On-disk image cache
 - `App/ProjectMWindowProviding.swift` - Protocol abstracting classic/modern
 
 ### Spectrum Analyzer


### PR DESCRIPTION
## Summary
- Wire arrow keys and R in classic `ProjectMView` to skip the Met Museum slideshow — previously these were a no-op in classic UI mode because the handler only branched for projectM/geiss/tripex and fell through to `nextPreset` on the inactive projectM engine. Modern view already had this.
- Scope `beatSensitivity`, `lowPowerMode`, and `pcmGain` to per-engine UserDefaults keys (`viz.<engine>.*`) so Met Museum, Geiss, Tripex, and ProjectM no longer share/overwrite each other's tuning. One-shot migration copies the legacy `projectM*` keys into the new scoped slots so existing users keep their settings.
- Bump `CFBundleShortVersionString` to 0.23.0.

Branch also includes the prior commits on this feature branch: initial Met Museum mode, rendering/hotkey/log-noise fixes, crash + throttling fixes, and pause-on-stop + classic context menu wiring.

## Test plan
- [ ] In classic UI mode, switch the ProjectM window to Met Museum and confirm Left/Right arrow and R skip to a new artwork.
- [ ] In modern UI mode, confirm Met Museum hotkeys still work (regression check).
- [ ] Adjust beat sensitivity / low-power / PCM gain in ProjectM, switch engines to Met Museum and back, confirm each engine retains its own values.
- [ ] Existing install: launch once with prior `projectMBeatSensitivity` / `projectMLowPowerMode` / `projectMPCMGain` set, confirm those values are picked up under the new `viz.projectM.*` keys.
- [ ] Confirm About dialog / Finder Get Info shows 0.23.0.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Met Museum visualization: public-domain artwork slideshow with audio-reactive effects, beat-triggered advances, multiple transitions, aspect handling, and attribution overlay
  * Department selection, random/all, configurable interval/duration, keyboard and context-menu controls, and menu integration across views
  * In-memory + on-disk image cache with manual clear, automatic pruning, and resilient network fetching/retry

* **Improvements**
  * Per-engine visualization preferences with migration from legacy keys; playback sync with audio state

* **Chores**
  * App version bumped to 0.23.0

* **Documentation**
  * Updated changelog and visualization docs to include Met Museum engine

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/ad-repo/nullplayer/pull/216?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->