### PR TITLE
Refine classic secondary window chrome

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@
 
 ### Improvements
 
+- **Classic secondary window chrome refined** — playlist-style windows now share the playlist close-widget artwork and scale, with matching companion circle controls and the small titlebar line gap on Spectrum, Waveform, ProjectM, and classic browser chrome while leaving Main and EQ unchanged.
 - **Windows menu coverage** — all primary toggleable app windows are now discoverable from the top-level Windows menu, including the standalone Spectrum Analyzer and the Video Player when a video window exists.
 - **Visualizations menu parity** — the top-level Visuals > Visualizations menu now exposes the visualization window toggle, engine selection before the window is opened, and the live visualization window controls once available, matching the functionality previously only reachable from the visualization window context menu.
 - **Visualizations menu cleanup** — projectM-only preset count, preset-folder, rescan, and bundled-preset Finder actions have been removed from the generic Visualizations menu.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,14 @@
 # Changelog
 
+## Unreleased
+
+### Improvements
+
+- **Windows menu coverage** — all primary toggleable app windows are now discoverable from the top-level Windows menu, including the standalone Spectrum Analyzer and the Video Player when a video window exists.
+- **Visualizations menu parity** — the top-level Visuals > Visualizations menu now exposes the visualization window toggle, engine selection before the window is opened, and the live visualization window controls once available, matching the functionality previously only reachable from the visualization window context menu.
+- **Visualizations menu cleanup** — projectM-only preset count, preset-folder, rescan, and bundled-preset Finder actions have been removed from the generic Visualizations menu.
+- **Main-window spectrum can be disabled** — Visuals > Spectrum Analyzer > Main Window > Mode now includes **Off**, matching Winamp's blank main-display option so compatible skins can show their prepared artwork without an analyzer overlay.
+
 ## 0.23.0
 
 ### New Features

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,7 +4,7 @@
 
 ### Improvements
 
-- **Classic secondary window chrome refined** — playlist-style windows now share the playlist close-widget artwork and scale, with matching companion circle controls and the small titlebar line gap on Spectrum, Waveform, ProjectM, and classic browser chrome while leaving Main and EQ unchanged.
+- **Classic secondary window chrome refined** — playlist-style windows now share the playlist close-widget artwork and scale, with matching companion circle controls and the small title bar line gap on Spectrum, Waveform, ProjectM, and classic browser chrome while leaving Main and EQ unchanged.
 - **Windows menu coverage** — all primary toggleable app windows are now discoverable from the top-level Windows menu, including the standalone Spectrum Analyzer and the Video Player when a video window exists.
 - **Visualizations menu parity** — the top-level Visuals > Visualizations menu now exposes the visualization window toggle, engine selection before the window is opened, and the live visualization window controls once available, matching the functionality previously only reachable from the visualization window context menu.
 - **Visualizations menu cleanup** — projectM-only preset count, preset-folder, rescan, and bundled-preset Finder actions have been removed from the generic Visualizations menu.

--- a/Sources/NullPlayer/App/ContextMenuBuilder.swift
+++ b/Sources/NullPlayer/App/ContextMenuBuilder.swift
@@ -98,6 +98,7 @@ class ContextMenuBuilder {
         menu.addItem(buildWindowItem("Main Window", visible: wm.mainWindowController?.window?.isVisible ?? false, action: #selector(MenuActions.toggleMainWindow)))
         menu.addItem(buildWindowItem("Equalizer", visible: wm.isEqualizerVisible, action: #selector(MenuActions.toggleEQ)))
         menu.addItem(buildWindowItem("Playlist Editor", visible: wm.isPlaylistVisible, action: #selector(MenuActions.togglePlaylist)))
+        menu.addItem(buildWindowItem("Spectrum Analyzer", visible: wm.isSpectrumVisible, action: #selector(MenuActions.toggleSpectrum)))
         menu.addItem(buildWindowItem("Waveform", visible: wm.isWaveformVisible, action: #selector(MenuActions.toggleWaveform)))
         menu.addItem(buildWindowItem("Library Browser", visible: wm.isPlexBrowserVisible, action: #selector(MenuActions.togglePlexBrowser)))
         if wm.isRunningModernUI {
@@ -105,6 +106,9 @@ class ContextMenuBuilder {
                                          action: #selector(MenuActions.toggleLibraryHistory)))
         }
         menu.addItem(buildWindowItem("ProjectM", visible: wm.isProjectMVisible, action: #selector(MenuActions.toggleProjectM)))
+        menu.addItem(buildWindowItem("Video Player", visible: wm.isVideoPlayerVisible,
+                                     action: #selector(MenuActions.toggleVideoPlayer),
+                                     enabled: wm.currentVideoPlayerController != nil))
         menu.addItem(buildWindowItem("Debug Console", visible: wm.isDebugWindowVisible, action: #selector(MenuActions.toggleDebugConsole)))
 
         menu.addItem(NSMenuItem.separator())
@@ -335,10 +339,11 @@ class ContextMenuBuilder {
     
     // MARK: - Window Toggle Items
     
-    private static func buildWindowItem(_ title: String, visible: Bool, action: Selector) -> NSMenuItem {
+    private static func buildWindowItem(_ title: String, visible: Bool, action: Selector, enabled: Bool = true) -> NSMenuItem {
         let item = NSMenuItem(title: title, action: action, keyEquivalent: "")
         item.target = MenuActions.shared
         item.state = visible ? .on : .off
+        item.isEnabled = enabled
         return item
     }
 
@@ -503,59 +508,44 @@ class ContextMenuBuilder {
         visMenu.autoenablesItems = false
         
         let wm = WindowManager.shared
-        
-        // Show preset count (can be determined without window open)
-        let counts = ProjectMWrapper.staticPresetCounts
-        let totalPresets = counts.bundled + counts.custom
-        
-        if totalPresets > 0 {
-            let infoText: String
-            if counts.custom > 0 {
-                infoText = "\(totalPresets) presets (\(counts.bundled) bundled, \(counts.custom) custom)"
-            } else {
-                infoText = "\(totalPresets) presets (bundled)"
-            }
-            
-            let infoItem = NSMenuItem(title: infoText, action: nil, keyEquivalent: "")
-            visMenu.addItem(infoItem)
-            visMenu.addItem(NSMenuItem.separator())
-        } else if wm.isProjectMVisible && !wm.isProjectMAvailable {
-            // Only show error if window is open but projectM failed to initialize
-            let unavailableItem = NSMenuItem(title: "projectM not available", action: nil, keyEquivalent: "")
-            visMenu.addItem(unavailableItem)
-            visMenu.addItem(NSMenuItem.separator())
-        }
-        
-        // Add Presets Folder...
-        let addFolderItem = NSMenuItem(title: "Add Presets Folder...", action: #selector(MenuActions.addVisualizationsFolder), keyEquivalent: "")
-        addFolderItem.target = MenuActions.shared
-        visMenu.addItem(addFolderItem)
-        
-        // Show Presets Folder (only if custom folder is set)
-        if ProjectMWrapper.hasCustomPresetsFolder {
-            let showFolderItem = NSMenuItem(title: "Show Custom Presets Folder", action: #selector(MenuActions.showVisualizationsFolder), keyEquivalent: "")
-            showFolderItem.target = MenuActions.shared
-            visMenu.addItem(showFolderItem)
-            
-            // Remove Custom Folder
-            let removeFolderItem = NSMenuItem(title: "Remove Custom Folder", action: #selector(MenuActions.removeVisualizationsFolder), keyEquivalent: "")
-            removeFolderItem.target = MenuActions.shared
-            visMenu.addItem(removeFolderItem)
-        }
-        
-        // Rescan Presets
-        let rescanItem = NSMenuItem(title: "Rescan Presets", action: #selector(MenuActions.rescanVisualizations), keyEquivalent: "")
-        rescanItem.target = MenuActions.shared
-        visMenu.addItem(rescanItem)
-        
+
+        let windowItem = NSMenuItem(title: wm.isProjectMVisible ? "Hide Visualization Window" : "Show Visualization Window",
+                                    action: #selector(MenuActions.toggleProjectM),
+                                    keyEquivalent: "")
+        windowItem.target = MenuActions.shared
+        windowItem.state = wm.isProjectMVisible ? .on : .off
+        visMenu.addItem(windowItem)
         visMenu.addItem(NSMenuItem.separator())
-        
-        // Show Bundled Presets in Finder
-        let showBundledItem = NSMenuItem(title: "Show Bundled Presets", action: #selector(MenuActions.showBundledPresets), keyEquivalent: "")
-        showBundledItem.target = MenuActions.shared
-        visMenu.addItem(showBundledItem)
-        
+
+        if let liveMenu = wm.buildVisualizationMenu() {
+            moveMenuItems(from: liveMenu, to: visMenu)
+            visMenu.addItem(NSMenuItem.separator())
+        } else {
+            visMenu.addItem(buildVisualizationEngineMenuItem())
+            visMenu.addItem(NSMenuItem.separator())
+        }
+
         return visMenu
+    }
+
+    private static func buildVisualizationEngineMenuItem() -> NSMenuItem {
+        let engineMenu = NSMenu()
+        engineMenu.autoenablesItems = false
+        let currentEngineType = WindowManager.shared.visualizationEngineType
+
+        for engineType in VisualizationType.allCases {
+            let item = NSMenuItem(title: engineType.displayName,
+                                  action: #selector(MenuActions.switchVisualizationEngine(_:)),
+                                  keyEquivalent: "")
+            item.target = MenuActions.shared
+            item.representedObject = engineType
+            item.state = currentEngineType == engineType ? .on : .off
+            engineMenu.addItem(item)
+        }
+
+        let engineItem = NSMenuItem(title: "Visualization Engine", action: nil, keyEquivalent: "")
+        engineItem.submenu = engineMenu
+        return engineItem
     }
     
     // MARK: - Options Submenu
@@ -942,7 +932,7 @@ class ContextMenuBuilder {
         let modeMenu = NSMenu()
         modeMenu.autoenablesItems = false
         
-        for mode in MainWindowVisMode.visualizationOrder {
+        for mode in MainWindowVisMode.menuOrder {
             let item = NSMenuItem(title: mode.displayName, action: #selector(MenuActions.setMainVisMode(_:)), keyEquivalent: "")
             item.target = MenuActions.shared
             item.representedObject = mode
@@ -956,6 +946,8 @@ class ContextMenuBuilder {
         }
         modeItem.submenu = modeMenu
         visMenu.addItem(modeItem)
+
+        guard currentMode != .none else { return visMenu }
         
         // Responsiveness submenu
         let responsivenessItem = NSMenuItem(title: "Responsiveness", action: nil, keyEquivalent: "")
@@ -2762,6 +2754,11 @@ class MenuActions: NSObject {
     @objc func toggleProjectM() {
         WindowManager.shared.toggleProjectM()
     }
+
+    @objc func switchVisualizationEngine(_ sender: NSMenuItem) {
+        guard let type = sender.representedObject as? VisualizationType else { return }
+        WindowManager.shared.switchVisualizationEngine(to: type)
+    }
     
     @objc func toggleSpectrum() {
         WindowManager.shared.toggleSpectrum()
@@ -2769,6 +2766,10 @@ class MenuActions: NSObject {
 
     @objc func toggleWaveform() {
         WindowManager.shared.toggleWaveform()
+    }
+
+    @objc func toggleVideoPlayer() {
+        WindowManager.shared.toggleVideoPlayer()
     }
     
     @objc func toggleDebugConsole() {

--- a/Sources/NullPlayer/App/ProjectMWindowProviding.swift
+++ b/Sources/NullPlayer/App/ProjectMWindowProviding.swift
@@ -71,4 +71,7 @@ protocol ProjectMWindowProviding: AnyObject {
     
     /// Get information about loaded presets
     var presetsInfo: (bundledCount: Int, customCount: Int, customPath: String?) { get }
+
+    /// Build the visualization window's full controls menu for use outside the view context menu.
+    func buildVisualizationMenu() -> NSMenu
 }

--- a/Sources/NullPlayer/App/WindowManager.swift
+++ b/Sources/NullPlayer/App/WindowManager.swift
@@ -149,6 +149,15 @@ class WindowManager {
     var classicScaleMultiplier: CGFloat {
         isDoubleSize ? 1.5 : 1.0
     }
+
+    /// Scale factor for playlist-style title-bar controls on classic secondary windows,
+    /// derived from the live main-window width so chrome stays in sync when the user resizes.
+    var playlistChromeScale: CGFloat {
+        if let mainWindow = mainWindowController?.window, mainWindow.frame.width > 0 {
+            return mainWindow.frame.width / Skin.baseMainSize.width
+        }
+        return Skin.scaleFactor * classicScaleMultiplier
+    }
     
     /// Always on top mode (floating window level)
     var isAlwaysOnTop: Bool = false {

--- a/Sources/NullPlayer/App/WindowManager.swift
+++ b/Sources/NullPlayer/App/WindowManager.swift
@@ -1824,6 +1824,11 @@ class WindowManager {
     func reloadVisualizationPresets() {
         projectMWindowController?.reloadPresets()
     }
+
+    /// Build the visualization window's full controls menu when the window has been created.
+    func buildVisualizationMenu() -> NSMenu? {
+        projectMWindowController?.buildVisualizationMenu()
+    }
     
     /// Select a visualization preset by index
     func selectVisualizationPreset(at index: Int) {

--- a/Sources/NullPlayer/Skin/SkinRenderer.swift
+++ b/Sources/NullPlayer/Skin/SkinRenderer.swift
@@ -1480,22 +1480,78 @@ class SkinRenderer {
     enum ProjectMButtonType {
         case close, shade
     }
+
+    private func drawPlaylistTitleBarControls(from pleditImage: NSImage,
+                                              in context: CGContext,
+                                              bounds: NSRect,
+                                              titleHeight: CGFloat,
+                                              isActive: Bool,
+                                              controlScale: CGFloat = 1.0,
+                                              showsShade: Bool,
+                                              closePressed: Bool,
+                                              shadePressed: Bool) {
+        let scale = max(1.0, controlScale)
+        let buttonSize = 9 * scale
+        let buttonY = min(3 * scale, max(0, (titleHeight - buttonSize) / 2))
+        let closeRect = NSRect(
+            x: bounds.width - SkinElements.Playlist.TitleBarButtons.closeOffset * scale,
+            y: buttonY,
+            width: buttonSize,
+            height: buttonSize
+        )
+        let inactiveYOffset: CGFloat = isActive ? 0 : 21
+        let closeSource = NSRect(x: 167, y: 3 + inactiveYOffset, width: 9, height: 9)
+        drawSprite(from: pleditImage, sourceRect: closeSource, to: closeRect, in: context)
+
+        if showsShade {
+            let shadeRect = NSRect(
+                x: bounds.width - SkinElements.Playlist.TitleBarButtons.shadeOffset * scale,
+                y: buttonY,
+                width: buttonSize,
+                height: buttonSize
+            )
+            let gapWidth = 4 * scale
+            let gapSource = NSRect(x: 153, y: inactiveYOffset, width: 4, height: 20)
+            let gapRect = NSRect(
+                x: shadeRect.minX - gapWidth,
+                y: 0,
+                width: gapWidth,
+                height: titleHeight
+            )
+            drawSprite(from: pleditImage, sourceRect: gapSource, to: gapRect, in: context)
+
+            let shadeSource = NSRect(x: 158, y: 3 + inactiveYOffset, width: 9, height: 9)
+            drawSprite(from: pleditImage, sourceRect: shadeSource, to: shadeRect, in: context)
+
+            if shadePressed {
+                NSColor(calibratedWhite: 0.3, alpha: 0.5).setFill()
+                context.fill(shadeRect)
+            }
+        }
+
+        if closePressed {
+            NSColor(calibratedWhite: 0.3, alpha: 0.5).setFill()
+            context.fill(closeRect)
+        }
+    }
     
     /// Draw the complete ProjectM window chrome (title bar, borders)
     /// The visualization area itself is handled by the OpenGL view
     func drawProjectMWindow(in context: CGContext, bounds: NSRect, isActive: Bool,
-                            pressedButton: ProjectMButtonType?, isShadeMode: Bool) {
+                            pressedButton: ProjectMButtonType?, isShadeMode: Bool,
+                            controlScale: CGFloat = 1.0) {
         if isShadeMode {
             drawProjectMShade(in: context, bounds: bounds, isActive: isActive, pressedButton: pressedButton)
         } else {
-            drawProjectMNormal(in: context, bounds: bounds, isActive: isActive, pressedButton: pressedButton)
+            drawProjectMNormal(in: context, bounds: bounds, isActive: isActive,
+                               pressedButton: pressedButton, controlScale: controlScale)
         }
     }
     
     /// Draw normal mode ProjectM window chrome
     /// Uses PLEDIT.BMP title bar sprites (same style as playlist) with "PROJECTM" text
     private func drawProjectMNormal(in context: CGContext, bounds: NSRect, isActive: Bool,
-                                    pressedButton: ProjectMButtonType?) {
+                                    pressedButton: ProjectMButtonType?, controlScale: CGFloat) {
         // Fill background with black for visualization area
         NSColor.black.setFill()
         context.fill(bounds)
@@ -1510,11 +1566,13 @@ class SkinRenderer {
         drawPlaylistStyleBottomBorder(in: context, bounds: bounds, bottomHeight: bottomHeight)
 
         // Draw title bar using PLEDIT.BMP sprites (without custom text)
-        drawProjectMTitleBarFromPledit(in: context, bounds: bounds, isActive: isActive, pressedButton: pressedButton)
+        drawProjectMTitleBarFromPledit(in: context, bounds: bounds, isActive: isActive,
+                                       pressedButton: pressedButton, controlScale: controlScale)
     }
     
     /// Draw ProjectM title bar using PLEDIT.BMP sprites (without custom text)
-    private func drawProjectMTitleBarFromPledit(in context: CGContext, bounds: NSRect, isActive: Bool, pressedButton: ProjectMButtonType?) {
+    private func drawProjectMTitleBarFromPledit(in context: CGContext, bounds: NSRect, isActive: Bool,
+                                                pressedButton: ProjectMButtonType?, controlScale: CGFloat) {
         guard let pleditImage = skin.pledit else {
             drawFallbackProjectMTitleBar(in: context, bounds: bounds, isActive: isActive)
             return
@@ -1556,24 +1614,14 @@ class SkinRenderer {
             x += tileWidth
         }
 
-        // Re-draw the close icon (baked into rightCorner) on top of the mirrored corner.
-        let closeIconYOffset: CGFloat = isActive ? 0 : 21
-        let closeBtnSource = NSRect(x: 167, y: 3 + closeIconYOffset, width: 9, height: 9)
-        drawSprite(from: pleditImage, sourceRect: closeBtnSource,
-                  to: NSRect(x: bounds.width - SkinElements.Playlist.TitleBarButtons.closeOffset,
-                             y: 3, width: 9, height: 9), in: context)
+        drawPlaylistTitleBarControls(from: pleditImage, in: context, bounds: bounds,
+                                     titleHeight: titleHeight, isActive: isActive,
+                                     controlScale: controlScale, showsShade: true,
+                                     closePressed: pressedButton == .close, shadePressed: false)
 
         _ = rightCorner
 
         // Note: Custom text removed - let the skin's title bar show through
-
-        // Draw close button pressed state if needed
-        if pressedButton == .close {
-            let closeRect = NSRect(x: bounds.width - SkinElements.Playlist.TitleBarButtons.closeOffset,
-                                   y: 3, width: 9, height: 9)
-            NSColor(calibratedWhite: 0.3, alpha: 0.5).setFill()
-            context.fill(closeRect)
-        }
     }
 
     /// Draw "PROJECTM" text using GenFont from gen.png
@@ -1677,17 +1725,19 @@ class SkinRenderer {
     /// Draw spectrum analyzer window chrome
     /// Uses same style as ProjectM window but with "SPECTRUM ANALYZER" title
     func drawSpectrumAnalyzerWindow(in context: CGContext, bounds: NSRect, isActive: Bool,
-                                    pressedButton: ProjectMButtonType?, isShadeMode: Bool) {
+                                    pressedButton: ProjectMButtonType?, isShadeMode: Bool,
+                                    controlScale: CGFloat = 1.0) {
         if isShadeMode {
             drawSpectrumAnalyzerShade(in: context, bounds: bounds, isActive: isActive, pressedButton: pressedButton)
         } else {
-            drawSpectrumAnalyzerNormal(in: context, bounds: bounds, isActive: isActive, pressedButton: pressedButton)
+            drawSpectrumAnalyzerNormal(in: context, bounds: bounds, isActive: isActive,
+                                       pressedButton: pressedButton, controlScale: controlScale)
         }
     }
     
     /// Draw normal mode spectrum analyzer window chrome
     private func drawSpectrumAnalyzerNormal(in context: CGContext, bounds: NSRect, isActive: Bool,
-                                            pressedButton: ProjectMButtonType?) {
+                                            pressedButton: ProjectMButtonType?, controlScale: CGFloat) {
         // Fill background with black for visualization area
         NSColor.black.setFill()
         context.fill(bounds)
@@ -1702,11 +1752,13 @@ class SkinRenderer {
         drawPlaylistStyleBottomBorder(in: context, bounds: bounds, bottomHeight: bottomHeight)
 
         // Draw title bar using PLEDIT.BMP sprites (without custom text)
-        drawSpectrumAnalyzerTitleBar(in: context, bounds: bounds, isActive: isActive, pressedButton: pressedButton)
+        drawSpectrumAnalyzerTitleBar(in: context, bounds: bounds, isActive: isActive,
+                                     pressedButton: pressedButton, controlScale: controlScale)
     }
     
     /// Draw spectrum analyzer title bar using PLEDIT.BMP sprites (without custom text)
-    private func drawSpectrumAnalyzerTitleBar(in context: CGContext, bounds: NSRect, isActive: Bool, pressedButton: ProjectMButtonType?) {
+    private func drawSpectrumAnalyzerTitleBar(in context: CGContext, bounds: NSRect, isActive: Bool,
+                                              pressedButton: ProjectMButtonType?, controlScale: CGFloat) {
         guard let pleditImage = skin.pledit else {
             drawFallbackProjectMTitleBar(in: context, bounds: bounds, isActive: isActive)
             return
@@ -1750,24 +1802,14 @@ class SkinRenderer {
             x += tileWidth
         }
 
-        // Re-draw the close icon (baked into rightCorner) on top of the mirrored corner.
-        let closeIconYOffset: CGFloat = isActive ? 0 : 21
-        let closeBtnSource = NSRect(x: 167, y: 3 + closeIconYOffset, width: 9, height: 9)
-        drawSprite(from: pleditImage, sourceRect: closeBtnSource,
-                  to: NSRect(x: bounds.width - SkinElements.Playlist.TitleBarButtons.closeOffset,
-                             y: 3, width: 9, height: 9), in: context)
+        drawPlaylistTitleBarControls(from: pleditImage, in: context, bounds: bounds,
+                                     titleHeight: titleHeight, isActive: isActive,
+                                     controlScale: controlScale, showsShade: true,
+                                     closePressed: pressedButton == .close, shadePressed: false)
 
         _ = rightCorner  // original sprite no longer drawn; reference kept above for parity
 
         // Note: Custom text removed - let the skin's title bar show through
-
-        // Draw close button pressed state if needed
-        if pressedButton == .close {
-            let closeRect = NSRect(x: bounds.width - SkinElements.Playlist.TitleBarButtons.closeOffset,
-                                   y: 3, width: 9, height: 9)
-            NSColor(calibratedWhite: 0.3, alpha: 0.5).setFill()
-            context.fill(closeRect)
-        }
     }
 
     /// Draw "NULLPLAYER ANALYZER" text using GenFont from gen.png
@@ -2458,17 +2500,14 @@ class SkinRenderer {
         let leftCorner: NSRect
         let titleSprite: NSRect
         let tileSprite: NSRect
-        let rightCorner: NSRect
         if isActive {
             leftCorner = SkinElements.Playlist.TitleBarActive.leftCorner
             titleSprite = SkinElements.Playlist.TitleBarActive.title
             tileSprite = SkinElements.Playlist.TitleBarActive.tile
-            rightCorner = SkinElements.Playlist.TitleBarActive.rightCorner
         } else {
             leftCorner = SkinElements.Playlist.TitleBarInactive.leftCorner
             titleSprite = SkinElements.Playlist.TitleBarInactive.title
             tileSprite = SkinElements.Playlist.TitleBarInactive.tile
-            rightCorner = SkinElements.Playlist.TitleBarInactive.rightCorner
         }
         
         // On non-Retina, fill background first to prevent seam gaps
@@ -2537,34 +2576,11 @@ class SkinRenderer {
         drawSprite(from: pleditImage, sourceRect: leftCorner, to: rightMirrorRect, in: context)
         context.restoreGState()
 
-        // The close + shade button icons were baked into rightCorner; re-draw just those
-        // icons on top of the mirrored corner so the user-facing buttons are preserved.
-        let buttonInactiveYOffset: CGFloat = isActive ? 0 : 21
-        let closeBtnSource = NSRect(x: 167, y: 3 + buttonInactiveYOffset, width: 9, height: 9)
-        let shadeBtnSource = NSRect(x: 158, y: 3 + buttonInactiveYOffset, width: 9, height: 9)
-        drawSprite(from: pleditImage, sourceRect: closeBtnSource,
-                  to: NSRect(x: bounds.width - SkinElements.Playlist.TitleBarButtons.closeOffset,
-                             y: 3, width: 9, height: 9), in: context)
-        drawSprite(from: pleditImage, sourceRect: shadeBtnSource,
-                  to: NSRect(x: bounds.width - SkinElements.Playlist.TitleBarButtons.shadeOffset,
-                             y: 3, width: 9, height: 9), in: context)
-        
-        // Draw window control button pressed states if needed
-        if pressedButton == .close {
-            // Close button highlight - drawn over the right corner
-            let closeRect = NSRect(x: bounds.width - SkinElements.Playlist.TitleBarButtons.closeOffset, 
-                                   y: 3, width: 9, height: 9)
-            NSColor(calibratedWhite: 0.3, alpha: 0.5).setFill()
-            context.fill(closeRect)
-        }
-        
-        if pressedButton == .shade {
-            // Shade button highlight
-            let shadeRect = NSRect(x: bounds.width - SkinElements.Playlist.TitleBarButtons.shadeOffset, 
-                                   y: 3, width: 9, height: 9)
-            NSColor(calibratedWhite: 0.3, alpha: 0.5).setFill()
-            context.fill(shadeRect)
-        }
+        drawPlaylistTitleBarControls(from: pleditImage, in: context, bounds: bounds,
+                                     titleHeight: titleHeight, isActive: isActive,
+                                     showsShade: true,
+                                     closePressed: pressedButton == .close,
+                                     shadePressed: pressedButton == .shade)
     }
     
     /// Build a horizontally-tileable bottom-border tile by rotating the playlist `leftSideTile`
@@ -2794,7 +2810,8 @@ class SkinRenderer {
     /// Draw the complete Plex browser window using skin sprites
     /// Uses playlist sprites for frame/chrome with custom content areas
     func drawPlexBrowserWindow(in context: CGContext, bounds: NSRect, isActive: Bool,
-                               pressedButton: PlexBrowserButtonType?, scrollPosition: CGFloat) {
+                               pressedButton: PlexBrowserButtonType?, scrollPosition: CGFloat,
+                               controlScale: CGFloat = 1.0) {
         let layout = SkinElements.PlexBrowser.Layout.self
         let titleHeight = layout.titleBarHeight  // 20px
         let leftBorder = layout.leftBorder
@@ -2825,16 +2842,20 @@ class SkinRenderer {
         drawPlexBrowserStatusBar(in: context, bounds: bounds)
         
         // Draw title bar (without custom text)
-        drawPlexBrowserTitleBar(in: context, bounds: bounds, isActive: isActive, pressedButton: pressedButton)
+        drawPlexBrowserTitleBar(in: context, bounds: bounds, isActive: isActive,
+                                pressedButton: pressedButton, controlScale: controlScale)
         
         // Scrollbar removed - users scroll with trackpad/wheel
     }
     
     /// Draw Plex browser title bar with skin sprites.
     /// Prefer the custom library chrome when present so the title bar matches the side/bottom borders.
-    func drawPlexBrowserTitleBar(in context: CGContext, bounds: NSRect, isActive: Bool, pressedButton: PlexBrowserButtonType?) {
+    func drawPlexBrowserTitleBar(in context: CGContext, bounds: NSRect, isActive: Bool,
+                                 pressedButton: PlexBrowserButtonType?, controlScale: CGFloat = 1.0) {
         if let libraryImage = skin.libraryWindowImage {
-            drawLibraryWindowTitleBar(from: libraryImage, in: context, bounds: bounds, isActive: isActive, pressedButton: pressedButton)
+            drawLibraryWindowTitleBar(from: libraryImage, in: context, bounds: bounds,
+                                      isActive: isActive, pressedButton: pressedButton,
+                                      controlScale: controlScale)
             return
         }
 
@@ -2845,12 +2866,16 @@ class SkinRenderer {
         }
         
         // Draw PLEDIT-based title bar
-        drawPlexBrowserTitleBarFromPledit(pleditImage, in: context, bounds: bounds, isActive: isActive, pressedButton: pressedButton)
+        drawPlexBrowserTitleBarFromPledit(pleditImage, in: context, bounds: bounds,
+                                          isActive: isActive, pressedButton: pressedButton,
+                                          controlScale: controlScale)
     }
     
     /// Draw Plex browser title bar using PLEDIT.BMP sprites
     /// Draw Plex browser title bar using PLEDIT.BMP sprites (same approach as ProjectM)
-    private func drawPlexBrowserTitleBarFromPledit(_ pleditImage: NSImage, in context: CGContext, bounds: NSRect, isActive: Bool, pressedButton: PlexBrowserButtonType?) {
+    private func drawPlexBrowserTitleBarFromPledit(_ pleditImage: NSImage, in context: CGContext, bounds: NSRect,
+                                                   isActive: Bool, pressedButton: PlexBrowserButtonType?,
+                                                   controlScale: CGFloat) {
         let titleHeight = SkinElements.Playlist.titleHeight
         let leftCornerWidth: CGFloat = 25
         let rightCornerWidth: CGFloat = 25
@@ -2887,38 +2912,21 @@ class SkinRenderer {
             x += tileWidth
         }
 
-        // Re-draw the close + shade icons (baked into rightCorner) on top of mirrored corner.
-        let closeIconYOffset: CGFloat = isActive ? 0 : 21
-        let closeBtnSource = NSRect(x: 167, y: 3 + closeIconYOffset, width: 9, height: 9)
-        let shadeBtnSource = NSRect(x: 158, y: 3 + closeIconYOffset, width: 9, height: 9)
-        drawSprite(from: pleditImage, sourceRect: closeBtnSource,
-                  to: NSRect(x: bounds.width - SkinElements.Playlist.TitleBarButtons.closeOffset,
-                             y: 3, width: 9, height: 9), in: context)
-        drawSprite(from: pleditImage, sourceRect: shadeBtnSource,
-                  to: NSRect(x: bounds.width - SkinElements.Playlist.TitleBarButtons.shadeOffset,
-                             y: 3, width: 9, height: 9), in: context)
+        drawPlaylistTitleBarControls(from: pleditImage, in: context, bounds: bounds,
+                                     titleHeight: titleHeight, isActive: isActive,
+                                     controlScale: controlScale, showsShade: true,
+                                     closePressed: pressedButton == .close,
+                                     shadePressed: pressedButton == .shade)
 
         _ = rightCorner
 
         // Note: Custom text removed - let the skin's title bar show through
-
-        if pressedButton == .close {
-            let closeRect = NSRect(x: bounds.width - SkinElements.Playlist.TitleBarButtons.closeOffset,
-                                   y: 3, width: 9, height: 9)
-            NSColor(calibratedWhite: 0.3, alpha: 0.5).setFill()
-            context.fill(closeRect)
-        }
-        
-        if pressedButton == .shade {
-            let shadeRect = NSRect(x: bounds.width - SkinElements.Playlist.TitleBarButtons.shadeOffset,
-                                   y: 3, width: 9, height: 9)
-            NSColor(calibratedWhite: 0.3, alpha: 0.5).setFill()
-            context.fill(shadeRect)
-        }
     }
     
     /// Draw title bar using library-window.png sprites
-    private func drawLibraryWindowTitleBar(from image: NSImage, in context: CGContext, bounds: NSRect, isActive: Bool, pressedButton: PlexBrowserButtonType?) {
+    private func drawLibraryWindowTitleBar(from image: NSImage, in context: CGContext, bounds: NSRect,
+                                           isActive: Bool, pressedButton: PlexBrowserButtonType?,
+                                           controlScale: CGFloat) {
         let layout = SkinElements.LibraryWindow.TitleBar.self
         let titleHeight = SkinElements.PlexBrowser.Layout.titleBarHeight
         let leftCornerWidth: CGFloat = 25
@@ -2954,18 +2962,23 @@ class SkinRenderer {
         // Draw "NULLPLAYER LIBRARY" text using GenFont with proper active/inactive colors
         drawLibraryTitleText(in: context, bounds: bounds, titleHeight: titleHeight, isActive: isActive)
         
-        // Draw window control buttons using skin titlebar sprites (same style as main window)
-        let closeRect = NSRect(x: bounds.width - SkinElements.LibraryWindow.TitleBarButtons.closeOffset - 9, 
-                               y: 4, width: 9, height: 9)
-        let shadeRect = NSRect(x: bounds.width - SkinElements.LibraryWindow.TitleBarButtons.shadeOffset - 9, 
-                               y: 4, width: 9, height: 9)
-        
-        let closeState: ButtonState = (pressedButton == .close) ? .pressed : .normal
-        let shadeState: ButtonState = (pressedButton == .shade) ? .pressed : .normal
-        
         drawLibraryWindowTitleSideRails(from: image, in: context, bounds: bounds, titleHeight: titleHeight)
-        drawButton(.close, state: closeState, at: closeRect, in: context)
-        drawButton(.shade, state: shadeState, at: shadeRect, in: context)
+        if let pleditImage = skin.pledit {
+            drawPlaylistTitleBarControls(from: pleditImage, in: context, bounds: bounds,
+                                         titleHeight: titleHeight, isActive: isActive,
+                                         controlScale: controlScale, showsShade: true,
+                                         closePressed: pressedButton == .close,
+                                         shadePressed: pressedButton == .shade)
+        } else {
+            let closeRect = NSRect(x: bounds.width - SkinElements.LibraryWindow.TitleBarButtons.closeOffset - 9,
+                                   y: 4, width: 9, height: 9)
+            let shadeRect = NSRect(x: bounds.width - SkinElements.LibraryWindow.TitleBarButtons.shadeOffset - 9,
+                                   y: 4, width: 9, height: 9)
+            let closeState: ButtonState = (pressedButton == .close) ? .pressed : .normal
+            let shadeState: ButtonState = (pressedButton == .shade) ? .pressed : .normal
+            drawButton(.close, state: closeState, at: closeRect, in: context)
+            drawButton(.shade, state: shadeState, at: shadeRect, in: context)
+        }
     }
 
     /// Restore matching outer side rails over the title-bar sprite so the border is continuous at the top.

--- a/Sources/NullPlayer/Skin/SkinRenderer.swift
+++ b/Sources/NullPlayer/Skin/SkinRenderer.swift
@@ -1617,7 +1617,7 @@ class SkinRenderer {
         drawPlaylistTitleBarControls(from: pleditImage, in: context, bounds: bounds,
                                      titleHeight: titleHeight, isActive: isActive,
                                      controlScale: controlScale, showsShade: true,
-                                     closePressed: pressedButton == .close, shadePressed: false)
+                                     closePressed: pressedButton == .close, shadePressed: pressedButton == .shade)
 
         _ = rightCorner
 
@@ -1805,7 +1805,7 @@ class SkinRenderer {
         drawPlaylistTitleBarControls(from: pleditImage, in: context, bounds: bounds,
                                      titleHeight: titleHeight, isActive: isActive,
                                      controlScale: controlScale, showsShade: true,
-                                     closePressed: pressedButton == .close, shadePressed: false)
+                                     closePressed: pressedButton == .close, shadePressed: pressedButton == .shade)
 
         _ = rightCorner  // original sprite no longer drawn; reference kept above for parity
 

--- a/Sources/NullPlayer/Windows/MainWindow/MainWindowView.swift
+++ b/Sources/NullPlayer/Windows/MainWindow/MainWindowView.swift
@@ -2,6 +2,7 @@ import AppKit
 
 /// Visualization mode for the main window's built-in visualization area
 enum MainWindowVisMode: String, CaseIterable {
+    case none = "None"               // No main-window visualization; leaves skin artwork visible
     case spectrum = "Spectrum"       // Classic 19-bar spectrum analyzer (CGContext)
     case visClassicExact = "vis_classic" // Exact vis_classic port (CPU frame in Metal overlay)
     case fire = "Fire"               // GPU flame simulation (Metal overlay)
@@ -15,12 +16,13 @@ enum MainWindowVisMode: String, CaseIterable {
     
     var displayName: String {
         switch self {
+        case .none: return "Off"
         case .spectrum: return SpectrumQualityMode.classic.displayName
         default: return rawValue
         }
     }
 
-    /// Shared user-facing order for visualization mode menus and click cycling.
+    /// Shared user-facing order for visualization click cycling.
     static let visualizationOrder: [MainWindowVisMode] = SpectrumQualityMode.visualizationOrder.compactMap { qualityMode in
         switch qualityMode {
         case .classic: return .spectrum
@@ -35,14 +37,17 @@ enum MainWindowVisMode: String, CaseIterable {
         case .visClassicExact: return .visClassicExact
         }
     }
+
+    /// User-facing menu order, including the Winamp-compatible blank display mode.
+    static let menuOrder: [MainWindowVisMode] = [.none] + visualizationOrder
     
-    /// Whether this mode uses the Metal overlay (all modes except spectrum)
-    var usesMetal: Bool { self != .spectrum }
+    /// Whether this mode uses the Metal overlay.
+    var usesMetal: Bool { spectrumQualityMode != nil }
     
     /// Map to the corresponding SpectrumQualityMode for the Metal overlay
     var spectrumQualityMode: SpectrumQualityMode? {
         switch self {
-        case .spectrum: return nil
+        case .none, .spectrum: return nil
         case .visClassicExact: return .visClassicExact
         case .fire: return .flame
         case .enhanced: return .enhanced

--- a/Sources/NullPlayer/Windows/ModernProjectM/ModernProjectMView.swift
+++ b/Sources/NullPlayer/Windows/ModernProjectM/ModernProjectMView.swift
@@ -764,6 +764,10 @@ class ModernProjectMView: NSView, GeissMenuTarget, TripexMenuTarget, MetMuseumMe
     // MARK: - Context Menu
     
     override func menu(for event: NSEvent) -> NSMenu? {
+        buildVisualizationMenu()
+    }
+
+    func buildVisualizationMenu() -> NSMenu {
         let menu = NSMenu()
         
         let currentEngineType = visualizationGLView?.currentEngineType ?? .projectM

--- a/Sources/NullPlayer/Windows/ModernProjectM/ModernProjectMWindowController.swift
+++ b/Sources/NullPlayer/Windows/ModernProjectM/ModernProjectMWindowController.swift
@@ -313,6 +313,10 @@ class ModernProjectMWindowController: NSWindowController, ProjectMWindowProvidin
     var presetsInfo: (bundledCount: Int, customCount: Int, customPath: String?) {
         return projectMView.visualizationGLView?.presetsInfo ?? (0, 0, nil)
     }
+
+    func buildVisualizationMenu() -> NSMenu {
+        projectMView.buildVisualizationMenu()
+    }
 }
 
 // MARK: - NSWindowDelegate

--- a/Sources/NullPlayer/Windows/PlexBrowser/PlexBrowserView.swift
+++ b/Sources/NullPlayer/Windows/PlexBrowser/PlexBrowserView.swift
@@ -1828,6 +1828,14 @@ class PlexBrowserView: NSView {
         }
     }
 
+    private var playlistChromeScale: CGFloat {
+        if let mainWindow = WindowManager.shared.mainWindowController?.window,
+           mainWindow.frame.width > 0 {
+            return mainWindow.frame.width / Skin.baseMainSize.width
+        }
+        return Skin.scaleFactor * WindowManager.shared.classicScaleMultiplier
+    }
+
     private func currentPlaylistColors() -> PlaylistColors {
         let skin = WindowManager.shared.currentSkin ?? SkinLoader.shared.loadDefault()
         return skin.playlistColors
@@ -1983,7 +1991,8 @@ class PlexBrowserView: NSView {
             if dirtyRect.minY >= serverBarMinY {
                 let scrollPosition = calculateScrollPosition()
                 renderer.drawPlexBrowserWindow(in: context, bounds: drawBounds, isActive: isActive,
-                                               pressedButton: pressedButton, scrollPosition: scrollPosition)
+                                               pressedButton: pressedButton, scrollPosition: scrollPosition,
+                                               controlScale: playlistChromeScale)
                 drawServerBar(in: context, drawBounds: drawBounds, colors: colors, renderer: renderer)
             } else {
                 // Calculate scroll position for scrollbar (0-1)
@@ -1991,7 +2000,8 @@ class PlexBrowserView: NSView {
 
                 // Draw window frame using skin sprites
                 renderer.drawPlexBrowserWindow(in: context, bounds: drawBounds, isActive: isActive,
-                                               pressedButton: pressedButton, scrollPosition: scrollPosition)
+                                               pressedButton: pressedButton, scrollPosition: scrollPosition,
+                                               controlScale: playlistChromeScale)
 
                 // Draw server/library selector bar
                 drawServerBar(in: context, drawBounds: drawBounds, colors: colors, renderer: renderer)

--- a/Sources/NullPlayer/Windows/PlexBrowser/PlexBrowserView.swift
+++ b/Sources/NullPlayer/Windows/PlexBrowser/PlexBrowserView.swift
@@ -1828,14 +1828,6 @@ class PlexBrowserView: NSView {
         }
     }
 
-    private var playlistChromeScale: CGFloat {
-        if let mainWindow = WindowManager.shared.mainWindowController?.window,
-           mainWindow.frame.width > 0 {
-            return mainWindow.frame.width / Skin.baseMainSize.width
-        }
-        return Skin.scaleFactor * WindowManager.shared.classicScaleMultiplier
-    }
-
     private func currentPlaylistColors() -> PlaylistColors {
         let skin = WindowManager.shared.currentSkin ?? SkinLoader.shared.loadDefault()
         return skin.playlistColors
@@ -1992,7 +1984,7 @@ class PlexBrowserView: NSView {
                 let scrollPosition = calculateScrollPosition()
                 renderer.drawPlexBrowserWindow(in: context, bounds: drawBounds, isActive: isActive,
                                                pressedButton: pressedButton, scrollPosition: scrollPosition,
-                                               controlScale: playlistChromeScale)
+                                               controlScale: WindowManager.shared.playlistChromeScale)
                 drawServerBar(in: context, drawBounds: drawBounds, colors: colors, renderer: renderer)
             } else {
                 // Calculate scroll position for scrollbar (0-1)
@@ -2001,7 +1993,7 @@ class PlexBrowserView: NSView {
                 // Draw window frame using skin sprites
                 renderer.drawPlexBrowserWindow(in: context, bounds: drawBounds, isActive: isActive,
                                                pressedButton: pressedButton, scrollPosition: scrollPosition,
-                                               controlScale: playlistChromeScale)
+                                               controlScale: WindowManager.shared.playlistChromeScale)
 
                 // Draw server/library selector bar
                 drawServerBar(in: context, drawBounds: drawBounds, colors: colors, renderer: renderer)

--- a/Sources/NullPlayer/Windows/ProjectM/ProjectMView.swift
+++ b/Sources/NullPlayer/Windows/ProjectM/ProjectMView.swift
@@ -81,6 +81,14 @@ class ProjectMView: NSView, GeissMenuTarget, TripexMenuTarget, MetMuseumMenuTarg
     private var Layout: SkinElements.ProjectM.Layout.Type {
         SkinElements.ProjectM.Layout.self
     }
+
+    private var playlistChromeScale: CGFloat {
+        if let mainWindow = WindowManager.shared.mainWindowController?.window,
+           mainWindow.frame.width > 0 {
+            return mainWindow.frame.width / Skin.baseMainSize.width
+        }
+        return Skin.scaleFactor * WindowManager.shared.classicScaleMultiplier
+    }
     
     // MARK: - Initialization
     
@@ -268,7 +276,8 @@ class ProjectMView: NSView, GeissMenuTarget, TripexMenuTarget, MetMuseumMenuTarg
         
         // Draw window chrome at actual window bounds (no scaling - chrome tiles to fill)
         renderer.drawProjectMWindow(in: context, bounds: bounds, isActive: isActive,
-                                    pressedButton: pressedButton, isShadeMode: isShadeMode)
+                                    pressedButton: pressedButton, isShadeMode: isShadeMode,
+                                    controlScale: playlistChromeScale)
         
         context.restoreGState()
 

--- a/Sources/NullPlayer/Windows/ProjectM/ProjectMView.swift
+++ b/Sources/NullPlayer/Windows/ProjectM/ProjectMView.swift
@@ -784,6 +784,10 @@ class ProjectMView: NSView, GeissMenuTarget, TripexMenuTarget, MetMuseumMenuTarg
     // MARK: - Context Menu
     
     override func menu(for event: NSEvent) -> NSMenu? {
+        buildVisualizationMenu()
+    }
+
+    func buildVisualizationMenu() -> NSMenu {
         let menu = NSMenu()
         
         let currentEngineType = visualizationGLView?.currentEngineType ?? .projectM

--- a/Sources/NullPlayer/Windows/ProjectM/ProjectMView.swift
+++ b/Sources/NullPlayer/Windows/ProjectM/ProjectMView.swift
@@ -82,14 +82,6 @@ class ProjectMView: NSView, GeissMenuTarget, TripexMenuTarget, MetMuseumMenuTarg
         SkinElements.ProjectM.Layout.self
     }
 
-    private var playlistChromeScale: CGFloat {
-        if let mainWindow = WindowManager.shared.mainWindowController?.window,
-           mainWindow.frame.width > 0 {
-            return mainWindow.frame.width / Skin.baseMainSize.width
-        }
-        return Skin.scaleFactor * WindowManager.shared.classicScaleMultiplier
-    }
-    
     // MARK: - Initialization
     
     override init(frame frameRect: NSRect) {
@@ -277,7 +269,7 @@ class ProjectMView: NSView, GeissMenuTarget, TripexMenuTarget, MetMuseumMenuTarg
         // Draw window chrome at actual window bounds (no scaling - chrome tiles to fill)
         renderer.drawProjectMWindow(in: context, bounds: bounds, isActive: isActive,
                                     pressedButton: pressedButton, isShadeMode: isShadeMode,
-                                    controlScale: playlistChromeScale)
+                                    controlScale: WindowManager.shared.playlistChromeScale)
         
         context.restoreGState()
 

--- a/Sources/NullPlayer/Windows/ProjectM/ProjectMWindowController.swift
+++ b/Sources/NullPlayer/Windows/ProjectM/ProjectMWindowController.swift
@@ -342,6 +342,10 @@ class ProjectMWindowController: NSWindowController, ProjectMWindowProviding {
     var presetsInfo: (bundledCount: Int, customCount: Int, customPath: String?) {
         return projectMView.visualizationGLView?.presetsInfo ?? (0, 0, nil)
     }
+
+    func buildVisualizationMenu() -> NSMenu {
+        projectMView.buildVisualizationMenu()
+    }
 }
 
 // MARK: - NSWindowDelegate

--- a/Sources/NullPlayer/Windows/Spectrum/SpectrumView.swift
+++ b/Sources/NullPlayer/Windows/Spectrum/SpectrumView.swift
@@ -40,14 +40,6 @@ class SpectrumView: NSView {
         SkinElements.SpectrumWindow.Layout.self
     }
 
-    private var playlistChromeScale: CGFloat {
-        if let mainWindow = WindowManager.shared.mainWindowController?.window,
-           mainWindow.frame.width > 0 {
-            return mainWindow.frame.width / Skin.baseMainSize.width
-        }
-        return Skin.scaleFactor * WindowManager.shared.classicScaleMultiplier
-    }
-    
     // MARK: - Initialization
     
     override init(frame frameRect: NSRect) {
@@ -186,7 +178,7 @@ class SpectrumView: NSView {
         // Draw window chrome with "NULLPLAYER ANALYZER" title
         renderer.drawSpectrumAnalyzerWindow(in: context, bounds: bounds, isActive: isActive,
                                             pressedButton: pressedButton, isShadeMode: isShadeMode,
-                                            controlScale: playlistChromeScale)
+                                            controlScale: WindowManager.shared.playlistChromeScale)
         
         context.restoreGState()
 

--- a/Sources/NullPlayer/Windows/Spectrum/SpectrumView.swift
+++ b/Sources/NullPlayer/Windows/Spectrum/SpectrumView.swift
@@ -39,6 +39,14 @@ class SpectrumView: NSView {
     private var Layout: SkinElements.SpectrumWindow.Layout.Type {
         SkinElements.SpectrumWindow.Layout.self
     }
+
+    private var playlistChromeScale: CGFloat {
+        if let mainWindow = WindowManager.shared.mainWindowController?.window,
+           mainWindow.frame.width > 0 {
+            return mainWindow.frame.width / Skin.baseMainSize.width
+        }
+        return Skin.scaleFactor * WindowManager.shared.classicScaleMultiplier
+    }
     
     // MARK: - Initialization
     
@@ -177,7 +185,8 @@ class SpectrumView: NSView {
         
         // Draw window chrome with "NULLPLAYER ANALYZER" title
         renderer.drawSpectrumAnalyzerWindow(in: context, bounds: bounds, isActive: isActive,
-                                            pressedButton: pressedButton, isShadeMode: isShadeMode)
+                                            pressedButton: pressedButton, isShadeMode: isShadeMode,
+                                            controlScale: playlistChromeScale)
         
         context.restoreGState()
 

--- a/Sources/NullPlayer/Windows/Waveform/WaveformView.swift
+++ b/Sources/NullPlayer/Windows/Waveform/WaveformView.swift
@@ -7,6 +7,14 @@ class WaveformView: BaseWaveformView {
     private var windowDragStartPoint: NSPoint = .zero
     private var isHighlighted = false
 
+    private var playlistChromeScale: CGFloat {
+        if let mainWindow = WindowManager.shared.mainWindowController?.window,
+           mainWindow.frame.width > 0 {
+            return mainWindow.frame.width / Skin.baseMainSize.width
+        }
+        return Skin.scaleFactor * WindowManager.shared.classicScaleMultiplier
+    }
+
     override var waveformRect: NSRect {
         let titleHeight = SkinElements.WaveformWindow.Layout.titleBarHeight
         let leftBorder = SkinElements.WaveformWindow.Layout.leftBorder
@@ -99,7 +107,8 @@ class WaveformView: BaseWaveformView {
             bounds: bounds,
             isActive: isActive,
             pressedButton: pressedClose ? .close : nil,
-            isShadeMode: false
+            isShadeMode: false,
+            controlScale: playlistChromeScale
         )
         context.restoreGState()
 

--- a/Sources/NullPlayer/Windows/Waveform/WaveformView.swift
+++ b/Sources/NullPlayer/Windows/Waveform/WaveformView.swift
@@ -7,14 +7,6 @@ class WaveformView: BaseWaveformView {
     private var windowDragStartPoint: NSPoint = .zero
     private var isHighlighted = false
 
-    private var playlistChromeScale: CGFloat {
-        if let mainWindow = WindowManager.shared.mainWindowController?.window,
-           mainWindow.frame.width > 0 {
-            return mainWindow.frame.width / Skin.baseMainSize.width
-        }
-        return Skin.scaleFactor * WindowManager.shared.classicScaleMultiplier
-    }
-
     override var waveformRect: NSRect {
         let titleHeight = SkinElements.WaveformWindow.Layout.titleBarHeight
         let leftBorder = SkinElements.WaveformWindow.Layout.leftBorder
@@ -108,7 +100,7 @@ class WaveformView: BaseWaveformView {
             isActive: isActive,
             pressedButton: pressedClose ? .close : nil,
             isShadeMode: false,
-            controlScale: playlistChromeScale
+            controlScale: WindowManager.shared.playlistChromeScale
         )
         context.restoreGState()
 

--- a/skills/user-guide/SKILL.md
+++ b/skills/user-guide/SKILL.md
@@ -247,7 +247,7 @@ Accessible via **Playback > Sleep Timer** (or the right-click context menu).
 ## Visualizations
 
 ### Main Window GPU Modes
-Spectrum, vis_classic, Fire, Enhanced, Ultra, JWST, Lightning, Matrix, Snow (double-click to cycle)
+Off, Spectrum, vis_classic, Fire, Enhanced, Ultra, JWST, Lightning, Matrix, Snow, EKG. Double-click cycles visual modes; choose Off from Visuals > Spectrum Analyzer > Main Window > Mode.
 
 ### Album Art Visualizer
 30 effects transforming album artwork based on audio

--- a/skills/visualizations/SKILL.md
+++ b/skills/visualizations/SKILL.md
@@ -11,12 +11,13 @@ Related but separate from the visualization stack is the standalone waveform win
 
 ## Main Window Visualization
 
-The main window's built-in visualization area (76x16 pixels in Winamp coordinates) supports ten rendering modes.
+The main window's built-in visualization area (76x16 pixels in Winamp coordinates) supports eleven display modes.
 
 ### Modes
 
 | Mode | Description |
 |------|-------------|
+| **Off** | No main-window visualization; leaves the skin's prepared display artwork visible |
 | **Classic** | Low-fi 19-bar spectrum analyzer with skin colors and cropped analyzer sub curve (default; persisted internally as `Spectrum`) |
 | **Enhanced** | Compact professional LED analyzer with cropped sub range, clean peak caps, and restrained meter colors |
 | **Ultra** | Dense professional spectrum analyzer with cropped sub range, fast decay, clean peak caps, and restrained meter colors |
@@ -31,7 +32,7 @@ The main window's built-in visualization area (76x16 pixels in Winamp coordinate
 ### Switching Modes
 
 - **Double-click** the visualization area to cycle through modes
-- **Right-click** → Spectrum Analyzer → Main Window → Mode to select specific mode
+- **Right-click** → Spectrum Analyzer → Main Window → Mode to select a specific mode, including **Off**
 - Setting persisted: `mainWindowVisMode` (UserDefaults)
 
 ### Settings
@@ -52,7 +53,7 @@ Mode-specific:
 - **vis_classic Core**: CPU frame generation via `VisClassicBridge` + `CVisClassicCore`, uploaded to a Metal texture
 - **Positioning**: Converted from Winamp coordinates to macOS view coordinates
 - **Lifecycle**: Created lazily on first GPU mode activation
-- **CPU Efficiency**: Display link pauses when window is minimized/occluded or in Spectrum mode
+- **CPU Efficiency**: Display link pauses when window is minimized/occluded, in Spectrum mode, or in Off mode
 
 ## Album Art Visualizer
 


### PR DESCRIPTION
## Summary

Bundles five UI refinements on the classic windows + visualizations menus:

- **Classic secondary window chrome** — Spectrum, Waveform, ProjectM, and classic browser title bars now share the playlist close/shade artwork and scale, with the companion circle control and the small titlebar line gap. Main and EQ unchanged. Sprite re-draw is consolidated into a single `drawPlaylistTitleBarControls` helper, and chrome scale is derived from a shared `WindowManager.playlistChromeScale`.
- **Windows menu coverage** — top-level Windows menu now lists the standalone Spectrum Analyzer, and the Video Player entry appears (disabled when no video window exists).
- **Visualizations menu parity** — top-level Visuals > Visualizations menu exposes the visualization window toggle, engine selection before the window is opened, and the live visualization window controls once available.
- **Visualizations menu cleanup** — projectM-only preset count, preset-folder, rescan, and bundled-preset Finder actions removed from the generic Visualizations menu.
- **Main-window spectrum Off mode** — Visuals > Spectrum Analyzer > Main Window > Mode now includes **Off**, matching Winamp's blank main-display option so skin display artwork shows through.

## Testing

- `swift build`
- Manual QA recommended across multiple skins, Double Size (1.5x) scaling, Off mode + skin spectrum artwork, Video Player menu enable/disable, engine switching from the top-level menu before the projectM window has been opened.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added "Off" mode to disable the main window spectrum analyzer visualization.
  * Enhanced Windows menu with toggles for Spectrum Analyzer, Waveform, Plex Browser, ProjectM, and Video Player.

* **Improvements**
  * Expanded Visualizations menu with live controls and visualization engine selection.
  * Refined secondary window chrome and title-bar control scaling for classic UI.

* **Documentation**
  * Updated user guides to document the new "Off" visualization mode.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/ad-repo/nullplayer/pull/223?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->