### PR TITLE
Clarify cast discovery skip reason for streams

### DIFF
--- a/Sources/NullPlayer/Casting/CastManager.swift
+++ b/Sources/NullPlayer/Casting/CastManager.swift
@@ -613,14 +613,16 @@ class CastManager {
         if discoveryRefreshTimer == nil {
             discoveryRefreshTimer = Timer.scheduledTimer(withTimeInterval: 60, repeats: true) { [weak self] _ in
                 guard let self = self else { return }
-                // Avoid discovery restart bursts during local playback, which can
-                // compete with high-throughput SMB/NAS reads on weaker WiFi links.
+                // Avoid discovery restart bursts during active playback, which can
+                // compete with high-throughput SMB/NAS reads or streaming on weaker WiFi links.
                 let engine = self.resolvedAudioEngine
-                let suppressForLocalRead = engine.state == .playing
-                    && !engine.isCastingActive
-                    && !RadioManager.shared.isActive
-                if suppressForLocalRead {
-                    NSLog("CastManager: Skipping discovery refresh - local audio is playing")
+                if let skipReason = Self.discoveryRefreshSkipReason(
+                    playbackState: engine.state,
+                    isCastingActive: engine.isCastingActive,
+                    isRadioActive: RadioManager.shared.isActive,
+                    currentTrack: engine.currentTrack
+                ) {
+                    NSLog("CastManager: Skipping discovery refresh - %@", skipReason)
                     return
                 }
                 self.refreshDevices()
@@ -650,6 +652,30 @@ class CastManager {
         discoveryIdleTimer?.invalidate()
         discoveryIdleTimer = Timer.scheduledTimer(withTimeInterval: 300, repeats: false) { [weak self] _ in
             self?.stopDiscovery()
+        }
+    }
+
+    static func discoveryRefreshSkipReason(playbackState: PlaybackState,
+                                           isCastingActive: Bool,
+                                           isRadioActive: Bool,
+                                           currentTrack: Track?) -> String? {
+        guard playbackState == .playing,
+              !isCastingActive,
+              !isRadioActive else {
+            return nil
+        }
+
+        guard let currentTrack else {
+            return "audio is playing"
+        }
+
+        switch currentTrack.playHistorySource {
+        case .local:
+            return "local audio is playing"
+        case .radio:
+            return "radio stream is playing"
+        case .plex, .subsonic, .jellyfin, .emby:
+            return "\(currentTrack.playHistorySource.displayName) streaming audio is playing"
         }
     }
     

--- a/Tests/NullPlayerAppTests/CastingTests.swift
+++ b/Tests/NullPlayerAppTests/CastingTests.swift
@@ -62,6 +62,54 @@ final class CastingTests: XCTestCase {
         XCTAssertEqual(CastManager.shared.preferredVideoCastDeviceID, videoDevice.id)
     }
 
+    func testDiscoveryRefreshSkipReasonLabelsLocalPlayback() {
+        let track = Track(url: URL(fileURLWithPath: "/tmp/local.flac"), title: "Local")
+
+        let reason = CastManager.discoveryRefreshSkipReason(
+            playbackState: .playing,
+            isCastingActive: false,
+            isRadioActive: false,
+            currentTrack: track
+        )
+
+        XCTAssertEqual(reason, "local audio is playing")
+    }
+
+    func testDiscoveryRefreshSkipReasonLabelsStreamingPlayback() {
+        let track = Track(
+            url: URL(string: "https://plex.example.test/library/parts/1/file.flac")!,
+            title: "Plex Stream",
+            plexRatingKey: "123",
+            plexServerId: "server"
+        )
+
+        let reason = CastManager.discoveryRefreshSkipReason(
+            playbackState: .playing,
+            isCastingActive: false,
+            isRadioActive: false,
+            currentTrack: track
+        )
+
+        XCTAssertEqual(reason, "Plex streaming audio is playing")
+    }
+
+    func testDiscoveryRefreshSkipReasonDoesNotSuppressCastingOrRadio() {
+        let track = Track(url: URL(fileURLWithPath: "/tmp/local.flac"), title: "Local")
+
+        XCTAssertNil(CastManager.discoveryRefreshSkipReason(
+            playbackState: .playing,
+            isCastingActive: true,
+            isRadioActive: false,
+            currentTrack: track
+        ))
+        XCTAssertNil(CastManager.discoveryRefreshSkipReason(
+            playbackState: .playing,
+            isCastingActive: false,
+            isRadioActive: true,
+            currentTrack: track
+        ))
+    }
+
     func testSetPreferredVideoCastDevicePostsSessionDidChangeNotification() {
         let expectation = expectation(description: "sessionDidChange posted")
         let observer = NotificationCenter.default.addObserver(


### PR DESCRIPTION
## Summary
- classify discovery refresh skip reasons by current playback source
- keep the existing local-audio message for local files
- report service-backed playback as streaming audio instead of local audio

Closes #217

## Tests
- swift test --filter CastingTests
- swift test

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Improved discovery refresh mechanism with centralized skip-reason logic and enhanced diagnostic logging during active playback.

* **Tests**
  * Added test coverage for discovery refresh skip behavior across different playback scenarios.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/ad-repo/nullplayer/pull/218?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->