### PR TITLE
Fix Data tab layout and Met visualization defaults

### DIFF
--- a/Sources/NullPlayer/Visualization/MetMuseum/MetMuseumEngine.swift
+++ b/Sources/NullPlayer/Visualization/MetMuseum/MetMuseumEngine.swift
@@ -24,7 +24,7 @@ final class MetMuseumEngine: VisualizationEngine {
         var audioReactiveEffects: Bool = false
         var beatTriggeredChanges: Bool = false
         var aspectMode: AspectMode = .fit
-        var showAttribution: Bool = false
+        var showAttribution: Bool = true
     }
 
     enum TransitionMode: String, CaseIterable, Codable {
@@ -305,7 +305,7 @@ final class MetMuseumEngine: VisualizationEngine {
 
         // Render
         glViewport(0, 0, GLsizei(width), GLsizei(height))
-        glClearColor(0.1, 0.1, 0.1, 1)
+        glClearColor(0.0, 0.0, 0.0, 1)
         glClear(GLbitfield(GL_COLOR_BUFFER_BIT))
 
         guard currentImage != nil || placeholderTexture != 0 else { return }
@@ -905,7 +905,7 @@ final class MetMuseumEngine: VisualizationEngine {
         }
         glBindTexture(GLenum(GL_TEXTURE_2D), 0)
 
-        // Create placeholder texture
+        // Create black loading texture
         createPlaceholderTexture()
 
         return true
@@ -924,14 +924,8 @@ final class MetMuseumEngine: VisualizationEngine {
     private func createPlaceholderTexture() {
         let placeholder = NSImage(size: NSMakeSize(256, 256))
         placeholder.lockFocus()
-        NSColor.darkGray.setFill()
+        NSColor.black.setFill()
         NSBezierPath(rect: NSMakeRect(0, 0, 256, 256)).fill()
-        let attr: [NSAttributedString.Key: Any] = [
-            .font: NSFont.systemFont(ofSize: 16),
-            .foregroundColor: NSColor.lightGray
-        ]
-        let str = NSAttributedString(string: "Met Museum\nunavailable", attributes: attr)
-        str.draw(at: NSMakePoint(30, 110))
         placeholder.unlockFocus()
 
         if let tiffData = placeholder.tiffRepresentation,

--- a/Sources/NullPlayer/Visualization/MetMuseumMenuBuilder.swift
+++ b/Sources/NullPlayer/Visualization/MetMuseumMenuBuilder.swift
@@ -181,7 +181,7 @@ final class MetMuseumMenuBuilder {
         menu.addItem(beatTriggeredItem)
 
         // Show Artist & Title toggle
-        let showAttributionEnabled = config?.showAttribution ?? false
+        let showAttributionEnabled = config?.showAttribution ?? true
         let attributionItem = NSMenuItem(title: "Show Artist & Title",
                                         action: #selector(MetMuseumMenuTarget.toggleMetMuseumShowAttribution(_:)),
                                         keyEquivalent: "")

--- a/Sources/NullPlayer/Windows/ModernLibraryBrowser/ModernLibraryBrowserView.swift
+++ b/Sources/NullPlayer/Windows/ModernLibraryBrowser/ModernLibraryBrowserView.swift
@@ -1012,7 +1012,7 @@ class ModernLibraryBrowserView: NSView {
         let sortText = "Sort"
         let sortAttrs: [NSAttributedString.Key: Any] = [
             .font: font,
-            .foregroundColor: skin.applyTextOpacity(to: browseMode.isHistoryMode ? skin.textDimColor.withAlphaComponent(0.45) : skin.textDimColor)
+            .foregroundColor: skin.applyTextOpacity(to: skin.textDimColor)
         ]
         let sortSize = sortText.size(withAttributes: sortAttrs)
         let sortWidth = sortSize.width + 16
@@ -1090,12 +1090,9 @@ class ModernLibraryBrowserView: NSView {
 
     private func drawInlineTabBarLabel(label: String, rect: NSRect,
                                        font: NSFont, skin: ModernSkin, context: CGContext) {
-        let color = browseMode.isHistoryMode
-            ? skin.textDimColor.withAlphaComponent(0.45)
-            : skin.textDimColor
         let attrs: [NSAttributedString.Key: Any] = [
             .font: font,
-            .foregroundColor: skin.applyTextOpacity(to: color)
+            .foregroundColor: skin.applyTextOpacity(to: skin.textDimColor)
         ]
         let textSize = label.size(withAttributes: attrs)
         let textOrigin = NSPoint(x: rect.midX - textSize.width / 2,
@@ -1157,7 +1154,7 @@ class ModernLibraryBrowserView: NSView {
         let artBtnHeight: CGFloat = Layout.serverBarHeight - 6 * m
         var artX = refreshX - artBtnWidth - 12 * m
         
-        if !browseMode.isHistoryMode, currentArtwork != nil {
+        if currentArtwork != nil {
             let artBtnRect = NSRect(x: artX, y: barRect.minY + 3 * m, width: artBtnWidth, height: artBtnHeight)
             drawToggleTab(label: artText, isActive: isArtOnlyMode, rect: artBtnRect,
                           font: font, skin: skin, context: context)
@@ -1167,7 +1164,7 @@ class ModernLibraryBrowserView: NSView {
         
         // VIS button (only in art-only mode, modern boxed toggle style)
         var visEndX = artX
-        if !browseMode.isHistoryMode && isArtOnlyMode && currentArtwork != nil {
+        if isArtOnlyMode && currentArtwork != nil {
             let visText = "VIS"
             let visTextWidth = visText.size(withAttributes: prefixAttrs).width
             let visBtnWidth = visTextWidth + 16 * m
@@ -1179,8 +1176,7 @@ class ModernLibraryBrowserView: NSView {
         }
         
         // Star rating (art-only mode with a track playing)
-        if !browseMode.isHistoryMode,
-           isArtOnlyMode,
+        if isArtOnlyMode,
            let currentTrack = WindowManager.shared.audioEngine.currentTrack,
            currentTrack.plexRatingKey != nil || currentTrack.subsonicId != nil || currentTrack.jellyfinId != nil || currentTrack.embyId != nil || currentTrack.url.isFileURL {
             let starSize: CGFloat = 14 * m
@@ -1221,8 +1217,8 @@ class ModernLibraryBrowserView: NSView {
             let addX = sourceNameStartX + sourceTextWidth + 28 * m
             drawText(addText, at: NSPoint(x: addX, y: textY), withAttributes: activeAttrs, context: context)
 
-            // Item count (only in list mode, not art-only, not history mode)
-            if !isArtOnlyMode && !browseMode.isHistoryMode {
+            // Item count (only in list mode)
+            if !isArtOnlyMode {
                 let totalCount: Int
                 if browseMode == .artists {
                     totalCount = localArtistTotal > 0 ? localArtistTotal : displayItems.count
@@ -1291,8 +1287,8 @@ class ModernLibraryBrowserView: NSView {
                                   availableWidth: maxLibraryWidth, scrollOffset: libraryNameScrollOffset,
                                   textHeight: textH, attributes: dataAttrs, in: context)
                 
-                // Item count (only in list mode, not art-only, not history mode)
-                if !isArtOnlyMode && !browseMode.isHistoryMode {
+                // Item count (only in list mode)
+                if !isArtOnlyMode {
                     let itemCount: Int
                     if manager.currentLibrary?.type == "artist" {
                         itemCount = cachedArtists.count
@@ -1343,8 +1339,8 @@ class ModernLibraryBrowserView: NSView {
                                   availableWidth: maxLibraryWidth, scrollOffset: libraryNameScrollOffset,
                                   textHeight: textH, attributes: dataAttrs, in: context)
 
-                // Item count (only in list mode, not art-only, not history mode)
-                if !isArtOnlyMode && !browseMode.isHistoryMode {
+                // Item count (only in list mode)
+                if !isArtOnlyMode {
                     let countText = "\(displayItems.count) items"
                     let countWidth = countText.size(withAttributes: dataAttrs).width
                     let countX = visEndX - countWidth - 24 * m
@@ -1387,8 +1383,8 @@ class ModernLibraryBrowserView: NSView {
                                   availableWidth: maxLibraryWidth, scrollOffset: libraryNameScrollOffset,
                                   textHeight: textH, attributes: dataAttrs, in: context)
 
-                // Item count (only in list mode, not art-only, not history mode)
-                if !isArtOnlyMode && !browseMode.isHistoryMode {
+                // Item count (only in list mode)
+                if !isArtOnlyMode {
                     let countText = "\(displayItems.count) items"
                     let countWidth = countText.size(withAttributes: dataAttrs).width
                     let countX = visEndX - countWidth - 24 * m
@@ -1431,8 +1427,8 @@ class ModernLibraryBrowserView: NSView {
                                   availableWidth: maxLibraryWidth, scrollOffset: libraryNameScrollOffset,
                                   textHeight: textH, attributes: dataAttrs, in: context)
 
-                // Item count (only in list mode, not art-only, not history mode)
-                if !isArtOnlyMode && !browseMode.isHistoryMode {
+                // Item count (only in list mode)
+                if !isArtOnlyMode {
                     let countText = "\(displayItems.count) items"
                     let countWidth = countText.size(withAttributes: dataAttrs).width
                     let countX = visEndX - countWidth - 24 * m
@@ -1454,8 +1450,8 @@ class ModernLibraryBrowserView: NSView {
             let addX = sourceNameStartX + sourceTextWidth + 28 * m
             drawText(addText, at: NSPoint(x: addX, y: textY), withAttributes: activeAttrs, context: context)
             
-            // Item count (only in list mode, not art-only, not history mode)
-            if !isArtOnlyMode && !browseMode.isHistoryMode {
+            // Item count (only in list mode)
+            if !isArtOnlyMode {
                 let countText = "\(displayItems.count) stations"
                 let countWidth = countText.size(withAttributes: dataAttrs).width
                 let countX = visEndX - countWidth - 24 * m
@@ -2792,7 +2788,6 @@ class ModernLibraryBrowserView: NSView {
     }
     
     private func hitTestSortIndicator(at point: NSPoint) -> Bool {
-        guard !browseMode.isHistoryMode else { return false }
         let tabBarTopY = bounds.height - Layout.titleBarHeight - Layout.serverBarHeight
         let tabBarBottomY = tabBarTopY - Layout.tabBarHeight
         guard point.y >= tabBarBottomY && point.y < tabBarTopY else { return false }
@@ -3578,12 +3573,12 @@ class ModernLibraryBrowserView: NSView {
         let artBtnWidth = artTextWidth + 16 * m
         let artZoneStart = refreshZoneStart - 12 * m - artBtnWidth
         let artZoneEnd = artZoneStart + artBtnWidth
-        if !browseMode.isHistoryMode, currentArtwork != nil && relativeX >= artZoneStart && relativeX <= artZoneEnd {
+        if currentArtwork != nil && relativeX >= artZoneStart && relativeX <= artZoneEnd {
             isArtOnlyMode.toggle(); return
         }
         
         // VIS button - match drawn button positions
-        if !browseMode.isHistoryMode && isArtOnlyMode && currentArtwork != nil {
+        if isArtOnlyMode && currentArtwork != nil {
             let visTextWidth = "VIS".size(withAttributes: fontAttrs).width
             let visBtnWidth = visTextWidth + 16 * m
             let visZoneStart = artZoneStart - 8 * m - visBtnWidth
@@ -3592,7 +3587,7 @@ class ModernLibraryBrowserView: NSView {
         }
         
         // RATE button click (star area in art-only mode)
-        if !browseMode.isHistoryMode && !rateButtonRect.isEmpty {
+        if !rateButtonRect.isEmpty {
             let rateRelativeStart = rateButtonRect.minX - barRect.minX
             let rateRelativeEnd = rateButtonRect.maxX - barRect.minX
             if relativeX >= rateRelativeStart && relativeX <= rateRelativeEnd {

--- a/Sources/NullPlayer/Windows/PlexBrowser/PlexBrowserView.swift
+++ b/Sources/NullPlayer/Windows/PlexBrowser/PlexBrowserView.swift
@@ -1481,7 +1481,7 @@ class PlexBrowserView: NSView {
     
     /// Toggle visualization mode
     func toggleVisualization() {
-        guard !browseMode.isHistoryMode, isArtOnlyMode, currentArtwork != nil else { return }
+        guard isArtOnlyMode, currentArtwork != nil else { return }
         isVisualizingArt.toggle()
     }
     
@@ -2209,7 +2209,7 @@ class PlexBrowserView: NSView {
             let visWidth = CGFloat(visText.count) * scaledCharWidth
             var visX = artX - visWidth - artModeVisSpacing
             
-            if !browseMode.isHistoryMode && currentArtwork != nil {
+            if currentArtwork != nil {
                 if isArtOnlyMode {
                     drawScaledWhiteSkinText(artText, at: NSPoint(x: artX, y: textY), scale: textScale, renderer: renderer, in: context)
                     // Show VIS button in art-only mode (white when active, green when inactive)
@@ -2229,8 +2229,7 @@ class PlexBrowserView: NSView {
             }
             
             // Star rating (art-only mode) or item count (list mode)
-            if !browseMode.isHistoryMode,
-               isArtOnlyMode,
+            if isArtOnlyMode,
                let currentTrack = WindowManager.shared.audioEngine.currentTrack,
                canRateTrack(currentTrack) {
                 let starSize: CGFloat = 12
@@ -2372,7 +2371,7 @@ class PlexBrowserView: NSView {
                 let visWidth = CGFloat(visText.count) * scaledCharWidth
                 var visX = artX - visWidth - artModeVisSpacing
                 
-                if !browseMode.isHistoryMode && currentArtwork != nil {
+                if currentArtwork != nil {
                     if isArtOnlyMode {
                         drawScaledWhiteSkinText(artText, at: NSPoint(x: artX, y: textY), scale: textScale, renderer: renderer, in: context)
                         // Show VIS button in art-only mode (white when active, green when inactive)
@@ -2392,8 +2391,7 @@ class PlexBrowserView: NSView {
                 }
                 
                 // Star rating (art-only mode) or item count (list mode)
-                if !browseMode.isHistoryMode,
-                   isArtOnlyMode,
+                if isArtOnlyMode,
                    let currentTrack = WindowManager.shared.audioEngine.currentTrack,
                    canRateTrack(currentTrack) {
                     let starSize: CGFloat = 12
@@ -2518,7 +2516,7 @@ class PlexBrowserView: NSView {
                 let visWidth = CGFloat(visText.count) * scaledCharWidth
                 var visX = artX - visWidth - 16
                 
-                if !browseMode.isHistoryMode && currentArtwork != nil {
+                if currentArtwork != nil {
                     if isArtOnlyMode {
                         drawScaledWhiteSkinText(artText, at: NSPoint(x: artX, y: textY), scale: textScale, renderer: renderer, in: context)
                         if isVisualizingArt {
@@ -2536,8 +2534,7 @@ class PlexBrowserView: NSView {
                 }
                 
                 // Star rating (art-only mode) or item count (list mode)
-                if !browseMode.isHistoryMode,
-                   isArtOnlyMode,
+                if isArtOnlyMode,
                    let currentTrack = WindowManager.shared.audioEngine.currentTrack,
                    canRateTrack(currentTrack) {
                     let starSize: CGFloat = 12
@@ -2637,7 +2634,7 @@ class PlexBrowserView: NSView {
                 let visWidth = CGFloat(visText.count) * scaledCharWidth
                 var visX = artX - visWidth - 16
                 
-                if !browseMode.isHistoryMode && currentArtwork != nil {
+                if currentArtwork != nil {
                     if isArtOnlyMode {
                         drawScaledWhiteSkinText(artText, at: NSPoint(x: artX, y: textY), scale: textScale, renderer: renderer, in: context)
                         if isVisualizingArt {
@@ -2654,8 +2651,7 @@ class PlexBrowserView: NSView {
                     visX = artX
                 }
                 
-                if !browseMode.isHistoryMode,
-                   isArtOnlyMode,
+                if isArtOnlyMode,
                    let currentTrack = WindowManager.shared.audioEngine.currentTrack,
                    canRateTrack(currentTrack) {
                     let starSize: CGFloat = 12
@@ -2750,7 +2746,7 @@ class PlexBrowserView: NSView {
                 let visWidth = CGFloat(visText.count) * scaledCharWidth
                 var visX = artX - visWidth - 16
 
-                if !browseMode.isHistoryMode && currentArtwork != nil {
+                if currentArtwork != nil {
                     if isArtOnlyMode {
                         drawScaledWhiteSkinText(artText, at: NSPoint(x: artX, y: textY), scale: textScale, renderer: renderer, in: context)
                         if isVisualizingArt {
@@ -2767,8 +2763,7 @@ class PlexBrowserView: NSView {
                     visX = artX
                 }
 
-                if !browseMode.isHistoryMode,
-                   isArtOnlyMode,
+                if isArtOnlyMode,
                    let currentTrack = WindowManager.shared.audioEngine.currentTrack,
                    canRateTrack(currentTrack) {
                     let starSize: CGFloat = 12
@@ -2903,7 +2898,7 @@ class PlexBrowserView: NSView {
         
         // Calculate sort indicator width (on the right)
         let sortText = "Sort"
-        let sortWidth = browseMode.isHistoryMode ? 0 : CGFloat(sortText.count) * scaledCharWidth + 8
+        let sortWidth = CGFloat(sortText.count) * scaledCharWidth + 8
         let tabLeftInset = tabItemHorizontalEdgePadding
         let tabRightInset = tabItemHorizontalEdgePadding + rightEdgeItemPaddingBoost
         let tabsStartX = tabBarRect.minX + tabLeftInset
@@ -2932,14 +2927,12 @@ class PlexBrowserView: NSView {
             }
         }
         
-        if !browseMode.isHistoryMode {
-            // Draw sort indicator on the right
-            let rawSortX = tabBarRect.maxX - tabRightInset - sortWidth + 4
-            let rawSortY = tabBarY + (Layout.tabBarHeight - scaledCharHeight) / 2
-            let sortX = shouldRound ? round(rawSortX) : rawSortX
-            let sortY = shouldRound ? round(rawSortY) : rawSortY
-            drawScaledSkinText(sortText, at: NSPoint(x: sortX, y: sortY), scale: textScale, renderer: renderer, in: context)
-        }
+        // Draw sort indicator on the right
+        let rawSortX = tabBarRect.maxX - tabRightInset - sortWidth + 4
+        let rawSortY = tabBarY + (Layout.tabBarHeight - scaledCharHeight) / 2
+        let sortX = shouldRound ? round(rawSortX) : rawSortX
+        let sortY = shouldRound ? round(rawSortY) : rawSortY
+        drawScaledSkinText(sortText, at: NSPoint(x: sortX, y: sortY), scale: textScale, renderer: renderer, in: context)
     }
     
     private func drawSearchBar(in context: CGContext, drawBounds: NSRect, colors: PlaylistColors, renderer: SkinRenderer) {
@@ -6722,7 +6715,7 @@ class PlexBrowserView: NSView {
         let textScale: CGFloat = 1.5
         let scaledCharWidth = charWidth * textScale
         let sortText = "Sort"
-        let sortWidth = browseMode.isHistoryMode ? 0 : CGFloat(sortText.count) * scaledCharWidth + 8
+        let sortWidth = CGFloat(sortText.count) * scaledCharWidth + 8
         let tabLeftInset = tabItemHorizontalEdgePadding
         let tabRightInset = tabItemHorizontalEdgePadding + rightEdgeItemPaddingBoost
 
@@ -6740,7 +6733,6 @@ class PlexBrowserView: NSView {
     
     /// Check if point is in sort indicator area
     private func hitTestSortIndicator(at skinPoint: NSPoint) -> Bool {
-        guard !browseMode.isHistoryMode else { return false }
         let tabY = Layout.titleBarHeight + Layout.serverBarHeight
         guard skinPoint.y >= tabY && skinPoint.y < tabY + Layout.tabBarHeight else { return false }
         
@@ -7677,13 +7669,13 @@ class PlexBrowserView: NSView {
         if relativeX >= refreshZoneStart {
             // Refresh icon click
             handleRefreshClick()
-        } else if !browseMode.isHistoryMode && currentArtwork != nil && relativeX >= artZoneStart && relativeX <= artZoneEnd {
+        } else if currentArtwork != nil && relativeX >= artZoneStart && relativeX <= artZoneEnd {
             // ART toggle click (only if artwork available)
             isArtOnlyMode.toggle()
-        } else if !browseMode.isHistoryMode && isArtOnlyMode && currentArtwork != nil && relativeX >= visZoneStart && relativeX <= visZoneEnd {
+        } else if isArtOnlyMode && currentArtwork != nil && relativeX >= visZoneStart && relativeX <= visZoneEnd {
             // VIS button click (only in art-only mode with artwork)
             toggleVisualization()
-        } else if !browseMode.isHistoryMode && !rateButtonRect.isEmpty {
+        } else if !rateButtonRect.isEmpty {
             let rateRelativeStart = rateButtonRect.minX - Layout.leftBorder
             let rateRelativeEnd = rateButtonRect.maxX - Layout.leftBorder
             if relativeX >= rateRelativeStart && relativeX <= rateRelativeEnd {


### PR DESCRIPTION
## Summary
- keep Data tab toolbar/options layout consistent with other library tabs
- enable Met Museum artist/title attribution by default while preserving explicit user prefs
- replace Met Museum startup unavailable placeholder with a black loading frame

## Verification
- swift build
- git diff --check

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Bug Fixes**
  * Server controls and sort indicators now function properly in history mode.
  * Item counts now display in additional browse modes.

* **Improvements**
  * Artist and title attribution now displayed by default.
  * Enhanced background rendering with improved color consistency.
  * UI controls more accessible across different browse modes.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/ad-repo/nullplayer/pull/221?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->