### PR TITLE
Rebuild EKG visualization as a pure peak detector

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@
 
 ### Improvements
 
+- **EKG visualization rebuilt as a pure peak detector** — the EKG mode no longer depends on BPM or aubio tempo tracking. Each detected audio peak now fires one QRS complex at the scan head, with height scaled to the peak's *prominence* (rise above the preceding valley) so soft and loud transients both register with proportional, oscilloscope-style heights. Detection runs on raw RMS instead of the saturated perceptual level signal, so brick-walled / compressed material no longer flatlines. Wider vertical clamp and a perceptual loudness curve give a much larger dynamic range between faint blips and tall kicks.
 - **Classic secondary window chrome refined** — playlist-style windows now share the playlist close-widget artwork and scale, with matching companion circle controls and the small title bar line gap on Spectrum, Waveform, ProjectM, and classic browser chrome while leaving Main and EQ unchanged.
 - **Windows menu coverage** — all primary toggleable app windows are now discoverable from the top-level Windows menu, including the standalone Spectrum Analyzer and the Video Player when a video window exists.
 - **Visualizations menu parity** — the top-level Visuals > Visualizations menu now exposes the visualization window toggle, engine selection before the window is opened, and the live visualization window controls once available, matching the functionality previously only reachable from the visualization window context menu.

--- a/Sources/NullPlayer/Audio/BPMDetector.swift
+++ b/Sources/NullPlayer/Audio/BPMDetector.swift
@@ -133,7 +133,7 @@ class BPMDetector {
             
             let bpm = aubio_tempo_get_bpm(tempoObj)
             let confidence = aubio_tempo_get_confidence(tempoObj)
-            
+
             if bpm > 0 && confidence >= minConfidence {
                 recentReadings[readingIndex % maxBPMReadings] = bpm
                 readingIndex += 1

--- a/Sources/NullPlayer/Visualization/EKGShaders.metal
+++ b/Sources/NullPlayer/Visualization/EKGShaders.metal
@@ -1,27 +1,40 @@
 // =============================================================================
-// EKG SHADERS - Beat-Synced Electrocardiogram Visualizer
+// EKG SHADERS - Peak-Driven Electrocardiogram Visualizer
 // =============================================================================
-// Persistent ECG monitor. BPM controls the cardiac clock, raw PCM amplitude
-// controls newly drawn peak height, and the already-drawn trace is preserved in
-// a ping-pong texture so historical line segments do not refresh or rescale.
-// This mode intentionally ignores frequency energy.
+// Persistent ECG monitor. Detected audio peaks fire QRS complexes at the scan
+// head; raw PCM amplitude controls peak height. The already-drawn trace is
+// preserved in a ping-pong texture so historical line segments do not refresh
+// or rescale. This mode intentionally ignores frequency energy and BPM.
 // =============================================================================
 
 #include <metal_stdlib>
 using namespace metal;
 
+constant int EKG_MAX_BEATS = 8;
+
 struct EKGParams {
     float2 viewportSize;
     float time;
-    float bpm;
-    float beatPhase;
     float amplitudeLevel;
     float noiseLevel;
     float scrollDelta;
     float brightnessBoost;
     int colorScheme;
-    float2 padding;
+    int beatCount;
+    float pad0;
+    float pad1;
+    float pad2;
+    float4 beatTimes[2];   // 8 beat timestamps (in localTime seconds); unused slots = -1000
+    float4 beatAmps[2];    // matching amplitude captured at each beat (0..1)
 };
+
+inline float ekg_beat_time(constant EKGParams& params, int i) {
+    return params.beatTimes[i >> 2][i & 3];
+}
+
+inline float ekg_beat_amp(constant EKGParams& params, int i) {
+    return params.beatAmps[i >> 2][i & 3];
+}
 
 constant float EKG_SCREEN_SECONDS = 5.6;
 constant float EKG_SCAN_HEAD_X = 0.965;
@@ -108,23 +121,46 @@ float ekg_wave_for_beat(float t, float beatTime, float beatIndex) {
 }
 
 float ekg_waveform_at_time(float t, constant EKGParams& params) {
-    float bpm = clamp(params.bpm, 40.0, 100.0);
-    float interval = 60.0 / bpm;
-    float beatCursor = floor(t / interval);
-    float loudness = mix(0.70, 1.42, smoothstep(0.02, 0.92, params.amplitudeLevel));
     float wave = 0.0;
 
-    for (int i = -1; i <= 1; i++) {
-        float beatIndex = beatCursor + float(i);
-        wave += ekg_wave_for_beat(t, beatIndex * interval, beatIndex);
+    int beatCount = min(params.beatCount, EKG_MAX_BEATS);
+    for (int i = 0; i < beatCount; i++) {
+        float bt = ekg_beat_time(params, i);
+        if (bt < -500.0) continue;
+        if (abs(t - bt) > 0.65) continue;   // QRS+T fits comfortably in ~0.6s
+        // Per-beat amplitude: locked in when the onset fired so each QRS keeps the
+        // height of its own peak. Oscilloscope-style mapping — fourth-root pulls the
+        // bottom end way up so the faintest blip is still visible, then a wide
+        // remap pushes loud peaks well above unity for dramatic spikes. Net effect:
+        // ~6× dynamic range between barely-audible and full-scale, with smooth
+        // gradation across the whole curve.
+        float a = clamp(ekg_beat_amp(params, i), 0.0, 1.0);
+        // sqrt curve: faint peaks get a healthy visibility boost (a=0.01 → 0.10,
+        // a=0.1 → 0.32, a=0.5 → 0.71, a=1 → 1) so there's a smooth gradient from
+        // tiny blip to towering kick across the whole input range, not clumped.
+        float perceptual = sqrt(a);
+        float beatLoudness = mix(0.08, 3.40, perceptual);
+        wave += ekg_wave_for_beat(t, bt, float(i)) * beatLoudness;
     }
 
     float nerve = (ekg_noise(float2(t * 19.0, params.time * 2.0)) - 0.5) * params.noiseLevel * 0.020;
-    return wave * loudness + nerve;
+    return wave + nerve;
+}
+
+// Returns absolute distance (seconds) from t to the nearest stored beat time,
+// or a large sentinel value when no beats are stored within range.
+float ekg_distance_to_nearest_beat(float t, constant EKGParams& params) {
+    float best = 100.0;
+    int beatCount = min(params.beatCount, EKG_MAX_BEATS);
+    for (int i = 0; i < beatCount; i++) {
+        float bt = ekg_beat_time(params, i);
+        if (bt < -500.0) continue;
+        best = min(best, abs(t - bt));
+    }
+    return best;
 }
 
 float ekg_trace_y_for_time(float sampleTime, constant EKGParams& params) {
-    float bpmNorm = clamp((params.bpm - 40.0) / 60.0, 0.0, 1.0);
     float tempoBreath = sin(sampleTime * 0.115 * 6.2831853);
 
     float baseline = 0.365;
@@ -132,8 +168,12 @@ float ekg_trace_y_for_time(float sampleTime, constant EKGParams& params) {
     baseline += sin(sampleTime * 0.050 * 6.2831853) * 0.008;
     baseline += sin(sampleTime * 0.33 * 6.2831853) * 0.003;
 
-    float amp = 0.305 + bpmNorm * 0.015;
-    return clamp(baseline + ekg_waveform_at_time(sampleTime, params) * amp, 0.055, 0.945);
+    // Lower per-sample deflection multiplier paired with the wider beatLoudness
+    // range in ekg_waveform_at_time gives oscilloscope-style headroom: faint blips
+    // stay near baseline, loud peaks travel almost the full screen height before
+    // clipping. Clamp uses the very edges of the trace area.
+    float amp = 0.205;
+    return clamp(baseline + ekg_waveform_at_time(sampleTime, params) * amp, 0.020, 0.980);
 }
 
 float ekg_sample_time_for_x(float x, constant EKGParams& params) {
@@ -193,8 +233,8 @@ fragment float4 ekg_update_fragment(
         minD = min(minD, distance_segment(p, float2(x0 * aspect, y0), float2(x1 * aspect, y1)));
     }
 
-    float phaseDistance = min(params.beatPhase, 1.0 - params.beatPhase);
-    float qrsFlash = exp(-pow(phaseDistance / 0.055, 2.0));
+    float headBeatDistance = ekg_distance_to_nearest_beat(params.time, params);
+    float qrsFlash = exp(-pow(headBeatDistance / 0.055, 2.0));
     float livePulse = clamp(qrsFlash * 1.10, 0.0, 1.25);
     float lineWidth = (1.05 + livePulse * 0.62) / max(minDim, 1.0);
     float aa = 1.35 / max(minDim, 1.0);
@@ -249,8 +289,8 @@ fragment float4 ekg_composite_fragment(
     color += trace.rgb;
 
     float minDim = min(params.viewportSize.x, params.viewportSize.y);
-    float phaseDistance = min(params.beatPhase, 1.0 - params.beatPhase);
-    float qrsFlash = exp(-pow(phaseDistance / 0.055, 2.0));
+    float headBeatDistance = ekg_distance_to_nearest_beat(params.time, params);
+    float qrsFlash = exp(-pow(headBeatDistance / 0.055, 2.0));
     float livePulse = clamp(qrsFlash * 1.10, 0.0, 1.25);
 
     float scanX = EKG_SCAN_HEAD_X;

--- a/Sources/NullPlayer/Visualization/SpectrumAnalyzerView.swift
+++ b/Sources/NullPlayer/Visualization/SpectrumAnalyzerView.swift
@@ -282,18 +282,25 @@ struct SnowParams {
     var brightnessBoost: Float = 1.0 // 4 bytes (offset 44) → total 48
 }
 
-/// Parameters for EKG Metal shaders (must match Metal EKGParams struct)
+/// Parameters for EKG Metal shaders (must match Metal EKGParams struct).
+/// Peak-driven: `beatTimes0`/`beatTimes1` carry up to 8 recent audio-onset timestamps
+/// in localTime seconds; unused slots are -1000.
 struct EKGParams {
     var viewportSize: SIMD2<Float>  // 8 bytes (offset 0)
     var time: Float                  // 4 bytes (offset 8)
-    var bpm: Float                   // 4 bytes (offset 12)
-    var beatPhase: Float             // 4 bytes (offset 16)
-    var amplitudeLevel: Float        // 4 bytes (offset 20)
-    var noiseLevel: Float            // 4 bytes (offset 24)
-    var scrollDelta: Float           // 4 bytes (offset 28)
-    var brightnessBoost: Float = 1.0 // 4 bytes (offset 32)
-    var colorScheme: Int32 = 0       // 4 bytes (offset 36)
-    var _padding: SIMD2<Float> = .zero // 8 bytes (offset 40), total 48
+    var amplitudeLevel: Float        // 4 bytes (offset 12)
+    var noiseLevel: Float            // 4 bytes (offset 16)
+    var scrollDelta: Float           // 4 bytes (offset 20)
+    var brightnessBoost: Float = 1.0 // 4 bytes (offset 24)
+    var colorScheme: Int32 = 0       // 4 bytes (offset 28)
+    var beatCount: Int32 = 0         // 4 bytes (offset 32)
+    var pad0: Float = 0              // 4 bytes (offset 36)
+    var pad1: Float = 0              // 4 bytes (offset 40)
+    var pad2: Float = 0              // 4 bytes (offset 44) → 48 (float4-aligned)
+    var beatTimes0: SIMD4<Float> = .init(repeating: -1000)  // 16 bytes (offset 48)
+    var beatTimes1: SIMD4<Float> = .init(repeating: -1000)  // 16 bytes (offset 64)
+    var beatAmps0: SIMD4<Float> = .init(repeating: 1)       // 16 bytes (offset 80)
+    var beatAmps1: SIMD4<Float> = .init(repeating: 1)       // 16 bytes (offset 96) → total 112
 }
 
 /// Decay mode controlling how quickly bars fall
@@ -374,10 +381,54 @@ private let spectrumAnalyzerEKGSharedClockStart = CACurrentMediaTime()
 private let EKG_SCREEN_SECONDS: Float = 5.6   // seconds of trace history visible on screen (matches Metal constant)
 private let EKG_SCAN_HEAD_X: Float = 0.965    // normalized x position of the scan head (matches Metal constant)
 
+/// Maximum number of beat timestamps the EKG shader can consume per frame.
+/// Matches `EKG_MAX_BEATS` in EKGShaders.metal.
+private let EKG_MAX_BEATS = 8
+
 /// Metal-based spectrum analyzer visualization view
 class SpectrumAnalyzerView: NSView {
-    nonisolated(unsafe) private static var ekgSharedBPM: Float = 0
     nonisolated(unsafe) private static var ekgSharedAmplitudeTarget: Float = 0.5
+
+    // Peak-driven EKG: parallel ring buffers of (timestamp, amplitude) for the last 8 detected
+    // beats. Each entry locks in the PCM amplitude observed at the moment the onset fired so
+    // the QRS height in the trace reflects how loud that specific peak was, not the live level.
+    nonisolated(unsafe) private static var ekgBeatTimeRing: [Float] = Array(repeating: -1000, count: 8)
+    nonisolated(unsafe) private static var ekgBeatAmpRing: [Float] = Array(repeating: 1, count: 8)
+    nonisolated(unsafe) private static var ekgBeatRingHead: Int = 0
+    private static let ekgBeatRingLock = NSLock()
+
+    static func ekgRecordBeat(at localTime: Float, amplitude: Float) {
+        ekgBeatRingLock.lock()
+        ekgBeatTimeRing[ekgBeatRingHead] = localTime
+        ekgBeatAmpRing[ekgBeatRingHead] = amplitude
+        ekgBeatRingHead = (ekgBeatRingHead + 1) % ekgBeatTimeRing.count
+        ekgBeatRingLock.unlock()
+    }
+
+    static func ekgSnapshotBeats() -> (times0: SIMD4<Float>, times1: SIMD4<Float>,
+                                       amps0: SIMD4<Float>, amps1: SIMD4<Float>, count: Int32) {
+        ekgBeatRingLock.lock()
+        let t = ekgBeatTimeRing
+        let a = ekgBeatAmpRing
+        ekgBeatRingLock.unlock()
+        return (
+            times0: SIMD4<Float>(t[0], t[1], t[2], t[3]),
+            times1: SIMD4<Float>(t[4], t[5], t[6], t[7]),
+            amps0:  SIMD4<Float>(a[0], a[1], a[2], a[3]),
+            amps1:  SIMD4<Float>(a[4], a[5], a[6], a[7]),
+            count: Int32(t.count)
+        )
+    }
+
+    static func ekgResetBeats() {
+        ekgBeatRingLock.lock()
+        for i in 0..<ekgBeatTimeRing.count {
+            ekgBeatTimeRing[i] = -1000
+            ekgBeatAmpRing[i] = 1
+        }
+        ekgBeatRingHead = 0
+        ekgBeatRingLock.unlock()
+    }
 
     private let waveformConsumerID = "visClassicWaveform.\(UUID().uuidString)"
 
@@ -748,11 +799,9 @@ class SpectrumAnalyzerView: NSView {
     nonisolated(unsafe) private var snowDensity: Float = 0.2
 
     // EKG mode state
-    nonisolated(unsafe) private var ekgBeatPhase: Float = 0
     nonisolated(unsafe) private var ekgAmplitudeLevel: Float = 0.5
     nonisolated(unsafe) private var ekgTargetAmplitudeLevel: Float = 0.5
     nonisolated(unsafe) private var ekgNoiseLevel: Float = 0.04
-    nonisolated(unsafe) private var ekgCurrentBPM: Float = 0
     nonisolated(unsafe) private var ekgLastRenderTime: Float = 0
     nonisolated(unsafe) private var renderEKGStyle: EKGStyle = .clinical
 
@@ -911,9 +960,10 @@ class SpectrumAnalyzerView: NSView {
         NotificationCenter.default.addObserver(self, selector: #selector(handlePlaybackStateChange),
                                                name: .audioPlaybackStateChanged, object: nil)
 
-        // Observe BPM detection updates for EKG mode's cardiac timing.
-        NotificationCenter.default.addObserver(self, selector: #selector(handleBPMUpdate(_:)),
-                                               name: .bpmUpdated, object: nil)
+        // EKG is now a pure peak detector driven directly from PCM updates
+        // (see handlePCMAmplitudeUpdate). aubio tempo ticks are intentionally
+        // ignored — they're predicted beats, not raw transients, and arrive
+        // with too much latency for an oscilloscope-style trace.
 
         // Observe raw PCM amplitude for EKG peak height. This intentionally avoids frequency-band energy.
         NotificationCenter.default.addObserver(self, selector: #selector(handlePCMAmplitudeUpdate(_:)),
@@ -1132,26 +1182,6 @@ class SpectrumAnalyzerView: NSView {
         }
     }
 
-    @objc private func handleBPMUpdate(_ notification: Notification) {
-        guard let bpm = notification.userInfo?["bpm"] as? Int else { return }
-        let foldedBPM = bpm > 0 ? Self.foldEKGBPM(Float(bpm)) : 0
-        Self.ekgSharedBPM = foldedBPM
-        dataLock.withLock {
-            ekgCurrentBPM = foldedBPM
-        }
-    }
-
-    private static func foldEKGBPM(_ bpm: Float) -> Float {
-        var folded = bpm
-        while folded > 100.0 {
-            folded *= 0.5
-        }
-        while folded > 0.0 && folded < 40.0 {
-            folded *= 2.0
-        }
-        return min(max(folded, 40.0), 100.0)
-    }
-
     @objc private func handlePCMAmplitudeUpdate(_ notification: Notification) {
         guard let pcm = notification.userInfo?["pcm"] as? [Float], !pcm.isEmpty else { return }
 
@@ -1164,11 +1194,94 @@ class SpectrumAnalyzerView: NSView {
         }
 
         let rms = sqrt(sumSquares / Float(pcm.count))
+
+        // Perceptual level used to modulate trace noise / scan-head glow — fine for
+        // it to saturate at 1.0 in loud material.
         let level = min(max(pow(min(max(rms * 7.0 + peak * 0.45, 0.0), 1.0), 0.58), 0.0), 1.0)
         Self.ekgSharedAmplitudeTarget = level
         dataLock.withLock {
             ekgTargetAmplitudeLevel = level
         }
+
+        // Peak detection runs on the *raw* RMS signal directly — NOT the perceptual
+        // `level`. The perceptual mapping deliberately saturates at 1.0 (peak * 0.45
+        // + rms * 7 easily exceeds 1.0 in loud material), which would pin the
+        // detection input flat and produce zero local maxima for the state machine.
+        // RMS itself caps at ~0.707 even at digital full-scale, never clips, and
+        // varies cleanly with energy regardless of how brick-walled the source is.
+        Self.ekgPeakDetect(currentLevel: rms)
+    }
+
+    /// localTime of the most recent QRS we fired; suppresses double-triggers.
+    nonisolated(unsafe) private static var ekgLastBeatLocalTime: Float = -1000
+    /// Local-maximum tracking state.
+    nonisolated(unsafe) private static var ekgRising: Bool = false
+    nonisolated(unsafe) private static var ekgRisingPeak: Float = 0
+    nonisolated(unsafe) private static var ekgValleyLevel: Float = 0
+    nonisolated(unsafe) private static var ekgPrevLevel: Float = 0
+
+    private static let ekgMinBeatInterval: Float = 0.050     // refractory ~20 Hz max trigger
+    private static let ekgSilenceFloor: Float = 0.002        // floor of "absolute silence"
+    // Minimum *peak prominence* (peak height above the most recent valley) for a
+    // local max to count. This works at any volume — including brick-walled
+    // compressed audio where peaks and envelope both pin to ~1.0 — because it
+    // measures the rise of *this* bump, not where it sits in absolute terms.
+    private static let ekgMinProminence: Float = 0.004
+
+    /// Detect QRS triggers by finding *local maxima* in the PCM amplitude stream
+    /// with a peak-prominence gate.
+    ///
+    /// Each call walks one frame of a rising/falling state machine, tracking both
+    /// the current rising peak and the most recent valley. When the signal turns
+    /// from rising to falling, the previous frame is the local maximum: if its
+    /// prominence over the valley exceeds `ekgMinProminence`, we fire a beat
+    /// using `peak - valley` as the captured amplitude. Prominence-based gating
+    /// (rather than ratio-vs-envelope) is robust against fully-saturated /
+    /// brick-walled audio where the level pins to 1.0 and ratio gates become
+    /// mathematically impossible.
+    ///
+    /// Captured amplitude is the prominence itself — for uncompressed music this
+    /// matches the perceived peak height, and for compressed audio it surfaces the
+    /// small but real bump-to-bump variation that's the only thing left.
+    static func ekgPeakDetect(currentLevel level: Float) {
+        let localTime = Float(CACurrentMediaTime() - spectrumAnalyzerEKGSharedClockStart)
+        let elapsed = localTime - ekgLastBeatLocalTime
+
+        // Track the running valley between peaks.
+        if level < ekgValleyLevel {
+            ekgValleyLevel = level
+        }
+
+        if level > ekgPrevLevel {
+            // Rising side of a bump — keep climbing, track the max we see.
+            ekgRising = true
+            if level > ekgRisingPeak {
+                ekgRisingPeak = level
+            }
+        } else if level < ekgPrevLevel, ekgRising {
+            // Turning point: previous frame was the local maximum.
+            ekgRising = false
+            let peak = ekgRisingPeak
+            let prominence = max(peak - ekgValleyLevel, 0)
+
+            if prominence > ekgMinProminence,
+               peak > ekgSilenceFloor,
+               elapsed >= ekgMinBeatInterval {
+                // Detection runs on raw RMS, which caps at ~0.707 — even huge
+                // transients rarely produce prominence above ~0.4. Scale into [0,1]
+                // so the shader's loudness curve uses its full visual range.
+                let scaled = min(prominence * 2.5, 1.0)
+                ekgRecordBeat(at: localTime, amplitude: scaled)
+                ekgLastBeatLocalTime = localTime
+            }
+
+            // Reset peak/valley tracking from this turning point onward so the next
+            // bump is measured relative to a fresh local trough.
+            ekgRisingPeak = level
+            ekgValleyLevel = level
+        }
+
+        ekgPrevLevel = level
     }
     
     // MARK: - Metal Setup
@@ -2583,7 +2696,7 @@ class SpectrumAnalyzerView: NSView {
         cb.commit()
     }
 
-    /// Render EKG mode: BPM-clocked ECG trace with no frequency-energy input
+    /// Render EKG mode: peak-driven ECG trace with no frequency-energy input
     private func renderEKG(drawable: CAMetalDrawable) {
         guard let cb = commandQueue?.makeCommandBuffer(),
               let updatePL = ekgUpdatePipeline,
@@ -2593,28 +2706,33 @@ class SpectrumAnalyzerView: NSView {
 
         let state = dataLock.withLock { () -> (
             time: Float,
-            bpm: Float,
-            beatPhase: Float,
             amplitude: Float,
             scrollDelta: Float,
             noise: Float,
-            style: EKGStyle
+            style: EKGStyle,
+            beats0: SIMD4<Float>,
+            beats1: SIMD4<Float>,
+            amps0: SIMD4<Float>,
+            amps1: SIMD4<Float>,
+            beatCount: Int32
         ) in
             let localTime = Float(CACurrentMediaTime() - spectrumAnalyzerEKGSharedClockStart)
             animationTime = localTime
             let frameDelta = ekgLastRenderTime > 0 ? min(max(localTime - ekgLastRenderTime, 1.0 / 120.0), 1.0 / 20.0) : 1.0 / 60.0
             ekgLastRenderTime = localTime
 
-            ekgCurrentBPM = Self.ekgSharedBPM
             ekgTargetAmplitudeLevel = Self.ekgSharedAmplitudeTarget
 
-            let detectedBPM = ekgCurrentBPM > 0 ? ekgCurrentBPM : 80.0
-            let tempoHz = detectedBPM / 60.0
-            let beatClock = localTime * tempoHz
-            ekgBeatPhase = beatClock - floor(beatClock)
+            let snap = Self.ekgSnapshotBeats()
 
-            let phaseDistance = min(ekgBeatPhase, 1.0 - ekgBeatPhase)
-            let qrsPulse = exp(-pow(phaseDistance / 0.075, 2.0))
+            // Find nearest beat distance for the boost/noise-modulation tied to QRS flashes.
+            var nearest: Float = 100
+            for slot in [snap.times0.x, snap.times0.y, snap.times0.z, snap.times0.w,
+                         snap.times1.x, snap.times1.y, snap.times1.z, snap.times1.w] {
+                guard slot > -500 else { continue }
+                nearest = min(nearest, abs(localTime - slot))
+            }
+            let qrsPulse = exp(-pow(nearest / 0.075, 2.0))
             let targetNoise = 0.025 + qrsPulse * 0.025
             ekgNoiseLevel += (targetNoise - ekgNoiseLevel) * 0.12
             let amplitudeRate: Float = ekgTargetAmplitudeLevel > ekgAmplitudeLevel ? 0.28 : 0.075
@@ -2622,12 +2740,15 @@ class SpectrumAnalyzerView: NSView {
 
             return (
                 time: localTime,
-                bpm: detectedBPM,
-                beatPhase: ekgBeatPhase,
                 amplitude: ekgAmplitudeLevel,
                 scrollDelta: frameDelta / EKG_SCREEN_SECONDS * EKG_SCAN_HEAD_X,
                 noise: ekgNoiseLevel,
-                style: renderEKGStyle
+                style: renderEKGStyle,
+                beats0: snap.times0,
+                beats1: snap.times1,
+                amps0: snap.amps0,
+                amps1: snap.amps1,
+                beatCount: snap.count
             )
         }
 
@@ -2644,13 +2765,16 @@ class SpectrumAnalyzerView: NSView {
             p.pointee = EKGParams(
                 viewportSize: viewport,
                 time: state.time,
-                bpm: state.bpm,
-                beatPhase: state.beatPhase,
                 amplitudeLevel: state.amplitude,
                 noiseLevel: state.noise,
                 scrollDelta: state.scrollDelta,
                 brightnessBoost: brightnessBoost,
-                colorScheme: state.style.colorScheme
+                colorScheme: state.style.colorScheme,
+                beatCount: state.beatCount,
+                beatTimes0: state.beats0,
+                beatTimes1: state.beats1,
+                beatAmps0: state.amps0,
+                beatAmps1: state.amps1
             )
         }
 
@@ -3554,12 +3678,18 @@ class SpectrumAnalyzerView: NSView {
             visClassicWaveLeft = Array(repeating: 128, count: 576)
             visClassicWaveRight = Array(repeating: 128, count: 576)
 
-            ekgBeatPhase = 0
             ekgAmplitudeLevel = 0.5
             ekgTargetAmplitudeLevel = 0.5
             ekgNoiseLevel = 0.04
             ekgLastRenderTime = 0
             ekgTraceNeedsClear = true
+            Self.ekgResetBeats()
+            Self.ekgSharedAmplitudeTarget = 0.5
+            Self.ekgLastBeatLocalTime = -1000
+            Self.ekgRising = false
+            Self.ekgRisingPeak = 0
+            Self.ekgValleyLevel = 0
+            Self.ekgPrevLevel = 0
         }
         NSLog("SpectrumAnalyzerView: State reset")
     }

--- a/skills/gpu-vis-modes/SKILL.md
+++ b/skills/gpu-vis-modes/SKILL.md
@@ -94,33 +94,32 @@ Shader file: `Visualization/SnowShaders.metal`
 
 ## EKG Mode
 
-Realistic electrocardiogram monitor visualization.
+Oscilloscope-style electrocardiogram monitor — pure peak-driven, no BPM or tempo clock.
 
 **Visual Elements**:
 - Procedural P-QRS-T ECG waveform with smooth antialiasing
 - Medical monitor grid with fine and major subdivisions
-- Green phosphor trace, glow, scan head, scanlines, vignette, analog monitor noise
-- QRS timing pulses from the BPM clock
-- R-peaks placed on a fixed seconds-wide monitor timebase, so faster BPM = closer peak spacing
-- Peak height follows smoothed raw PCM amplitude (no frequency energy used)
+- Phosphor trace, glow, scan head, scanlines, vignette, analog monitor noise
+- Each detected audio peak fires one QRS complex at the scan head; flat baseline between peaks
+- Per-beat amplitude (the prominence of the detected peak) drives that specific QRS's height — quiet peaks read as small blips, loud peaks tower
 - Persistent ping-pong trace texture preserves already-drawn history; only the scan-head region is redrawn
-- Larger vertical scale and lower baseline use more of the monitor area
+- Wide vertical clamp `[0.020, 0.980]` plus loudness range `mix(0.08, 3.40, sqrt(amp))` gives oscilloscope-like headroom
 - Selectable styles: Clinical, Cyan, Amber, Neon, Crimson, Ice
-- Subtle per-beat procedural variance keeps the trace alive without fighting amplitude response
 
 **Audio Reactivity**:
-- Detected BPM drives the cardiac clock when available, folded into a 40–100 BPM display range
-- Fast tempos are halved until they fit; unusually slow readings are doubled
-- Smoothed raw PCM amplitude controls QRS/R-peak height
-- **No spectrum or frequency-band energy is sampled in this mode**
-- Defaults to 80 BPM when no confident BPM has been detected yet
+- Pure peak detector driven directly from `.audioPCMDataUpdated`. **Does not use BPM, aubio tempo, or spectrum energy.**
+- Detection runs on *raw RMS* per PCM frame (NOT the perceptual `level` formula, which saturates at 1.0 on compressed audio and would pin the input flat)
+- State machine: tracks rising peak and running valley between bumps. On a rising-to-falling transition, fires a beat with `amplitude = (peak − valley) × 2.5` clamped to `[0,1]`
+- Peak-prominence gate (`> 0.004`) replaces ratio-vs-envelope gating — works at any volume including brick-walled material where absolute peak is pinned at 1.0
+- 50 ms refractory (~20 Hz max trigger rate); shared 8-slot ring buffer of `(timestamp, amplitude)` feeds the shader
+- Shader sums QRS gaussians around stored beat timestamps; scan-head glow / noise modulation tracks the perceptual `level` for separate scan-head pulse feel
 - EKG Style appears in the spectrum window context menu and the main-window Visuals menu when EKG is active
 
 **Technical**: Two-pass Metal path:
 1. update pass — scrolls/preserves the persistent trace texture and draws only the scan-head band
 2. composite pass — renders the monitor grid, glow, and stored trace
 
-Uses `.bpmUpdated` notifications for timing and `.audioPCMDataUpdated` for raw-amplitude scaling. 60 FPS.
+`EKGParams` packs up to 8 beat timestamps (`beatTimes[2]` float4 array) and matching amplitudes (`beatAmps[2]`). Unused slots use sentinel `-1000`. Shared static ring buffer in `SpectrumAnalyzerView` (`ekgBeatTimeRing` / `ekgBeatAmpRing`) is written from the audio tap thread via `ekgRecordBeat` under `ekgBeatRingLock`. 60 FPS.
 
 Shader file: `Visualization/EKGShaders.metal`
 

--- a/skills/main-window-visualization/SKILL.md
+++ b/skills/main-window-visualization/SKILL.md
@@ -20,7 +20,7 @@ The main window's built-in visualization area (76×16 pixels in Winamp coordinat
 | **Lightning** | GPU lightning storm with fractal bolts mapped to spectrum peaks |
 | **Matrix** | Falling digital rain with procedural glyphs mapped to spectrum bands |
 | **Snow** | Audio-reactive snowfall with flurry-to-blizzard intensity and bass-driven wind gusts |
-| **EKG** | Realistic high-resolution ECG monitor trace synchronized to detected BPM and waveform amplitude |
+| **EKG** | Oscilloscope-style ECG monitor; each detected audio peak fires one QRS, height scales with peak prominence (no BPM clock) |
 | **vis_classic** | Exact-port vis_classic analyzer core with profile-compatible rendering (see [vis-classic-guide](../vis-classic-guide/SKILL.md)) |
 
 ## Switching Modes

--- a/skills/spectrum-analyzer-window/SKILL.md
+++ b/skills/spectrum-analyzer-window/SKILL.md
@@ -39,7 +39,7 @@ Participates in the docking system with Main, EQ, and Playlist:
 | **Lightning** | GPU lightning storm with fractal bolts mapped to spectrum peaks (8 color schemes) |
 | **Matrix** | Falling digital rain with procedural glyphs (5 color schemes, 2 intensity presets) |
 | **Snow** | Layered procedural snowfall with spectrum-shaped density, gusting drift, soft atmospheric haze |
-| **EKG** | Beat-synced ECG monitor with phosphor trace, medical grid, scan glow, BPM-driven QRS pulses, PCM-driven peak height |
+| **EKG** | Oscilloscope-style ECG monitor with phosphor trace, medical grid, scan glow; pure peak detector — each audio onset fires one QRS, height = peak prominence |
 | **vis_classic** | Exact-port vis_classic analyzer core with profile-compatible INI behavior |
 
 ## Switching Modes


### PR DESCRIPTION
## Summary

- Drop the BPM-clock-driven QRS scheduling from the EKG visualization. The mode is now a pure peak detector: each detected audio onset fires one QRS at the scan head, with height scaled to the peak's *prominence* over the preceding valley. Flat baseline between peaks.
- Peak detection runs on raw RMS, not the perceptual `level` signal. The perceptual formula clamps to 1.0 on compressed audio, which previously pinned the detector input flat and caused brick-walled material to flatline. RMS caps at ~0.707 even at full-scale digital audio and varies cleanly with energy regardless of source dynamics.
- Prominence-based gating (`peak − valley > 0.004`) replaces ratio-vs-envelope. Works at any volume — quiet sustained music's gentle undulations and loud compressed rock's subtle bump-to-bump variation both qualify.
- Shader now carries up to 8 `(timestamp, amplitude)` beats per frame as `float4[2]` arrays. `ekg_waveform_at_time` sums QRS gaussians around stored timestamps, and `ekg_distance_to_nearest_beat` drives the scan-head pulse glow.
- Wider vertical clamp (`[0.020, 0.980]`) and a `mix(0.08, 3.40, sqrt(amp))` loudness curve give oscilloscope-style headroom: faint blips read small, big kicks tower.

## Cleanup

- Removed the now-unused `EKGBeatClock` struct, its tests, and the `ekgSharedBeatClock` static.
- Reverted the `audioBeatDetected` notification + its post in `BPMDetector` (no consumers remain). `BPMDetector` itself is left intact for any other future use.
- Skill docs updated: `gpu-vis-modes`, `main-window-visualization`, `spectrum-analyzer-window`.

## Test plan

- [ ] Build (`swift build`) and unit tests (`swift test`) pass — verified locally (80 tests, 0 failures).
- [ ] Pick EKG mode in the spectrum window. Confirm flat baseline when paused.
- [ ] Play a drum-heavy track: each kick/snare produces a QRS at the scan head with visibly different heights for soft vs. loud hits.
- [ ] Play sustained / orchestral / vocal-only music with no drums: gentle undulations produce a steady ECG rhythm — no long flat stretches.
- [ ] Play brick-walled / loud compressed rock: trace stays alive, beats fire on transient prominence rather than absolute level.
- [ ] Switch tracks: detector state resets, new track immediately produces beats.
- [ ] Try all six styles (Clinical, Cyan, Amber, Neon, Crimson, Ice).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Improvements**
  * Rebuilt EKG visualization mode to detect audio peaks directly, independent of BPM tracking
  * Each detected audio peak now triggers a QRS complex with height scaled by peak prominence
  * Enhanced dynamic range preservation for clearer visualization of faint and loud transients

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/ad-repo/nullplayer/pull/227?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->