### PR TITLE
Reference Tuning: pitch-shift local playback to a chosen reference Hz

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## Unreleased
 
+### New Features
+
+- **Reference Tuning** — Playback > Options > **Reference Tuning** can pitch-shift all local playback to a different reference frequency (e.g. retune A=440 content to A=432). Presets for Off, 432 Hz, 440 Hz, and a Custom… dialog accepting source/target Hz are exposed in the menu; settings persist across launches. Applies to local files and HTTP streaming (Plex/Subsonic/Jellyfin/Emby/radio) through a shared `AVAudioUnitTimePitch` inserted after the mixer; the spectrum analyzer continues to display source (pre-pitch) frequencies. Not available while casting (Sonos / Chromecast / DLNA) because the remote renderer receives the stream URL directly with no local audio graph to insert the pitch shifter into. CLI flags `--tuning <off|Hz>`, `--tuning-source <Hz>`, and `--tuning-offset-cents <n>` provide session-only overrides.
+
 ### Improvements
 
 - **Data tab — genre artist drill-down** — selecting a genre in the Data tab now shows the artists that play in that genre with their play counts and listen time, mirroring the existing artist → tracks drill-down. The panel appears directly under the Genres chart and clears when the genre filter is removed. Works in both modern and classic library browsers.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,7 +4,7 @@
 
 ### New Features
 
-- **Reference Tuning** — Playback > Options > **Reference Tuning** can pitch-shift all local playback to a different reference frequency (e.g. retune A=440 content to A=432). Presets for Off, 432 Hz, 440 Hz, and a Custom… dialog accepting source/target Hz are exposed in the menu; settings persist across launches. Applies to local files and HTTP streaming (Plex/Subsonic/Jellyfin/Emby/radio) through a shared `AVAudioUnitTimePitch` inserted after the mixer; the spectrum analyzer continues to display source (pre-pitch) frequencies. Not available while casting (Sonos / Chromecast / DLNA) because the remote renderer receives the stream URL directly with no local audio graph to insert the pitch shifter into. CLI flags `--tuning <off|Hz>`, `--tuning-source <Hz>`, and `--tuning-offset-cents <n>` provide session-only overrides.
+- **Reference Tuning** — Playback > Options > **Reference Tuning** can pitch-shift all local playback to a different reference frequency (e.g. retune A=440 content to A=432). Presets for Off, 432 Hz, 440 Hz, and a Custom… dialog accepting source/target Hz are exposed in the menu; settings persist across launches. Applies to local files and HTTP streaming (Plex/Subsonic/Jellyfin/Emby/radio) via `AVAudioUnitTimePitch` nodes inserted into the active local or streaming graph; the spectrum analyzer continues to display source (pre-pitch) frequencies. Not available while casting (Sonos / Chromecast / DLNA) because the remote renderer receives the stream URL directly with no local audio graph to insert the pitch shifter into. CLI flags `--tuning <off|Hz>`, `--tuning-source <Hz>`, and `--tuning-offset-cents <n>` provide session-only overrides.
 
 ### Improvements
 

--- a/README.md
+++ b/README.md
@@ -38,6 +38,7 @@
 - Original Spenctrum analysis visualization system
 - Album art visualization system with user selected effects
 - Modern mode with 21-band EQ implementation, Classic mode with standard 10-band EQ
+- Reference Tuning for pitch-shifting local playback and HTTP streams to a different reference frequency, with 432 Hz, 440 Hz, and custom source/target Hz options
 - Classic window snapping and docking behavior
 - Audio playback: MP3, FLAC, AAC, WAV, AIFF, ALAC, OGG
 - Video playback: MKV, MP4, MOV, AVI, WebM, HEVC (KSPlayer/FFmpeg)
@@ -219,6 +220,7 @@ nullplayer --cli --source local --genre "Jazz" --repeat-all
 nullplayer --cli --station "KEXP" --source radio
 nullplayer --cli --source local --radio artist --artist "Björk"
 nullplayer --cli --source local --volume 80 --eq "Rock"
+nullplayer --cli --source plex --album "Kind of Blue" --tuning 432
 nullplayer --cli --source jellyfin --playlist "Late Night" --cast "Bedroom" --cast-type sonos
 nullplayer --cli --source local --album "Selected Ambient Works 85-92" --cast "Office TV" --cast-type dlna
 ```
@@ -239,6 +241,18 @@ During playback:
 - `m` toggles mute
 
 When casting is active, the same CLI volume control path is used for the cast target as well.
+
+### Reference Tuning
+
+Reference Tuning pitch-shifts local output to a selected reference frequency, such as retuning A=440 content to A=432. In the app, use **Playback > Options > Reference Tuning** for Off, 432 Hz, 440 Hz, or custom source/target Hz. It applies to local files and HTTP streams from Plex, Subsonic/Navidrome, Jellyfin, Emby, and internet radio. It is unavailable while casting because Sonos, Chromecast, and DLNA renderers receive the media URL directly.
+
+CLI overrides are session-only:
+
+```bash
+nullplayer --cli --source local --artist "Björk" --tuning 432
+nullplayer --cli --source plex --playlist "Focus" --tuning 432 --tuning-source 440
+nullplayer --cli --source radio --station "KEXP" --tuning-offset-cents -31.766
+```
 
 ### Keyboard controls (during playback)
 

--- a/Sources/NullPlayer/App/ContextMenuBuilder.swift
+++ b/Sources/NullPlayer/App/ContextMenuBuilder.swift
@@ -3804,17 +3804,25 @@ class MenuActions: NSObject {
 
         guard alert.runModal() == .alertFirstButtonReturn else { return }
 
-        guard let source = Double(sourceField.stringValue), source > 0,
-              let target = Double(targetField.stringValue), target > 0 else {
+        func showInvalidReferenceAlert(_ message: String = "Source and target must both be positive numbers in Hz.") {
             let err = NSAlert()
             err.messageText = "Invalid reference frequency"
-            err.informativeText = "Source and target must both be positive numbers in Hz."
+            err.informativeText = message
             err.alertStyle = .warning
             err.runModal()
+        }
+
+        guard let source = Double(sourceField.stringValue), source.isFinite, source > 0,
+              let target = Double(targetField.stringValue), target.isFinite, target > 0 else {
+            showInvalidReferenceAlert()
             return
         }
 
         let cents = 1200.0 * log2(target / source)
+        guard cents.isFinite else {
+            showInvalidReferenceAlert("Source and target must produce a finite cents value.")
+            return
+        }
         if cents < PitchTuningController.minCents || cents > PitchTuningController.maxCents {
             let err = NSAlert()
             err.messageText = "Reference tuning out of range"

--- a/Sources/NullPlayer/App/ContextMenuBuilder.swift
+++ b/Sources/NullPlayer/App/ContextMenuBuilder.swift
@@ -257,6 +257,38 @@ class ContextMenuBuilder {
         return menu
     }
 
+    /// Builds the Reference Tuning submenu.
+    static func buildReferenceTuningMenu() -> NSMenu {
+        let menu = NSMenu()
+        menu.autoenablesItems = false
+
+        let engine = WindowManager.shared.audioEngine
+        let current = engine.tuningController.currentPreset
+
+        func makeItem(_ title: String, _ action: Selector, isOn: Bool) -> NSMenuItem {
+            let item = NSMenuItem(title: title, action: action, keyEquivalent: "")
+            item.target = MenuActions.shared
+            item.state = isOn ? .on : .off
+            return item
+        }
+
+        menu.addItem(makeItem("Off", #selector(MenuActions.setReferenceTuningOff), isOn: current == .off))
+        menu.addItem(makeItem("432 Hz", #selector(MenuActions.setReferenceTuning432), isOn: current == .hz432))
+        menu.addItem(makeItem("440 Hz", #selector(MenuActions.setReferenceTuning440), isOn: current == .hz440))
+
+        let isCustom: Bool = {
+            if case .custom = current { return true }
+            return false
+        }()
+        var customTitle = "Custom…"
+        if case .custom(let source, let target) = current {
+            customTitle = String(format: "Custom… (%.2f → %.2f Hz)", source, target)
+        }
+        menu.addItem(makeItem(customTitle, #selector(MenuActions.setReferenceTuningCustom), isOn: isCustom))
+
+        return menu
+    }
+
     /// Builds the top-level "Visuals" menu content for the macOS menu bar.
     static func buildMenuBarVisualsMenu() -> NSMenu {
         let menu = NSMenu()
@@ -819,9 +851,18 @@ class ContextMenuBuilder {
         normalizeItem.target = MenuActions.shared
         normalizeItem.state = engine.volumeNormalizationEnabled ? .on : .off
         optionsMenu.addItem(normalizeItem)
-        
+
+        // Reference Tuning submenu
+        let tuningRoot = NSMenuItem(title: "Reference Tuning", action: nil, keyEquivalent: "")
+        tuningRoot.submenu = buildReferenceTuningMenu()
+        if engine.isAnyCastingActive {
+            tuningRoot.isEnabled = false
+            tuningRoot.toolTip = "Not available while casting"
+        }
+        optionsMenu.addItem(tuningRoot)
+
         optionsMenu.addItem(NSMenuItem.separator())
-        
+
         // Sweet Fades (Crossfade) toggle
         let sweetFadeItem = NSMenuItem(title: "Sweet Fades (Crossfade)", action: #selector(MenuActions.toggleSweetFade), keyEquivalent: "")
         sweetFadeItem.target = MenuActions.shared
@@ -3702,6 +3743,91 @@ class MenuActions: NSObject {
     
     @objc func toggleVolumeNormalization() {
         WindowManager.shared.audioEngine.volumeNormalizationEnabled.toggle()
+    }
+
+    // MARK: - Reference Tuning
+
+    @objc func setReferenceTuningOff() {
+        WindowManager.shared.audioEngine.setTuningPreset(.off)
+    }
+
+    @objc func setReferenceTuning432() {
+        WindowManager.shared.audioEngine.setTuningPreset(.hz432)
+    }
+
+    @objc func setReferenceTuning440() {
+        WindowManager.shared.audioEngine.setTuningPreset(.hz440)
+    }
+
+    @objc func setReferenceTuningCustom() {
+        let engine = WindowManager.shared.audioEngine
+        let initialSource = engine.tuningController.sourceReferenceHz
+        let initialTarget = engine.tuningController.targetReferenceHz
+
+        let alert = NSAlert()
+        alert.messageText = "Custom Reference Tuning"
+        alert.informativeText = "Enter source and target reference frequencies in Hz. Pitch shift = 1200 × log₂(target / source) cents, limited to ±2400 cents."
+        alert.alertStyle = .informational
+        alert.addButton(withTitle: "Apply")
+        alert.addButton(withTitle: "Cancel")
+
+        let stack = NSStackView()
+        stack.orientation = .vertical
+        stack.alignment = .leading
+        stack.spacing = 6
+        stack.translatesAutoresizingMaskIntoConstraints = false
+
+        func row(label: String, value: Double) -> (NSStackView, NSTextField) {
+            let row = NSStackView()
+            row.orientation = .horizontal
+            row.spacing = 8
+            let lbl = NSTextField(labelWithString: label)
+            lbl.alignment = .right
+            lbl.widthAnchor.constraint(equalToConstant: 90).isActive = true
+            let field = NSTextField(string: String(format: "%g", value))
+            field.widthAnchor.constraint(equalToConstant: 100).isActive = true
+            row.addArrangedSubview(lbl)
+            row.addArrangedSubview(field)
+            return (row, field)
+        }
+
+        let (sourceRow, sourceField) = row(label: "Source Hz:", value: initialSource)
+        let (targetRow, targetField) = row(label: "Target Hz:", value: initialTarget)
+        stack.addArrangedSubview(sourceRow)
+        stack.addArrangedSubview(targetRow)
+
+        let accessory = NSView(frame: NSRect(x: 0, y: 0, width: 240, height: 60))
+        stack.frame = accessory.bounds
+        stack.autoresizingMask = [.width, .height]
+        accessory.addSubview(stack)
+        alert.accessoryView = accessory
+
+        guard alert.runModal() == .alertFirstButtonReturn else { return }
+
+        guard let source = Double(sourceField.stringValue), source > 0,
+              let target = Double(targetField.stringValue), target > 0 else {
+            let err = NSAlert()
+            err.messageText = "Invalid reference frequency"
+            err.informativeText = "Source and target must both be positive numbers in Hz."
+            err.alertStyle = .warning
+            err.runModal()
+            return
+        }
+
+        let cents = 1200.0 * log2(target / source)
+        if cents < PitchTuningController.minCents || cents > PitchTuningController.maxCents {
+            let err = NSAlert()
+            err.messageText = "Reference tuning out of range"
+            err.informativeText = String(
+                format: "The requested shift is %.1f cents. Reference Tuning is limited to ±%.0f cents (about ±2 octaves).",
+                cents, PitchTuningController.maxCents
+            )
+            err.alertStyle = .warning
+            err.runModal()
+            return
+        }
+
+        engine.setTuningPreset(.custom(source: source, target: target))
     }
     
     @objc func toggleSweetFade() {

--- a/Sources/NullPlayer/Audio/AudioEngine.swift
+++ b/Sources/NullPlayer/Audio/AudioEngine.swift
@@ -4103,7 +4103,7 @@ class AudioEngine {
         if streamingPlayer == nil {
             streamingPlayer = StreamingAudioPlayer(
                 eqConfiguration: activeEQConfiguration,
-                pitchNode: tuningController.streamingPitchNode
+                pitchNode: tuningController.makeStreamingPitchNode()
             )
             streamingPlayer?.delegate = self
             streamingPlayer?.spectrumNeeded = spectrumNeeded
@@ -4715,7 +4715,10 @@ class AudioEngine {
         // parameter objects pointing at invalid state, which crashes during EQ sync.
         crossfadeStreamingPlayer?.delegate = nil
         crossfadeStreamingPlayer?.stop()
-        crossfadeStreamingPlayer = StreamingAudioPlayer(eqConfiguration: activeEQConfiguration)
+        crossfadeStreamingPlayer = StreamingAudioPlayer(
+            eqConfiguration: activeEQConfiguration,
+            pitchNode: tuningController.makeStreamingPitchNode()
+        )
         // Note: We don't set delegate - we handle state internally during crossfade
         
         // Sync EQ settings to crossfade player

--- a/Sources/NullPlayer/Audio/AudioEngine.swift
+++ b/Sources/NullPlayer/Audio/AudioEngine.swift
@@ -150,7 +150,11 @@ class AudioEngine {
     
     /// Mixer node to combine player nodes (class property for graph rebuilding)
     private let mixerNode = AVAudioMixerNode()
-    
+
+    /// Reference Tuning controller. Owns the pitch-shift nodes used in both the
+    /// local AVAudioEngine graph and the AudioStreaming graph.
+    let tuningController = PitchTuningController()
+
     /// Current audio file (for local files)
     private var audioFile: AVAudioFile?
     
@@ -1009,20 +1013,25 @@ class AudioEngine {
         engine.attach(crossfadePlayerNode)  // For Sweet Fades crossfade
         engine.attach(eqNode)
         engine.attach(mixerNode)  // Class property for graph rebuilding
-        
+        engine.attach(tuningController.localPitchNode)
+
         // Get the standard format from the mixer
         let mixerFormat = engine.mainMixerNode.outputFormat(forBus: 0)
-        
+
         // Signal flow: playerNode ─┐
-        //                          ├─► mixerNode ─► eqNode ─► output
+        //                          ├─► mixerNode ─► localPitchNode ─► eqNode ─► output
         //  crossfadePlayerNode ────┘
-        
+        //
+        // Pitch node sits AFTER the mixer so a single instance handles both player + crossfade,
+        // and the spectrum tap on mixerNode keeps capturing pre-pitch (source) frequencies.
+
         // Connect both players to the mixer
         engine.connect(playerNode, to: mixerNode, format: mixerFormat)
         engine.connect(crossfadePlayerNode, to: mixerNode, format: mixerFormat)
-        
-        // Connect mixer to EQ to output
-        engine.connect(mixerNode, to: eqNode, format: mixerFormat)
+
+        // Connect mixer → pitch → EQ → output
+        engine.connect(mixerNode, to: tuningController.localPitchNode, format: mixerFormat)
+        engine.connect(tuningController.localPitchNode, to: eqNode, format: mixerFormat)
         engine.connect(eqNode, to: engine.mainMixerNode, format: mixerFormat)
         
         // Player nodes stay at unity gain (1.0) - volume applied at mainMixerNode
@@ -1051,6 +1060,29 @@ class AudioEngine {
         // Load sweet fade duration with default of 5.0 seconds
         let savedDuration = UserDefaults.standard.double(forKey: "sweetFadeDuration")
         sweetFadeDuration = savedDuration > 0 ? savedDuration : 5.0
+        tuningController.loadFromDefaults()
+    }
+
+    // MARK: - Reference Tuning
+
+    /// Apply a Reference Tuning preset and persist it. Use `.off` to disable.
+    func setTuningPreset(_ preset: PitchTuningController.Preset, persist: Bool = true) {
+        tuningController.applyPreset(preset)
+        if persist { tuningController.saveToDefaults() }
+    }
+
+    /// Direct cents override (used by --tuning-offset-cents). Source defaults to 440.
+    /// Out-of-range cents are clamped by PitchTuningController.
+    func setTuningOffsetCents(_ cents: Double, persist: Bool = true) {
+        let source = 440.0
+        let target = source * pow(2.0, cents / 1200.0)
+        tuningController.applyPreset(.custom(source: source, target: target))
+        if persist { tuningController.saveToDefaults() }
+    }
+
+    func setTuningEnabled(_ enabled: Bool, persist: Bool = true) {
+        tuningController.setEnabled(enabled)
+        if persist { tuningController.saveToDefaults() }
     }
     
     // MARK: - Audio Configuration Change Handling
@@ -1154,9 +1186,15 @@ class AudioEngine {
     private func reconnectAudioGraph(format mixerFormat: AVAudioFormat) -> Bool {
         var exceptionError: NSError?
         let connected = NPObjCExceptionCatch({
+            // Re-attach the pitch node if a previous rebuild detached it
+            // (AVAudioEngine.attach is idempotent for already-attached nodes — checked via engine.attachedNodes).
+            if !self.engine.attachedNodes.contains(self.tuningController.localPitchNode) {
+                self.engine.attach(self.tuningController.localPitchNode)
+            }
             self.engine.connect(self.playerNode, to: self.mixerNode, format: mixerFormat)
             self.engine.connect(self.crossfadePlayerNode, to: self.mixerNode, format: mixerFormat)
-            self.engine.connect(self.mixerNode, to: self.eqNode, format: mixerFormat)
+            self.engine.connect(self.mixerNode, to: self.tuningController.localPitchNode, format: mixerFormat)
+            self.engine.connect(self.tuningController.localPitchNode, to: self.eqNode, format: mixerFormat)
             self.engine.connect(self.eqNode, to: self.engine.mainMixerNode, format: mixerFormat)
         }, &exceptionError)
 
@@ -1219,6 +1257,9 @@ class AudioEngine {
         engine.disconnectNodeOutput(playerNode)
         engine.disconnectNodeOutput(crossfadePlayerNode)
         engine.disconnectNodeOutput(mixerNode)
+        if engine.attachedNodes.contains(tuningController.localPitchNode) {
+            engine.disconnectNodeOutput(tuningController.localPitchNode)
+        }
         engine.disconnectNodeOutput(eqNode)
         
         // Reconnect all nodes with new format. AVAudioEngine raises NSException
@@ -4060,7 +4101,10 @@ class AudioEngine {
         
         // Create streaming player if needed
         if streamingPlayer == nil {
-            streamingPlayer = StreamingAudioPlayer(eqConfiguration: activeEQConfiguration)
+            streamingPlayer = StreamingAudioPlayer(
+                eqConfiguration: activeEQConfiguration,
+                pitchNode: tuningController.streamingPitchNode
+            )
             streamingPlayer?.delegate = self
             streamingPlayer?.spectrumNeeded = spectrumNeeded
             streamingPlayer?.waveformNeeded = waveformNeeded

--- a/Sources/NullPlayer/Audio/PitchTuningController.swift
+++ b/Sources/NullPlayer/Audio/PitchTuningController.swift
@@ -2,8 +2,8 @@ import AVFoundation
 import Foundation
 
 /// Owns the pitch-shift nodes used for the Reference Tuning feature and
-/// drives both the local AVAudioEngine graph and AudioStreaming's graph
-/// from a single cents offset.
+/// drives the local AVAudioEngine graph plus each AudioStreaming graph from
+/// a single cents offset.
 ///
 /// `AVAudioUnitTimePitch.pitch` is in cents, ±2400 max.
 final class PitchTuningController {
@@ -24,8 +24,19 @@ final class PitchTuningController {
 
     /// Attached to the main AVAudioEngine graph (local files).
     let localPitchNode = AVAudioUnitTimePitch()
-    /// Attached to AudioStreaming's graph (HTTP streaming).
-    let streamingPitchNode = AVAudioUnitTimePitch()
+
+    private final class WeakPitchNode {
+        weak var node: AVAudioUnitTimePitch?
+
+        init(_ node: AVAudioUnitTimePitch) {
+            self.node = node
+        }
+    }
+
+    /// AudioStreaming players each own a private AVAudioEngine, so every player
+    /// needs its own pitch node. Weak storage avoids keeping retired crossfade
+    /// players alive after their wrapper is released.
+    private var streamingPitchNodes: [WeakPitchNode] = []
 
     private(set) var enabled: Bool = false
     private(set) var sourceReferenceHz: Double = 440
@@ -56,6 +67,14 @@ final class PitchTuningController {
         sourceReferenceHz = source
         targetReferenceHz = target
         apply()
+    }
+
+    func makeStreamingPitchNode() -> AVAudioUnitTimePitch {
+        let node = AVAudioUnitTimePitch()
+        streamingPitchNodes.append(WeakPitchNode(node))
+        configure(node, cents: Float(appliedCents))
+        pruneReleasedStreamingNodes()
+        return node
     }
 
     func applyPreset(_ preset: Preset) {
@@ -109,10 +128,22 @@ final class PitchTuningController {
 
     private func apply() {
         let cents = Float(appliedCents)
-        for node in [localPitchNode, streamingPitchNode] {
-            node.bypass = !enabled
-            node.pitch = cents
-            node.rate = 1.0
+        configure(localPitchNode, cents: cents)
+        pruneReleasedStreamingNodes()
+        for entry in streamingPitchNodes {
+            if let node = entry.node {
+                configure(node, cents: cents)
+            }
         }
+    }
+
+    private func configure(_ node: AVAudioUnitTimePitch, cents: Float) {
+        node.bypass = !enabled
+        node.pitch = cents
+        node.rate = 1.0
+    }
+
+    private func pruneReleasedStreamingNodes() {
+        streamingPitchNodes.removeAll { $0.node == nil }
     }
 }

--- a/Sources/NullPlayer/Audio/PitchTuningController.swift
+++ b/Sources/NullPlayer/Audio/PitchTuningController.swift
@@ -1,0 +1,118 @@
+import AVFoundation
+import Foundation
+
+/// Owns the pitch-shift nodes used for the Reference Tuning feature and
+/// drives both the local AVAudioEngine graph and AudioStreaming's graph
+/// from a single cents offset.
+///
+/// `AVAudioUnitTimePitch.pitch` is in cents, ±2400 max.
+final class PitchTuningController {
+
+    enum Preset: Equatable {
+        case off
+        case hz432
+        case hz440
+        case custom(source: Double, target: Double)
+    }
+
+    static let userDefaultsEnabledKey = "referenceTuningEnabled"
+    static let userDefaultsSourceKey = "referenceTuningSourceHz"
+    static let userDefaultsTargetKey = "referenceTuningTargetHz"
+
+    static let minCents: Double = -2400
+    static let maxCents: Double = 2400
+
+    /// Attached to the main AVAudioEngine graph (local files).
+    let localPitchNode = AVAudioUnitTimePitch()
+    /// Attached to AudioStreaming's graph (HTTP streaming).
+    let streamingPitchNode = AVAudioUnitTimePitch()
+
+    private(set) var enabled: Bool = false
+    private(set) var sourceReferenceHz: Double = 440
+    private(set) var targetReferenceHz: Double = 432
+
+    init() {
+        apply()
+    }
+
+    /// Cents offset = 1200 * log2(target / source). Returns 0 if inputs invalid.
+    var offsetCents: Double {
+        guard sourceReferenceHz > 0, targetReferenceHz > 0 else { return 0 }
+        return 1200.0 * log2(targetReferenceHz / sourceReferenceHz)
+    }
+
+    /// Cents offset that will actually be applied to the audio graph (clamped to ±2400 and zeroed when disabled).
+    var appliedCents: Double {
+        guard enabled else { return 0 }
+        return max(Self.minCents, min(Self.maxCents, offsetCents))
+    }
+
+    func setEnabled(_ value: Bool) {
+        enabled = value
+        apply()
+    }
+
+    func setReferences(source: Double, target: Double) {
+        sourceReferenceHz = source
+        targetReferenceHz = target
+        apply()
+    }
+
+    func applyPreset(_ preset: Preset) {
+        switch preset {
+        case .off:
+            enabled = false
+        case .hz432:
+            sourceReferenceHz = 440
+            targetReferenceHz = 432
+            enabled = true
+        case .hz440:
+            sourceReferenceHz = 440
+            targetReferenceHz = 440
+            enabled = true
+        case .custom(let source, let target):
+            sourceReferenceHz = source
+            targetReferenceHz = target
+            enabled = true
+        }
+        apply()
+    }
+
+    /// Active preset (used by menu state). `custom` matches anything that isn't an exact 432/440 match.
+    var currentPreset: Preset {
+        guard enabled else { return .off }
+        if sourceReferenceHz == 440 && targetReferenceHz == 432 { return .hz432 }
+        if sourceReferenceHz == 440 && targetReferenceHz == 440 { return .hz440 }
+        return .custom(source: sourceReferenceHz, target: targetReferenceHz)
+    }
+
+    // MARK: - Persistence
+
+    func loadFromDefaults() {
+        let defaults = UserDefaults.standard
+        enabled = defaults.bool(forKey: Self.userDefaultsEnabledKey)
+        let savedSource = defaults.double(forKey: Self.userDefaultsSourceKey)
+        sourceReferenceHz = savedSource > 0 ? savedSource : 440
+        let savedTarget = defaults.double(forKey: Self.userDefaultsTargetKey)
+        targetReferenceHz = savedTarget > 0 ? savedTarget : 432
+        apply()
+    }
+
+    func saveToDefaults() {
+        let defaults = UserDefaults.standard
+        defaults.set(enabled, forKey: Self.userDefaultsEnabledKey)
+        defaults.set(sourceReferenceHz, forKey: Self.userDefaultsSourceKey)
+        defaults.set(targetReferenceHz, forKey: Self.userDefaultsTargetKey)
+    }
+
+    // MARK: - Apply
+
+    private func apply() {
+        let cents = Float(appliedCents)
+        for node in [localPitchNode, streamingPitchNode] {
+            node.bypass = !enabled
+            node.pitch = cents
+            node.rate = 1.0
+        }
+    }
+}

--- a/Sources/NullPlayer/Audio/StreamingAudioPlayer.swift
+++ b/Sources/NullPlayer/Audio/StreamingAudioPlayer.swift
@@ -31,6 +31,10 @@ class StreamingAudioPlayer {
 
     /// Equalizer attached to the player
     private let eqNode: AVAudioUnitEQ
+
+    /// Optional Reference Tuning pitch node. Retained here because AudioStreaming's
+    /// custom node list is private to its AudioPlayer.
+    private let pitchNode: AVAudioUnitTimePitch?
     
     /// Real-time BPM detector for tempo display
     let bpmDetector = BPMDetector()
@@ -183,6 +187,7 @@ class StreamingAudioPlayer {
         pitchNode: AVAudioUnitTimePitch? = nil
     ) {
         self.eqConfiguration = eqConfiguration
+        self.pitchNode = pitchNode
 
         // Initialize cached normalization mode from UserDefaults
         if let saved = UserDefaults.standard.string(forKey: "spectrumNormalizationMode"),

--- a/Sources/NullPlayer/Audio/StreamingAudioPlayer.swift
+++ b/Sources/NullPlayer/Audio/StreamingAudioPlayer.swift
@@ -178,7 +178,10 @@ class StreamingAudioPlayer {
     
     // MARK: - Initialization
     
-    init(eqConfiguration: EQConfiguration = .forModernUI(UserDefaults.standard.bool(forKey: "modernUIEnabled"))) {
+    init(
+        eqConfiguration: EQConfiguration = .forModernUI(UserDefaults.standard.bool(forKey: "modernUIEnabled")),
+        pitchNode: AVAudioUnitTimePitch? = nil
+    ) {
         self.eqConfiguration = eqConfiguration
 
         // Initialize cached normalization mode from UserDefaults
@@ -186,16 +189,23 @@ class StreamingAudioPlayer {
            let mode = SpectrumNormalizationMode(rawValue: saved) {
             spectrumNormalizationMode = mode
         }
-        
+
         // Create the player
         player = AudioPlayer()
-        
+
         // Create and configure the EQ
         eqNode = AVAudioUnitEQ(numberOfBands: eqConfiguration.bandCount)
         setupEQ()
-        
+
         // Attach EQ to the player's audio graph
         player.attach(node: eqNode)
+
+        // Attach the Reference Tuning pitch node (after EQ, before output) when provided.
+        // AudioStreaming's own private `rateNode` (AVAudioUnitTimePitch) is bypassed while
+        // player.rate == 1.0, so this does not stack two active time-pitch units in normal playback.
+        if let pitchNode {
+            player.attach(node: pitchNode)
+        }
         
         // Set up spectrum analysis
         setupSpectrumAnalyzer()

--- a/Sources/NullPlayer/CLI/CLIDisplay.swift
+++ b/Sources/NullPlayer/CLI/CLIDisplay.swift
@@ -167,6 +167,9 @@ class CLIDisplay {
             --volume <0-100>            Set volume
             --eq <preset>               Set EQ preset
             --output <device>           Set audio output device
+            --tuning <off|Hz>           Reference Tuning target Hz
+            --tuning-source <Hz>        Source reference Hz (default: 440)
+            --tuning-offset-cents <n>   Direct tuning offset in cents
             --cast <device>             Cast to device
             --cast-type <type>          Filter: sonos, chromecast, dlna
             --sonos-rooms <rooms>       Multi-room (comma-separated)

--- a/Sources/NullPlayer/CLI/CLIMode.swift
+++ b/Sources/NullPlayer/CLI/CLIMode.swift
@@ -57,6 +57,11 @@ struct CLIOptions {
     var eq: String?
     var output: String?
 
+    // Reference Tuning
+    var tuning: String?            // "432" | "440" | "off" | numeric Hz
+    var tuningSource: String?      // numeric Hz; default 440
+    var tuningOffsetCents: Double? // direct override in cents
+
     var isQueryMode: Bool {
         listSources || listLibraries || listArtists || listAlbums || listTracks ||
         listGenres || listPlaylists || listStations || listDevices ||
@@ -128,6 +133,14 @@ struct CLIOptions {
                     case "--sonos-rooms": opts.sonosRooms = value
                     case "--eq": opts.eq = value
                     case "--output": opts.output = value
+                    case "--tuning": opts.tuning = value
+                    case "--tuning-source": opts.tuningSource = value
+                    case "--tuning-offset-cents":
+                        guard let d = Double(value) else {
+                            fputs("Error: --tuning-offset-cents requires a number\n", stderr)
+                            exit(1)
+                        }
+                        opts.tuningOffsetCents = d
                     default:
                         fputs("Error: Unknown flag '\(arg)'\n", stderr)
                         exit(1)

--- a/Sources/NullPlayer/CLI/CLIPlayer.swift
+++ b/Sources/NullPlayer/CLI/CLIPlayer.swift
@@ -40,14 +40,18 @@ class CLIPlayer: AudioEngineDelegate {
         // Reference Tuning (session-only — does not write back to UserDefaults).
         // Precedence: --tuning-offset-cents → --tuning off → --tuning <Hz> → persisted state.
         if let cents = options.tuningOffsetCents {
+            guard cents.isFinite else {
+                fputs("Error: --tuning-offset-cents must be a finite number\n", stderr)
+                exit(1)
+            }
             audioEngine.setTuningOffsetCents(cents, persist: false)
         } else if let tuning = options.tuning {
             if tuning.caseInsensitiveCompare("off") == .orderedSame {
                 audioEngine.setTuningEnabled(false, persist: false)
-            } else if let targetHz = Double(tuning), targetHz > 0 {
+            } else if let targetHz = Double(tuning), targetHz.isFinite, targetHz > 0 {
                 let sourceHz: Double
                 if let src = options.tuningSource {
-                    guard let parsed = Double(src), parsed > 0 else {
+                    guard let parsed = Double(src), parsed.isFinite, parsed > 0 else {
                         fputs("Error: --tuning-source requires a positive number (Hz)\n", stderr)
                         exit(1)
                     }

--- a/Sources/NullPlayer/CLI/CLIPlayer.swift
+++ b/Sources/NullPlayer/CLI/CLIPlayer.swift
@@ -37,6 +37,31 @@ class CLIPlayer: AudioEngineDelegate {
             audioEngine.volume = Float(max(0, min(100, vol))) / 100.0
         }
 
+        // Reference Tuning (session-only — does not write back to UserDefaults).
+        // Precedence: --tuning-offset-cents → --tuning off → --tuning <Hz> → persisted state.
+        if let cents = options.tuningOffsetCents {
+            audioEngine.setTuningOffsetCents(cents, persist: false)
+        } else if let tuning = options.tuning {
+            if tuning.caseInsensitiveCompare("off") == .orderedSame {
+                audioEngine.setTuningEnabled(false, persist: false)
+            } else if let targetHz = Double(tuning), targetHz > 0 {
+                let sourceHz: Double
+                if let src = options.tuningSource {
+                    guard let parsed = Double(src), parsed > 0 else {
+                        fputs("Error: --tuning-source requires a positive number (Hz)\n", stderr)
+                        exit(1)
+                    }
+                    sourceHz = parsed
+                } else {
+                    sourceHz = 440
+                }
+                audioEngine.setTuningPreset(.custom(source: sourceHz, target: targetHz), persist: false)
+            } else {
+                fputs("Error: --tuning requires 'off' or a positive number in Hz (e.g. 432)\n", stderr)
+                exit(1)
+            }
+        }
+
         // EQ
         if let eqName = options.eq {
             if let preset = EQPreset.allPresets.first(where: {

--- a/Tests/NullPlayerAppTests/PitchTuningControllerTests.swift
+++ b/Tests/NullPlayerAppTests/PitchTuningControllerTests.swift
@@ -44,4 +44,24 @@ final class PitchTuningControllerTests: XCTestCase {
         c.applyPreset(.off)
         XCTAssertEqual(c.currentPreset, .off)
     }
+
+    func testStreamingPitchNodesAreIndependentAndFollowControllerState() {
+        let c = PitchTuningController()
+        let first = c.makeStreamingPitchNode()
+
+        c.applyPreset(.hz432)
+        XCTAssertFalse(first.bypass)
+        XCTAssertEqual(first.pitch, Float(c.appliedCents), accuracy: 0.001)
+
+        let second = c.makeStreamingPitchNode()
+        XCTAssertFalse(first === second)
+        XCTAssertFalse(second.bypass)
+        XCTAssertEqual(second.pitch, Float(c.appliedCents), accuracy: 0.001)
+
+        c.applyPreset(.off)
+        XCTAssertTrue(first.bypass)
+        XCTAssertTrue(second.bypass)
+        XCTAssertEqual(first.pitch, 0, accuracy: 0.001)
+        XCTAssertEqual(second.pitch, 0, accuracy: 0.001)
+    }
 }

--- a/Tests/NullPlayerAppTests/PitchTuningControllerTests.swift
+++ b/Tests/NullPlayerAppTests/PitchTuningControllerTests.swift
@@ -1,0 +1,47 @@
+import XCTest
+@testable import NullPlayer
+
+final class PitchTuningControllerTests: XCTestCase {
+
+    func testOffsetCents_440to432_isApproximatelyMinus31p766() {
+        let c = PitchTuningController()
+        c.setReferences(source: 440, target: 432)
+        XCTAssertEqual(c.offsetCents, -31.766654, accuracy: 0.001)
+    }
+
+    func testOffsetCents_440to440_isZero() {
+        let c = PitchTuningController()
+        c.setReferences(source: 440, target: 440)
+        XCTAssertEqual(c.offsetCents, 0, accuracy: 1e-9)
+    }
+
+    func testOffsetCents_432to440_isApproximatelyPlus31p766() {
+        let c = PitchTuningController()
+        c.setReferences(source: 432, target: 440)
+        XCTAssertEqual(c.offsetCents, 31.766654, accuracy: 0.001)
+    }
+
+    func testAppliedCentsZeroWhenDisabled() {
+        let c = PitchTuningController()
+        c.applyPreset(.hz432)
+        XCTAssertTrue(c.appliedCents < 0)
+
+        c.setEnabled(false)
+        XCTAssertEqual(c.appliedCents, 0)
+    }
+
+    func testAppliedCentsClampedToRange() {
+        let c = PitchTuningController()
+        // 440 → 10000 Hz is ~5400 cents, well past the +2400 ceiling.
+        c.applyPreset(.custom(source: 440, target: 10000))
+        XCTAssertEqual(c.appliedCents, PitchTuningController.maxCents, accuracy: 1e-9)
+    }
+
+    func testCurrentPresetReflectsExactMatch() {
+        let c = PitchTuningController()
+        c.applyPreset(.hz432)
+        XCTAssertEqual(c.currentPreset, .hz432)
+        c.applyPreset(.off)
+        XCTAssertEqual(c.currentPreset, .off)
+    }
+}

--- a/skills/audio-system/SKILL.md
+++ b/skills/audio-system/SKILL.md
@@ -85,6 +85,7 @@ Main audio controller managing:
 - Gapless playback (optional; local files and same-pipeline streaming)
 - Volume normalization (optional, local files only)
 - Sweet Fades crossfade (both pipelines)
+- Reference Tuning pitch shift (both pipelines via a shared `PitchTuningController`; disabled while casting)
 - Output device selection
 - Delegate notifications for UI updates
 - Separate consumer gating for FFT/spectrum work vs live waveform chunk generation
@@ -213,6 +214,34 @@ func setEQBand(_ band: Int, gain: Float) {
     streamingPlayer?.setEQBand(band, gain: clampedGain)  // Streaming pipeline
 }
 ```
+
+## Reference Tuning
+
+Reference Tuning shifts playback pitch by a precise cents offset to retune content from one reference frequency to another (e.g. A=440 → A=432). It is implemented as a shared `PitchTuningController` (`Audio/PitchTuningController.swift`) that owns two `AVAudioUnitTimePitch` nodes — one inserted into the local `AVAudioEngine` graph, one attached to the AudioStreaming graph — and drives both from the same state.
+
+### Graph placement
+
+Local graph: `playerNode + crossfadePlayerNode → mixerNode → localPitchNode → eqNode → mainMixerNode`. Placing the pitch node **after** the mixer means a single node handles both the primary and crossfade players, and the spectrum tap on `mixerNode` keeps capturing pre-pitch (source) frequencies — the analyzer shows the source content's spectrum, not the shifted output. This is a deliberate trade-off; moving the tap onto `localPitchNode` would invert it.
+
+Streaming graph: `streamingPitchNode` is attached via `AudioStreaming.AudioPlayer.attach(node:)` after the EQ node. AudioStreaming's own private `rateNode` (also an `AVAudioUnitTimePitch`, used for `player.rate`) is bypassed while `player.rate == 1.0`, so this does not stack two active time-pitch units in normal playback. If variable-rate playback is ever added, both nodes would be active — at which point driving the library's `rateNode.pitch` directly may become preferable.
+
+### Math and clamp
+
+Cents offset = `1200 · log2(target / source)` (e.g. 440 → 432 ≈ −31.766 cents). `AVAudioUnitTimePitch.pitch` is in cents, ±2400. The controller clamps `appliedCents` to that range; the Custom… dialog validates input at entry time and rejects out-of-range frequencies rather than silently clamping.
+
+### Persistence and overrides
+
+UserDefaults keys (mirrors EQ/volume normalization pattern):
+
+- `referenceTuningEnabled: Bool`
+- `referenceTuningSourceHz: Double` (default 440)
+- `referenceTuningTargetHz: Double` (default 432)
+
+CLI flags (`--tuning`, `--tuning-source`, `--tuning-offset-cents`) provide session-only overrides — they do not write back to UserDefaults, matching `--volume` and `--eq`.
+
+### Casting
+
+Casting paths (Sonos / Chromecast / DLNA) hand the remote renderer a stream URL with no local AVFoundation graph to insert into, so Reference Tuning is intentionally unavailable while casting. The menu greys out with a "Not available while casting" tooltip; `engine.isAnyCastingActive` is the gate.
 
 ## Spectrum Analyzer
 

--- a/skills/audio-system/SKILL.md
+++ b/skills/audio-system/SKILL.md
@@ -217,13 +217,13 @@ func setEQBand(_ band: Int, gain: Float) {
 
 ## Reference Tuning
 
-Reference Tuning shifts playback pitch by a precise cents offset to retune content from one reference frequency to another (e.g. A=440 → A=432). It is implemented as a shared `PitchTuningController` (`Audio/PitchTuningController.swift`) that owns two `AVAudioUnitTimePitch` nodes — one inserted into the local `AVAudioEngine` graph, one attached to the AudioStreaming graph — and drives both from the same state.
+Reference Tuning shifts playback pitch by a precise cents offset to retune content from one reference frequency to another (e.g. A=440 → A=432). It is implemented as a shared `PitchTuningController` (`Audio/PitchTuningController.swift`) that owns the local `AVAudioUnitTimePitch` node and creates one configured streaming pitch node per AudioStreaming player. This keeps the primary and Sweet Fades crossfade streaming graphs independent while driving all nodes from the same state.
 
 ### Graph placement
 
 Local graph: `playerNode + crossfadePlayerNode → mixerNode → localPitchNode → eqNode → mainMixerNode`. Placing the pitch node **after** the mixer means a single node handles both the primary and crossfade players, and the spectrum tap on `mixerNode` keeps capturing pre-pitch (source) frequencies — the analyzer shows the source content's spectrum, not the shifted output. This is a deliberate trade-off; moving the tap onto `localPitchNode` would invert it.
 
-Streaming graph: `streamingPitchNode` is attached via `AudioStreaming.AudioPlayer.attach(node:)` after the EQ node. AudioStreaming's own private `rateNode` (also an `AVAudioUnitTimePitch`, used for `player.rate`) is bypassed while `player.rate == 1.0`, so this does not stack two active time-pitch units in normal playback. If variable-rate playback is ever added, both nodes would be active — at which point driving the library's `rateNode.pitch` directly may become preferable.
+Streaming graph: each `StreamingAudioPlayer` receives its own node from `PitchTuningController.makeStreamingPitchNode()` and attaches it via `AudioStreaming.AudioPlayer.attach(node:)` after the EQ node. AudioStreaming's own private `rateNode` (also an `AVAudioUnitTimePitch`, used for `player.rate`) is bypassed while `player.rate == 1.0`, so this does not stack two active time-pitch units in normal playback. If variable-rate playback is ever added, both nodes would be active — at which point driving the library's `rateNode.pitch` directly may become preferable.
 
 ### Math and clamp
 

--- a/skills/cli/SKILL.md
+++ b/skills/cli/SKILL.md
@@ -161,6 +161,9 @@ Avoid vague phrasing like "CLI browser" when the real value is orchestration acr
 | `--sonos-rooms <rooms>` | string | Comma-separated Sonos room names for multi-room |
 | `--eq <preset>` | string | EQ preset name (case-insensitive; from `EQPreset.allPresets`) |
 | `--output <device>` | string | Audio output device name (case-insensitive) |
+| `--tuning <off\|Hz>` | string | Reference Tuning: `off`, or target reference frequency in Hz (e.g. `432`). Enables pitch shift for local playback only — not casting. Session-only override. |
+| `--tuning-source <Hz>` | string | Source reference frequency in Hz (default `440`). Used with `--tuning <Hz>`. |
+| `--tuning-offset-cents <n>` | float | Direct cents offset (±2400). Wins over `--tuning`/`--tuning-source`. Session-only. |
 
 ## Multi-Source / Multi-Output Framing
 

--- a/skills/cli/SKILL.md
+++ b/skills/cli/SKILL.md
@@ -161,7 +161,7 @@ Avoid vague phrasing like "CLI browser" when the real value is orchestration acr
 | `--sonos-rooms <rooms>` | string | Comma-separated Sonos room names for multi-room |
 | `--eq <preset>` | string | EQ preset name (case-insensitive; from `EQPreset.allPresets`) |
 | `--output <device>` | string | Audio output device name (case-insensitive) |
-| `--tuning <off\|Hz>` | string | Reference Tuning: `off`, or target reference frequency in Hz (e.g. `432`). Enables pitch shift for local playback only — not casting. Session-only override. |
+| `--tuning <off\|Hz>` | string | Reference Tuning: `off`, or target reference frequency in Hz (e.g. `432`). Enables pitch shift for local output only (local files and HTTP streams) — not casting. Session-only override. |
 | `--tuning-source <Hz>` | string | Source reference frequency in Hz (default `440`). Used with `--tuning <Hz>`. |
 | `--tuning-offset-cents <n>` | float | Direct cents offset (±2400). Wins over `--tuning`/`--tuning-source`. Session-only. |
 

--- a/skills/user-guide/SKILL.md
+++ b/skills/user-guide/SKILL.md
@@ -219,6 +219,7 @@ Import discovery is now unified across classic + modern entry points (main windo
 - **Gapless Playback**: Seamless track transitions (local files)
 - **Sweet Fades**: Crossfade between tracks (1-10s duration)
 - **Volume Normalization**: Consistent loudness (-14dB target)
+- **Reference Tuning**: Pitch-shift playback to a different reference frequency. Presets for Off, 432 Hz, 440 Hz, and a Custom… dialog (source/target Hz, ±2400 cents). Applies to local files and HTTP streams; unavailable while casting because remote renderers have no local audio graph to insert the pitch shifter into. Persists across launches; the CLI also accepts `--tuning`, `--tuning-source`, and `--tuning-offset-cents` as session-only overrides.
 - **Remember State on Quit**: `AppStateManager.restorePlaylistState` restores playlist contents and ordering; it intentionally does not restore the selected track, seek position, or playing state
 
 ### Sleep Timer


### PR DESCRIPTION
## Summary
- New **Reference Tuning** feature shifts playback pitch by a precise cents offset (e.g. retune A=440 content to A=432). Exposed in **Playback > Options > Reference Tuning** with Off / 432 Hz / 440 Hz / Custom… presets, persisted in UserDefaults.
- Single `PitchTuningController` (`Sources/NullPlayer/Audio/PitchTuningController.swift`) owns two `AVAudioUnitTimePitch` nodes — one inserted into the local AVAudioEngine graph (mixer → pitch → EQ), one attached to AudioStreaming via `player.attach(node:)`. Both pipelines apply the same shift; the spectrum tap stays on `mixerNode` so the analyzer shows source (pre-pitch) frequencies.
- CLI gets `--tuning <off|Hz>`, `--tuning-source <Hz>`, `--tuning-offset-cents <n>` as session-only overrides (precedence: cents > off > Hz > persisted).
- Casting paths (Sonos / Chromecast / DLNA) hand a stream URL to a remote renderer with no local audio graph, so the menu greys out with a "Not available while casting" tooltip.

## Notes on the streaming graph
AudioStreaming's library owns a private `AVAudioUnitTimePitch` (`rateNode`) used for `player.rate`, bypassed at rate==1.0. The new node is cascaded after the EQ; in normal playback only one time-pitch unit is actually processing. If variable-rate playback is ever added, this should be revisited.

## Test plan
- [x] `swift build` succeeds
- [x] `swift test --filter PitchTuningControllerTests` — 6 tests pass (cents math for 440↔432, zero/disable behavior, ±2400 clamp, preset matching)
- [ ] Manual: play a sustained-tone local file; toggle Reference Tuning → 432 Hz; pitch drops audibly (~−31.77 cents). Toggle Off mid-playback; pitch returns without interruption (graph stays connected, only `bypass` changes).
- [ ] Manual: Custom… with source=440, target=415.30 (A♭) → ≈ −100 cents. Invalid input shows an error rather than silently clamping.
- [ ] Manual: with tuning enabled, play a Plex/Subsonic/Jellyfin/Emby stream and a local file back-to-back — both pitch-shifted equally.
- [ ] Manual: start a Sonos or Chromecast cast — Reference Tuning menu is disabled with tooltip.
- [ ] Quit & relaunch — setting persists.
- [ ] CLI: `--tuning 432`, `--tuning-offset-cents -31.77`, `--tuning off`, `--tuning-offset-cents foo` (exits 1).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added Reference Tuning playback option (Off, 432 Hz, 440 Hz, Custom) with a Custom dialog for source/target Hz
  * Applies to local files and HTTP streams; spectrum analyzer continues to show source (pre-tune) frequencies
  * Settings persist across launches; feature disabled while casting
  * Session-only CLI overrides for tuning, source Hz, and cent-offset

* **Documentation**
  * Audio system, CLI, and user guide updated for Reference Tuning

* **Tests**
  * Added/expanded unit tests covering tuning behavior and streaming nodes

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/ad-repo/nullplayer/pull/231?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->