### PR TITLE
Fix internet radio column sorting

### DIFF
--- a/Sources/NullPlayer/Windows/ModernLibraryBrowser/ModernLibraryBrowserView.swift
+++ b/Sources/NullPlayer/Windows/ModernLibraryBrowser/ModernLibraryBrowserView.swift
@@ -2735,18 +2735,27 @@ class ModernLibraryBrowserView: NSView {
     }
 
     private func sortedInternetRadioItems(_ items: [ModernDisplayItem], sortColumn: ModernBrowserColumn, ascending: Bool) -> [ModernDisplayItem] {
-        items.enumerated().sorted { lhs, rhs in
-            let comparison = compareInternetRadioItems(lhs.element, rhs.element, sortColumn: sortColumn)
+        let ratingsByItemId = Dictionary(uniqueKeysWithValues: items.map { item in
+            (item.id, internetRadioRating(for: item))
+        })
+
+        return items.enumerated().sorted { lhs, rhs in
+            let comparison = compareInternetRadioItems(lhs.element, rhs.element, sortColumn: sortColumn, ratingsByItemId: ratingsByItemId)
             if comparison == .orderedSame { return lhs.offset < rhs.offset }
             return ascending ? comparison == .orderedAscending : comparison == .orderedDescending
         }.map(\.element)
     }
 
-    private func compareInternetRadioItems(_ lhs: ModernDisplayItem, _ rhs: ModernDisplayItem, sortColumn: ModernBrowserColumn) -> ComparisonResult {
+    private func compareInternetRadioItems(
+        _ lhs: ModernDisplayItem,
+        _ rhs: ModernDisplayItem,
+        sortColumn: ModernBrowserColumn,
+        ratingsByItemId: [String: Int]
+    ) -> ComparisonResult {
         switch sortColumn.id {
         case "rating":
-            let lhsRating = internetRadioRating(for: lhs)
-            let rhsRating = internetRadioRating(for: rhs)
+            let lhsRating = internetRadioRating(for: lhs, ratingsByItemId: ratingsByItemId)
+            let rhsRating = internetRadioRating(for: rhs, ratingsByItemId: ratingsByItemId)
             if lhsRating != rhsRating {
                 return lhsRating < rhsRating ? .orderedAscending : .orderedDescending
             }
@@ -2763,6 +2772,10 @@ class ModernLibraryBrowserView: NSView {
     private func internetRadioRating(for item: ModernDisplayItem) -> Int {
         guard case .radioStation(let station) = item.type else { return 0 }
         return RadioManager.shared.rating(for: station)
+    }
+
+    private func internetRadioRating(for item: ModernDisplayItem, ratingsByItemId: [String: Int]) -> Int {
+        ratingsByItemId[item.id] ?? 0
     }
     
     private func parseDuration(_ str: String) -> Int {

--- a/Sources/NullPlayer/Windows/ModernLibraryBrowser/ModernLibraryBrowserView.swift
+++ b/Sources/NullPlayer/Windows/ModernLibraryBrowser/ModernLibraryBrowserView.swift
@@ -2633,6 +2633,10 @@ class ModernLibraryBrowserView: NSView {
         guard let sortColumn = ModernBrowserColumn.findColumn(id: sortColumnId) else {
             needsDisplay = true; return
         }
+
+        if applyInternetRadioColumnSort(sortColumn: sortColumn, ascending: columnSortAscending) {
+            needsDisplay = true; return
+        }
         
         let hasNestedItems = displayItems.contains { $0.indentLevel > 0 }
         if hasNestedItems { needsDisplay = true; return }
@@ -2701,6 +2705,64 @@ class ModernLibraryBrowserView: NSView {
             displayItems[originalIndex] = sortableItems[sortedIndex]
         }
         needsDisplay = true
+    }
+
+    private func applyInternetRadioColumnSort(sortColumn: ModernBrowserColumn, ascending: Bool) -> Bool {
+        guard case .radio = currentSource,
+              ModernBrowserColumn.internetRadioColumns.contains(where: { $0.id == sortColumn.id }),
+              displayItems.contains(where: isInternetRadioItem) else {
+            return false
+        }
+
+        var index = 0
+        var didSort = false
+        while index < displayItems.count {
+            guard isInternetRadioItem(displayItems[index]) else {
+                index += 1
+                continue
+            }
+
+            let start = index
+            while index < displayItems.count, isInternetRadioItem(displayItems[index]) {
+                index += 1
+            }
+
+            let sorted = sortedInternetRadioItems(Array(displayItems[start..<index]), sortColumn: sortColumn, ascending: ascending)
+            displayItems.replaceSubrange(start..<index, with: sorted)
+            didSort = true
+        }
+        return didSort
+    }
+
+    private func sortedInternetRadioItems(_ items: [ModernDisplayItem], sortColumn: ModernBrowserColumn, ascending: Bool) -> [ModernDisplayItem] {
+        items.enumerated().sorted { lhs, rhs in
+            let comparison = compareInternetRadioItems(lhs.element, rhs.element, sortColumn: sortColumn)
+            if comparison == .orderedSame { return lhs.offset < rhs.offset }
+            return ascending ? comparison == .orderedAscending : comparison == .orderedDescending
+        }.map(\.element)
+    }
+
+    private func compareInternetRadioItems(_ lhs: ModernDisplayItem, _ rhs: ModernDisplayItem, sortColumn: ModernBrowserColumn) -> ComparisonResult {
+        switch sortColumn.id {
+        case "rating":
+            let lhsRating = internetRadioRating(for: lhs)
+            let rhsRating = internetRadioRating(for: rhs)
+            if lhsRating != rhsRating {
+                return lhsRating < rhsRating ? .orderedAscending : .orderedDescending
+            }
+            return LibraryTextSorter.compare(lhs.title, rhs.title, ignoreLeadingArticles: true)
+        case "genre":
+            let genreComparison = LibraryTextSorter.compare(lhs.columnValue(for: sortColumn), rhs.columnValue(for: sortColumn), ignoreLeadingArticles: true)
+            if genreComparison != .orderedSame { return genreComparison }
+            return LibraryTextSorter.compare(lhs.title, rhs.title, ignoreLeadingArticles: true)
+        default:
+            return LibraryTextSorter.compare(lhs.columnValue(for: sortColumn), rhs.columnValue(for: sortColumn), ignoreLeadingArticles: true)
+        }
+    }
+
+    private func internetRadioRating(for item: ModernDisplayItem) -> Int {
+        guard case .radioStation(let station) = item.type else { return 0 }
+        return RadioManager.shared.rating(for: station)
     }
     
     private func parseDuration(_ str: String) -> Int {
@@ -7884,6 +7946,7 @@ class ModernLibraryBrowserView: NSView {
         cachedRadioStations = RadioManager.shared.stations
         cachedRadioFolders = RadioManager.shared.internetRadioFolderDescriptors()
         buildRadioStationItems()
+        if columnSortId != nil { applyColumnSort() }
         needsDisplay = true
     }
 
@@ -7893,6 +7956,7 @@ class ModernLibraryBrowserView: NSView {
         stopLoadingAnimation()
         cachedRadioStations = RadioManager.shared.stations
         buildRadioSearchItems()
+        if columnSortId != nil { applyColumnSort() }
         needsDisplay = true
     }
 
@@ -9639,6 +9703,7 @@ class ModernLibraryBrowserView: NSView {
             default:
                 displayItems = []
             }
+            if columnSortId != nil { applyColumnSort() }
             needsDisplay = true
             return
         }

--- a/Sources/NullPlayer/Windows/PlexBrowser/PlexBrowserView.swift
+++ b/Sources/NullPlayer/Windows/PlexBrowser/PlexBrowserView.swift
@@ -635,6 +635,11 @@ class PlexBrowserView: NSView {
             needsDisplay = true
             return
         }
+
+        if applyInternetRadioColumnSort(sortColumn: sortColumn, ascending: columnSortAscending) {
+            needsDisplay = true
+            return
+        }
         
         // If there are any nested/expanded items (indentLevel > 0), skip column sorting
         // to avoid orphaning children from their parents. The build functions already
@@ -727,6 +732,66 @@ class PlexBrowserView: NSView {
         }
         
         needsDisplay = true
+    }
+
+    private func applyInternetRadioColumnSort(sortColumn: BrowserColumn, ascending: Bool) -> Bool {
+        guard case .radio = currentSource,
+              BrowserColumn.internetRadioColumns.contains(where: { $0.id == sortColumn.id }),
+              displayItems.contains(where: isInternetRadioItem) else {
+            return false
+        }
+
+        var index = 0
+        var didSort = false
+        while index < displayItems.count {
+            guard isInternetRadioItem(displayItems[index]) else {
+                index += 1
+                continue
+            }
+
+            let start = index
+            while index < displayItems.count, isInternetRadioItem(displayItems[index]) {
+                index += 1
+            }
+
+            let sorted = sortedInternetRadioItems(Array(displayItems[start..<index]), sortColumn: sortColumn, ascending: ascending)
+            displayItems.replaceSubrange(start..<index, with: sorted)
+            didSort = true
+        }
+        return didSort
+    }
+
+    private func sortedInternetRadioItems(_ items: [PlexDisplayItem], sortColumn: BrowserColumn, ascending: Bool) -> [PlexDisplayItem] {
+        items.enumerated().sorted { lhs, rhs in
+            let comparison = compareInternetRadioItems(lhs.element, rhs.element, sortColumn: sortColumn)
+            if comparison == .orderedSame {
+                return lhs.offset < rhs.offset
+            }
+            return ascending ? comparison == .orderedAscending : comparison == .orderedDescending
+        }.map(\.element)
+    }
+
+    private func compareInternetRadioItems(_ lhs: PlexDisplayItem, _ rhs: PlexDisplayItem, sortColumn: BrowserColumn) -> ComparisonResult {
+        switch sortColumn.id {
+        case "rating":
+            let lhsRating = internetRadioRating(for: lhs)
+            let rhsRating = internetRadioRating(for: rhs)
+            if lhsRating != rhsRating {
+                return lhsRating < rhsRating ? .orderedAscending : .orderedDescending
+            }
+            return LibraryTextSorter.compare(lhs.title, rhs.title, ignoreLeadingArticles: true)
+        case "genre":
+            let genreComparison = LibraryTextSorter.compare(lhs.columnValue(for: sortColumn), rhs.columnValue(for: sortColumn), ignoreLeadingArticles: true)
+            if genreComparison != .orderedSame { return genreComparison }
+            return LibraryTextSorter.compare(lhs.title, rhs.title, ignoreLeadingArticles: true)
+        default:
+            return LibraryTextSorter.compare(lhs.columnValue(for: sortColumn), rhs.columnValue(for: sortColumn), ignoreLeadingArticles: true)
+        }
+    }
+
+    private func internetRadioRating(for item: PlexDisplayItem) -> Int {
+        guard case .radioStation(let station) = item.type else { return 0 }
+        return RadioManager.shared.rating(for: station)
     }
     
     /// Parse duration string (e.g., "3:45" or "1:23:45") to seconds
@@ -13364,6 +13429,9 @@ class PlexBrowserView: NSView {
         
         // Build display items for radio stations
         buildRadioStationItems()
+        if columnSortId != nil {
+            applyColumnSort()
+        }
         
         needsDisplay = true
     }
@@ -13375,6 +13443,9 @@ class PlexBrowserView: NSView {
 
         cachedRadioStations = RadioManager.shared.stations
         buildRadioSearchItems()
+        if columnSortId != nil {
+            applyColumnSort()
+        }
 
         needsDisplay = true
     }
@@ -15352,6 +15423,9 @@ class PlexBrowserView: NSView {
                 buildRadioSearchItems()
             } else {
                 displayItems = []
+            }
+            if columnSortId != nil {
+                applyColumnSort()
             }
             needsDisplay = true
             return

--- a/Sources/NullPlayer/Windows/PlexBrowser/PlexBrowserView.swift
+++ b/Sources/NullPlayer/Windows/PlexBrowser/PlexBrowserView.swift
@@ -762,8 +762,12 @@ class PlexBrowserView: NSView {
     }
 
     private func sortedInternetRadioItems(_ items: [PlexDisplayItem], sortColumn: BrowserColumn, ascending: Bool) -> [PlexDisplayItem] {
-        items.enumerated().sorted { lhs, rhs in
-            let comparison = compareInternetRadioItems(lhs.element, rhs.element, sortColumn: sortColumn)
+        let ratingsByItemId = Dictionary(uniqueKeysWithValues: items.map { item in
+            (item.id, internetRadioRating(for: item))
+        })
+
+        return items.enumerated().sorted { lhs, rhs in
+            let comparison = compareInternetRadioItems(lhs.element, rhs.element, sortColumn: sortColumn, ratingsByItemId: ratingsByItemId)
             if comparison == .orderedSame {
                 return lhs.offset < rhs.offset
             }
@@ -771,11 +775,16 @@ class PlexBrowserView: NSView {
         }.map(\.element)
     }
 
-    private func compareInternetRadioItems(_ lhs: PlexDisplayItem, _ rhs: PlexDisplayItem, sortColumn: BrowserColumn) -> ComparisonResult {
+    private func compareInternetRadioItems(
+        _ lhs: PlexDisplayItem,
+        _ rhs: PlexDisplayItem,
+        sortColumn: BrowserColumn,
+        ratingsByItemId: [String: Int]
+    ) -> ComparisonResult {
         switch sortColumn.id {
         case "rating":
-            let lhsRating = internetRadioRating(for: lhs)
-            let rhsRating = internetRadioRating(for: rhs)
+            let lhsRating = internetRadioRating(for: lhs, ratingsByItemId: ratingsByItemId)
+            let rhsRating = internetRadioRating(for: rhs, ratingsByItemId: ratingsByItemId)
             if lhsRating != rhsRating {
                 return lhsRating < rhsRating ? .orderedAscending : .orderedDescending
             }
@@ -792,6 +801,10 @@ class PlexBrowserView: NSView {
     private func internetRadioRating(for item: PlexDisplayItem) -> Int {
         guard case .radioStation(let station) = item.type else { return 0 }
         return RadioManager.shared.rating(for: station)
+    }
+
+    private func internetRadioRating(for item: PlexDisplayItem, ratingsByItemId: [String: Int]) -> Int {
+        ratingsByItemId[item.id] ?? 0
     }
     
     /// Parse duration string (e.g., "3:45" or "1:23:45") to seconds


### PR DESCRIPTION
## Summary
- sort Internet Radio station rows when Title, Genre, or Rating headers are clicked
- preserve folder grouping while sorting visible station runs
- reapply the active radio sort after radio list and search rebuilds

## Verification
- swift build
- swift test

Closes #222

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added column sorting functionality for Internet Radio items.
  * Support for sorting by rating, genre, and other columns.
  * Automatic sorting applied when viewing radio stations and search results.
  * Intelligent tie-breaking uses title comparison for consistent results.
  * Sort order respects user preference for ascending or descending.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/ad-repo/nullplayer/pull/236?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->