### PR TITLE
Fix Geiss shader log printing

### DIFF
--- a/Sources/NullPlayer/Visualization/GeissEngine.swift
+++ b/Sources/NullPlayer/Visualization/GeissEngine.swift
@@ -401,7 +401,8 @@ final class GeissEngine: VisualizationEngine {
             glGetShaderiv(shader, GLenum(GL_INFO_LOG_LENGTH), &logLen)
             var log = [GLchar](repeating: 0, count: Int(max(logLen, 1)))
             glGetShaderInfoLog(shader, GLsizei(log.count), nil, &log)
-            NSLog("GeissEngine: shader compile failed: %s", log)
+            let msg = String(cString: log)
+            NSLog("GeissEngine: shader compile failed: %@", msg)
             glDeleteShader(shader)
             return nil
         }
@@ -427,7 +428,8 @@ final class GeissEngine: VisualizationEngine {
             glGetProgramiv(prog, GLenum(GL_INFO_LOG_LENGTH), &logLen)
             var log = [GLchar](repeating: 0, count: Int(max(logLen, 1)))
             glGetProgramInfoLog(prog, GLsizei(log.count), nil, &log)
-            NSLog("GeissEngine: program link failed: %s", log)
+            let msg = String(cString: log)
+            NSLog("GeissEngine: program link failed: %@", msg)
             glDeleteProgram(prog)
             return nil
         }


### PR DESCRIPTION
## Summary
- convert Geiss shader compile logs from GLchar buffers to Swift strings before logging
- apply the same fix to program link logs

Closes #214

## Tests
- swift test --filter GeissEngineSmokeTests
- swift test

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved shader compilation error message formatting to display logs more clearly.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/ad-repo/nullplayer/pull/219?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->