### PR TITLE
Document playback speed and wrap snow accumulators

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@
 ### New Features
 
 - **Reference Tuning** — Playback > Options > **Reference Tuning** can pitch-shift all local playback to a different reference frequency (e.g. retune A=440 content to A=432). Presets for Off, 432 Hz, 440 Hz, and a Custom… dialog accepting source/target Hz are exposed in the menu; settings persist across launches. Applies to local files and HTTP streaming (Plex/Subsonic/Jellyfin/Emby/radio) via `AVAudioUnitTimePitch` nodes inserted into the active local or streaming graph; the spectrum analyzer continues to display source (pre-pitch) frequencies. Not available while casting (Sonos / Chromecast / DLNA) because the remote renderer receives the stream URL directly with no local audio graph to insert the pitch shifter into. CLI flags `--tuning <off|Hz>`, `--tuning-source <Hz>`, and `--tuning-offset-cents <n>` provide session-only overrides.
+- **Playback Speed** — Playback > Options > **Playback Speed** can adjust tempo from 0.25× to 4.0× while preserving pitch. Presets for 0.25×, 0.5×, 0.75×, 1.0×, 1.25×, 1.5×, 1.75×, 2.0×, 2.5×, 3.0×, 4.0×, plus a Custom… dialog are exposed in the menu; settings persist across launches. Applies to local files and HTTP streaming (Plex/Subsonic/Jellyfin/Emby/radio). Not available while casting (Sonos / Chromecast / DLNA) because the remote renderer receives the stream URL directly with no local audio graph to time-stretch.
 
 ### Improvements
 

--- a/Sources/NullPlayer/Visualization/SpectrumAnalyzerView.swift
+++ b/Sources/NullPlayer/Visualization/SpectrumAnalyzerView.swift
@@ -2733,6 +2733,11 @@ class SpectrumAnalyzerView: NSView {
 
             snowFallOffset += fallSpeed * (1.0 / 60.0)
             snowWindPhase += windSpeed * (1.0 / 60.0)
+            // Wrap accumulators so float32 precision in the shader's floor(field) doesn't
+            // collapse particle Y cells into stripes after long playback. 20.0 makes
+            // fall*rows integer for every layer (see SnowShaders.metal), so wrap is seamless.
+            if snowFallOffset >= 20.0 { snowFallOffset -= 20.0 }
+            if snowWindPhase >= 1024.0 { snowWindPhase -= 1024.0 }
 
             localFallOffset = snowFallOffset
             localWindPhase = snowWindPhase


### PR DESCRIPTION
## Summary
- add the missing Unreleased changelog entry for Playback Speed
- wrap Snow visualization fall and wind accumulators to avoid long-running shader precision artifacts

## Tests
- Not run (changelog plus small accumulator guard only).

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Adjustable playback speed from 0.25× to 4.0× with pitch preservation. Choose from presets or customize. Settings persist between sessions. Note: Not available while casting.

* **Bug Fixes**
  * Resolved spectrum visualization artifacts during extended playback sessions.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/ad-repo/nullplayer/pull/235?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->