### PR TITLE
Add playback speed control

### DIFF
--- a/Sources/NullPlayer/App/ContextMenuBuilder.swift
+++ b/Sources/NullPlayer/App/ContextMenuBuilder.swift
@@ -289,6 +289,53 @@ class ContextMenuBuilder {
         return menu
     }
 
+    /// Builds the Playback Speed submenu.
+    static func buildPlaybackSpeedMenu() -> NSMenu {
+        let menu = NSMenu()
+        menu.autoenablesItems = false
+
+        let current = WindowManager.shared.audioEngine.playbackSpeed
+
+        func isCurrent(_ value: Float) -> Bool {
+            abs(current - value) < 0.001
+        }
+
+        func makeItem(_ title: String, _ action: Selector, isOn: Bool) -> NSMenuItem {
+            let item = NSMenuItem(title: title, action: action, keyEquivalent: "")
+            item.target = MenuActions.shared
+            item.state = isOn ? .on : .off
+            return item
+        }
+
+        let presets: [(title: String, value: Float, action: Selector)] = [
+            ("0.25×", 0.25, #selector(MenuActions.setPlaybackSpeedQuarter)),
+            ("0.5×", 0.5, #selector(MenuActions.setPlaybackSpeedHalf)),
+            ("0.75×", 0.75, #selector(MenuActions.setPlaybackSpeed075)),
+            ("1.0× (Normal)", 1.0, #selector(MenuActions.setPlaybackSpeedNormal)),
+            ("1.25×", 1.25, #selector(MenuActions.setPlaybackSpeed125)),
+            ("1.5×", 1.5, #selector(MenuActions.setPlaybackSpeed150)),
+            ("1.75×", 1.75, #selector(MenuActions.setPlaybackSpeed175)),
+            ("2.0×", 2.0, #selector(MenuActions.setPlaybackSpeedDouble)),
+            ("2.5×", 2.5, #selector(MenuActions.setPlaybackSpeed250)),
+            ("3.0×", 3.0, #selector(MenuActions.setPlaybackSpeed300)),
+            ("4.0×", 4.0, #selector(MenuActions.setPlaybackSpeed400))
+        ]
+
+        var matchesPreset = false
+        for preset in presets {
+            let isOn = isCurrent(preset.value)
+            matchesPreset = matchesPreset || isOn
+            menu.addItem(makeItem(preset.title, preset.action, isOn: isOn))
+        }
+
+        menu.addItem(NSMenuItem.separator())
+
+        let customTitle = matchesPreset ? "Custom…" : String(format: "Custom… (%.2f×)", current)
+        menu.addItem(makeItem(customTitle, #selector(MenuActions.setPlaybackSpeedCustom), isOn: !matchesPreset))
+
+        return menu
+    }
+
     /// Builds the top-level "Visuals" menu content for the macOS menu bar.
     static func buildMenuBarVisualsMenu() -> NSMenu {
         let menu = NSMenu()
@@ -860,6 +907,15 @@ class ContextMenuBuilder {
             tuningRoot.toolTip = "Not available while casting"
         }
         optionsMenu.addItem(tuningRoot)
+
+        // Playback Speed submenu
+        let speedRoot = NSMenuItem(title: "Playback Speed", action: nil, keyEquivalent: "")
+        speedRoot.submenu = buildPlaybackSpeedMenu()
+        if engine.isAnyCastingActive {
+            speedRoot.isEnabled = false
+            speedRoot.toolTip = "Not available while casting"
+        }
+        optionsMenu.addItem(speedRoot)
 
         optionsMenu.addItem(NSMenuItem.separator())
 
@@ -3836,6 +3892,106 @@ class MenuActions: NSObject {
         }
 
         engine.setTuningPreset(.custom(source: source, target: target))
+    }
+
+    // MARK: - Playback Speed
+
+    @objc func setPlaybackSpeedQuarter() {
+        WindowManager.shared.audioEngine.setPlaybackSpeed(0.25)
+    }
+
+    @objc func setPlaybackSpeedHalf() {
+        WindowManager.shared.audioEngine.setPlaybackSpeed(0.5)
+    }
+
+    @objc func setPlaybackSpeed075() {
+        WindowManager.shared.audioEngine.setPlaybackSpeed(0.75)
+    }
+
+    @objc func setPlaybackSpeedNormal() {
+        WindowManager.shared.audioEngine.setPlaybackSpeed(1.0)
+    }
+
+    @objc func setPlaybackSpeed125() {
+        WindowManager.shared.audioEngine.setPlaybackSpeed(1.25)
+    }
+
+    @objc func setPlaybackSpeed150() {
+        WindowManager.shared.audioEngine.setPlaybackSpeed(1.5)
+    }
+
+    @objc func setPlaybackSpeed175() {
+        WindowManager.shared.audioEngine.setPlaybackSpeed(1.75)
+    }
+
+    @objc func setPlaybackSpeedDouble() {
+        WindowManager.shared.audioEngine.setPlaybackSpeed(2.0)
+    }
+
+    @objc func setPlaybackSpeed250() {
+        WindowManager.shared.audioEngine.setPlaybackSpeed(2.5)
+    }
+
+    @objc func setPlaybackSpeed300() {
+        WindowManager.shared.audioEngine.setPlaybackSpeed(3.0)
+    }
+
+    @objc func setPlaybackSpeed400() {
+        WindowManager.shared.audioEngine.setPlaybackSpeed(4.0)
+    }
+
+    @objc func setPlaybackSpeedCustom() {
+        let engine = WindowManager.shared.audioEngine
+
+        let alert = NSAlert()
+        alert.messageText = "Custom Playback Speed"
+        alert.informativeText = String(
+            format: "Enter a playback speed from %.2g× to %.2g×.",
+            PitchTuningController.minRate,
+            PitchTuningController.maxRate
+        )
+        alert.alertStyle = .informational
+        alert.addButton(withTitle: "Apply")
+        alert.addButton(withTitle: "Cancel")
+
+        let stack = NSStackView()
+        stack.orientation = .horizontal
+        stack.spacing = 8
+        stack.translatesAutoresizingMaskIntoConstraints = false
+
+        let label = NSTextField(labelWithString: "Speed:")
+        label.alignment = .right
+        label.widthAnchor.constraint(equalToConstant: 60).isActive = true
+        let field = NSTextField(string: String(format: "%g", Double(engine.playbackSpeed)))
+        field.widthAnchor.constraint(equalToConstant: 100).isActive = true
+        stack.addArrangedSubview(label)
+        stack.addArrangedSubview(field)
+
+        let accessory = NSView(frame: NSRect(x: 0, y: 0, width: 180, height: 24))
+        stack.frame = accessory.bounds
+        stack.autoresizingMask = [.width, .height]
+        accessory.addSubview(stack)
+        alert.accessoryView = accessory
+
+        guard alert.runModal() == .alertFirstButtonReturn else { return }
+
+        guard let speed = Float(field.stringValue),
+              speed.isFinite,
+              speed >= PitchTuningController.minRate,
+              speed <= PitchTuningController.maxRate else {
+            let err = NSAlert()
+            err.messageText = "Invalid playback speed"
+            err.informativeText = String(
+                format: "Playback speed must be a number from %.2g× to %.2g×.",
+                PitchTuningController.minRate,
+                PitchTuningController.maxRate
+            )
+            err.alertStyle = .warning
+            err.runModal()
+            return
+        }
+
+        engine.setPlaybackSpeed(speed)
     }
     
     @objc func toggleSweetFade() {

--- a/Sources/NullPlayer/Audio/AudioEngine.swift
+++ b/Sources/NullPlayer/Audio/AudioEngine.swift
@@ -102,10 +102,11 @@ class AudioEngine {
     static func freezeLocalPlaybackClockForSleep(
         currentTime: TimeInterval,
         playbackStartDate: Date,
+        playbackRate: Float = 1.0,
         now: Date
     ) -> LocalPlaybackSleepClockState {
         LocalPlaybackSleepClockState(
-            currentTime: currentTime + now.timeIntervalSince(playbackStartDate),
+            currentTime: currentTime + now.timeIntervalSince(playbackStartDate) * TimeInterval(playbackRate),
             playbackStartDate: nil,
             suspendedForSleep: true
         )
@@ -972,6 +973,7 @@ class AudioEngine {
         let clockState = Self.freezeLocalPlaybackClockForSleep(
             currentTime: _currentTime,
             playbackStartDate: startDate,
+            playbackRate: playbackSpeed,
             now: Date()
         )
         _currentTime = clockState.currentTime
@@ -1083,6 +1085,29 @@ class AudioEngine {
     func setTuningEnabled(_ enabled: Bool, persist: Bool = true) {
         tuningController.setEnabled(enabled)
         if persist { tuningController.saveToDefaults() }
+    }
+
+    // MARK: - Playback Speed
+
+    var playbackSpeed: Float {
+        tuningController.rate
+    }
+
+    /// Apply tempo-preserving playback speed and persist it.
+    func setPlaybackSpeed(_ value: Float, persist: Bool = true) {
+        if !isStreamingPlayback, !isAnyCastingActive, state == .playing {
+            _currentTime = currentTime
+            lastReportedTime = _currentTime
+            playbackStartDate = Date()
+        }
+
+        tuningController.setRate(value)
+        if persist { tuningController.saveToDefaults() }
+
+        let rate = tuningController.rate
+        streamingPlayer?.rate = rate
+        crossfadeStreamingPlayer?.rate = rate
+        notifyPlaybackOptionsChanged()
     }
     
     // MARK: - Audio Configuration Change Handling
@@ -1960,9 +1985,8 @@ class AudioEngine {
     func pauseLocalOnly() {
         // Save current position before pausing
         let pausePosition = currentTime
-        if let startDate = playbackStartDate {
-            _currentTime += Date().timeIntervalSince(startDate)
-        }
+        _currentTime = pausePosition
+        lastReportedTime = pausePosition
         playbackStartDate = nil
         suspendedLocalPlaybackClockForSleep = false
         
@@ -2079,9 +2103,8 @@ class AudioEngine {
         
         // Save current position before stopping
         let currentPosition = currentTime
-        if let startDate = playbackStartDate {
-            _currentTime += Date().timeIntervalSince(startDate)
-        }
+        _currentTime = currentPosition
+        lastReportedTime = currentPosition
         playbackStartDate = nil
         suspendedLocalPlaybackClockForSleep = false
 
@@ -2495,7 +2518,7 @@ class AudioEngine {
             }
             
             let elapsed = Date().timeIntervalSince(startDate)
-            return _currentTime + elapsed
+            return _currentTime + elapsed * TimeInterval(playbackSpeed)
         }
     }
     
@@ -4105,6 +4128,7 @@ class AudioEngine {
                 eqConfiguration: activeEQConfiguration,
                 pitchNode: tuningController.makeStreamingPitchNode()
             )
+            streamingPlayer?.rate = tuningController.rate
             streamingPlayer?.delegate = self
             streamingPlayer?.spectrumNeeded = spectrumNeeded
             streamingPlayer?.waveformNeeded = waveformNeeded
@@ -4719,6 +4743,7 @@ class AudioEngine {
             eqConfiguration: activeEQConfiguration,
             pitchNode: tuningController.makeStreamingPitchNode()
         )
+        crossfadeStreamingPlayer?.rate = tuningController.rate
         // Note: We don't set delegate - we handle state internally during crossfade
         
         // Sync EQ settings to crossfade player

--- a/Sources/NullPlayer/Audio/PitchTuningController.swift
+++ b/Sources/NullPlayer/Audio/PitchTuningController.swift
@@ -18,9 +18,12 @@ final class PitchTuningController {
     static let userDefaultsEnabledKey = "referenceTuningEnabled"
     static let userDefaultsSourceKey = "referenceTuningSourceHz"
     static let userDefaultsTargetKey = "referenceTuningTargetHz"
+    static let userDefaultsRateKey = "playbackSpeedRate"
 
     static let minCents: Double = -2400
     static let maxCents: Double = 2400
+    static let minRate: Float = 0.25
+    static let maxRate: Float = 4.0
 
     /// Attached to the main AVAudioEngine graph (local files).
     let localPitchNode = AVAudioUnitTimePitch()
@@ -41,6 +44,7 @@ final class PitchTuningController {
     private(set) var enabled: Bool = false
     private(set) var sourceReferenceHz: Double = 440
     private(set) var targetReferenceHz: Double = 432
+    private(set) var rate: Float = 1.0
 
     init() {
         apply()
@@ -69,10 +73,15 @@ final class PitchTuningController {
         apply()
     }
 
+    func setRate(_ value: Float) {
+        rate = Self.clampedRate(value)
+        apply()
+    }
+
     func makeStreamingPitchNode() -> AVAudioUnitTimePitch {
         let node = AVAudioUnitTimePitch()
         streamingPitchNodes.append(WeakPitchNode(node))
-        configure(node, cents: Float(appliedCents))
+        configureStreaming(node, cents: Float(appliedCents))
         pruneReleasedStreamingNodes()
         return node
     }
@@ -114,6 +123,9 @@ final class PitchTuningController {
         sourceReferenceHz = savedSource > 0 ? savedSource : 440
         let savedTarget = defaults.double(forKey: Self.userDefaultsTargetKey)
         targetReferenceHz = savedTarget > 0 ? savedTarget : 432
+        // UserDefaults.float(forKey:) returns 0 for missing keys, so 0 means "use default".
+        let savedRate = defaults.float(forKey: Self.userDefaultsRateKey)
+        rate = savedRate > 0 ? Self.clampedRate(savedRate) : 1.0
         apply()
     }
 
@@ -122,28 +134,39 @@ final class PitchTuningController {
         defaults.set(enabled, forKey: Self.userDefaultsEnabledKey)
         defaults.set(sourceReferenceHz, forKey: Self.userDefaultsSourceKey)
         defaults.set(targetReferenceHz, forKey: Self.userDefaultsTargetKey)
+        defaults.set(rate, forKey: Self.userDefaultsRateKey)
     }
 
     // MARK: - Apply
 
     private func apply() {
         let cents = Float(appliedCents)
-        configure(localPitchNode, cents: cents)
+        configureLocal(localPitchNode, cents: cents)
         pruneReleasedStreamingNodes()
         for entry in streamingPitchNodes {
             if let node = entry.node {
-                configure(node, cents: cents)
+                configureStreaming(node, cents: cents)
             }
         }
     }
 
-    private func configure(_ node: AVAudioUnitTimePitch, cents: Float) {
-        node.bypass = !enabled
+    private func configureLocal(_ node: AVAudioUnitTimePitch, cents: Float) {
+        node.pitch = cents
+        node.rate = rate
+        node.bypass = (!enabled || cents.isZero) && rate == 1.0
+    }
+
+    private func configureStreaming(_ node: AVAudioUnitTimePitch, cents: Float) {
         node.pitch = cents
         node.rate = 1.0
+        node.bypass = !enabled || cents.isZero
     }
 
     private func pruneReleasedStreamingNodes() {
         streamingPitchNodes.removeAll { $0.node == nil }
+    }
+
+    private static func clampedRate(_ value: Float) -> Float {
+        max(minRate, min(maxRate, value))
     }
 }

--- a/Tests/NullPlayerAppTests/PitchTuningControllerTests.swift
+++ b/Tests/NullPlayerAppTests/PitchTuningControllerTests.swift
@@ -45,6 +45,42 @@ final class PitchTuningControllerTests: XCTestCase {
         XCTAssertEqual(c.currentPreset, .off)
     }
 
+    func testPlaybackRateClampsAndDrivesLocalPitchNode() {
+        let c = PitchTuningController()
+
+        c.setRate(1.5)
+        XCTAssertEqual(c.rate, 1.5, accuracy: 0.001)
+        XCTAssertEqual(c.localPitchNode.rate, 1.5, accuracy: 0.001)
+        XCTAssertFalse(c.localPitchNode.bypass)
+
+        c.setRate(8.0)
+        XCTAssertEqual(c.rate, 4.0, accuracy: 0.001)
+        XCTAssertEqual(c.localPitchNode.rate, 4.0, accuracy: 0.001)
+
+        c.setRate(0.1)
+        XCTAssertEqual(c.rate, 0.25, accuracy: 0.001)
+        XCTAssertEqual(c.localPitchNode.rate, 0.25, accuracy: 0.001)
+
+        c.setRate(1.0)
+        XCTAssertTrue(c.localPitchNode.bypass)
+    }
+
+    func testStreamingPitchNodeKeepsNeutralRateWhenPlaybackRateChanges() {
+        let c = PitchTuningController()
+        c.setRate(1.5)
+
+        let stream = c.makeStreamingPitchNode()
+        XCTAssertEqual(stream.rate, 1.0, accuracy: 0.001)
+        XCTAssertTrue(stream.bypass)
+
+        c.applyPreset(.hz432)
+        XCTAssertEqual(stream.rate, 1.0, accuracy: 0.001)
+        XCTAssertFalse(stream.bypass)
+
+        c.setRate(0.75)
+        XCTAssertEqual(stream.rate, 1.0, accuracy: 0.001)
+    }
+
     func testStreamingPitchNodesAreIndependentAndFollowControllerState() {
         let c = PitchTuningController()
         let first = c.makeStreamingPitchNode()

--- a/skills/audio-system/SKILL.md
+++ b/skills/audio-system/SKILL.md
@@ -86,6 +86,7 @@ Main audio controller managing:
 - Volume normalization (optional, local files only)
 - Sweet Fades crossfade (both pipelines)
 - Reference Tuning pitch shift (both pipelines via a shared `PitchTuningController`; disabled while casting)
+- Playback Speed tempo control (`0.25×...4.0×`; local files and HTTP streams; disabled while casting)
 - Output device selection
 - Delegate notifications for UI updates
 - Separate consumer gating for FFT/spectrum work vs live waveform chunk generation
@@ -215,19 +216,25 @@ func setEQBand(_ band: Int, gain: Float) {
 }
 ```
 
-## Reference Tuning
+## Reference Tuning and Playback Speed
 
 Reference Tuning shifts playback pitch by a precise cents offset to retune content from one reference frequency to another (e.g. A=440 → A=432). It is implemented as a shared `PitchTuningController` (`Audio/PitchTuningController.swift`) that owns the local `AVAudioUnitTimePitch` node and creates one configured streaming pitch node per AudioStreaming player. This keeps the primary and Sweet Fades crossfade streaming graphs independent while driving all nodes from the same state.
+
+Playback Speed is also owned by `PitchTuningController`, but it is a tempo/time-stretch control, not a pitch shift. The supported user range is `0.25×...4.0×`; `1.0×` is normal speed. Pitch is preserved while tempo changes.
 
 ### Graph placement
 
 Local graph: `playerNode + crossfadePlayerNode → mixerNode → localPitchNode → eqNode → mainMixerNode`. Placing the pitch node **after** the mixer means a single node handles both the primary and crossfade players, and the spectrum tap on `mixerNode` keeps capturing pre-pitch (source) frequencies — the analyzer shows the source content's spectrum, not the shifted output. This is a deliberate trade-off; moving the tap onto `localPitchNode` would invert it.
 
-Streaming graph: each `StreamingAudioPlayer` receives its own node from `PitchTuningController.makeStreamingPitchNode()` and attaches it via `AudioStreaming.AudioPlayer.attach(node:)` after the EQ node. AudioStreaming's own private `rateNode` (also an `AVAudioUnitTimePitch`, used for `player.rate`) is bypassed while `player.rate == 1.0`, so this does not stack two active time-pitch units in normal playback. If variable-rate playback is ever added, both nodes would be active — at which point driving the library's `rateNode.pitch` directly may become preferable.
+Streaming graph: each `StreamingAudioPlayer` receives its own node from `PitchTuningController.makeStreamingPitchNode()` and attaches it via `AudioStreaming.AudioPlayer.attach(node:)` after the EQ node. These streaming pitch nodes only carry Reference Tuning cents: they always keep `node.rate = 1.0`. Streaming tempo is applied through AudioStreaming's own private `rateNode` via `StreamingAudioPlayer.rate` / `AudioPlayer.rate`. This avoids double-applying rate when Reference Tuning and Playback Speed are used together.
+
+When `AudioEngine.setPlaybackSpeed(_:)` changes the rate, it updates the controller, persists the preference, applies the rate to the active primary streaming player, and applies it to the crossfade streaming player if one exists. Newly-created streaming players must immediately inherit `tuningController.rate`.
 
 ### Math and clamp
 
 Cents offset = `1200 · log2(target / source)` (e.g. 440 → 432 ≈ −31.766 cents). `AVAudioUnitTimePitch.pitch` is in cents, ±2400. The controller clamps `appliedCents` to that range; the Custom… dialog validates input at entry time and rejects out-of-range frequencies rather than silently clamping.
+
+Playback Speed clamps via `PitchTuningController.minRate` / `maxRate` (`0.25...4.0`). Local file time display is wall-clock based, so local `currentTime` must multiply elapsed wall time by `playbackSpeed`; streaming time comes from AudioStreaming's own player progress.
 
 ### Persistence and overrides
 
@@ -236,12 +243,13 @@ UserDefaults keys (mirrors EQ/volume normalization pattern):
 - `referenceTuningEnabled: Bool`
 - `referenceTuningSourceHz: Double` (default 440)
 - `referenceTuningTargetHz: Double` (default 432)
+- `playbackSpeedRate: Float` (default 1.0; `UserDefaults.float(forKey:) == 0` means missing/default)
 
 CLI flags (`--tuning`, `--tuning-source`, `--tuning-offset-cents`) provide session-only overrides — they do not write back to UserDefaults, matching `--volume` and `--eq`.
 
 ### Casting
 
-Casting paths (Sonos / Chromecast / DLNA) hand the remote renderer a stream URL with no local AVFoundation graph to insert into, so Reference Tuning is intentionally unavailable while casting. The menu greys out with a "Not available while casting" tooltip; `engine.isAnyCastingActive` is the gate.
+Casting paths (Sonos / Chromecast / DLNA) hand the remote renderer a stream URL with no local AVFoundation graph to insert into, so Reference Tuning and Playback Speed are intentionally unavailable while casting. Their menus grey out with a "Not available while casting" tooltip; `engine.isAnyCastingActive` is the gate. The persisted speed remains stored and resumes for local/HTTP playback after casting ends.
 
 ## Spectrum Analyzer
 

--- a/skills/user-guide/SKILL.md
+++ b/skills/user-guide/SKILL.md
@@ -220,6 +220,7 @@ Import discovery is now unified across classic + modern entry points (main windo
 - **Sweet Fades**: Crossfade between tracks (1-10s duration)
 - **Volume Normalization**: Consistent loudness (-14dB target)
 - **Reference Tuning**: Pitch-shift playback to a different reference frequency. Presets for Off, 432 Hz, 440 Hz, and a Custom… dialog (source/target Hz, ±2400 cents). Applies to local files and HTTP streams; unavailable while casting because remote renderers have no local audio graph to insert the pitch shifter into. Persists across launches; the CLI also accepts `--tuning`, `--tuning-source`, and `--tuning-offset-cents` as session-only overrides.
+- **Playback Speed**: Tempo-preserving speed control from `0.25×` to `4.0×`, with presets plus Custom…. Applies to local files and HTTP streams; unavailable while casting. Persists across launches.
 - **Remember State on Quit**: `AppStateManager.restorePlaylistState` restores playlist contents and ordering; it intentionally does not restore the selected track, seek position, or playing state
 
 ### Sleep Timer


### PR DESCRIPTION
## Summary
- add persisted playback speed control with 0.25x-4.0x presets and custom input
- apply tempo changes through the local time-pitch node and AudioStreaming rate without double-applying streaming speed
- document playback speed behavior in audio/user skills and add regression tests

## Tests
- swift test

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added playback speed control with preset options (0.25× to 4.0×) and a custom speed entry dialog.
  * Supports both local files and HTTP streams.
  * Speed setting persists across app launches.
  * Feature is disabled while audio casting is active.

* **Documentation**
  * Updated user guide and technical documentation to describe the Playback Speed feature.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/ad-repo/nullplayer/pull/232?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->