### PR TITLE
Fix radio tab source switching

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,6 +19,11 @@
 - **Main-window spectrum can be disabled** — Visuals > Spectrum Analyzer > Main Window > Mode now includes **Off**, matching Winamp's blank main-display option so compatible skins can show their prepared artwork without an analyzer overlay.
 - **Homebrew cask install** — NullPlayer can now be installed via a personal tap: `brew install --cask ad-repo/nullplayer/nullplayer`. The cask strips the quarantine attribute on install (the app is still ad-hoc signed; Developer ID notarization is on the roadmap). `scripts/build_dmg.sh` now prints the final DMG SHA256 for the per-release cask bump, and `docs/development-workflow.md` documents the release flow.
 
+### Bug Fixes
+
+- **Library source switching from Radio fixed** — selecting a different source while the Library Browser is on the Radio tab now keeps the Radio tab active and loads that source's library-radio view instead of forcing the browser back to Artists. Fixed in both classic and modern library browsers.
+- **Internet radio column sorting fixed** — radio station columns now sort correctly in both classic and modern library browsers, including rating-aware sorting without repeated rating-store lookups during comparisons.
+
 ## 0.23.0
 
 ### New Features

--- a/Sources/NullPlayer/Windows/ModernLibraryBrowser/ModernLibraryBrowserView.swift
+++ b/Sources/NullPlayer/Windows/ModernLibraryBrowser/ModernLibraryBrowserView.swift
@@ -6721,9 +6721,10 @@ class ModernLibraryBrowserView: NSView {
         clearAllCachedData(); clearLocalCachedData()
         displayItems.removeAll(); selectedIndices.removeAll()
         scrollOffset = 0; errorMessage = nil; isLoading = false; stopLoadingAnimation()
-        if !browseMode.isHistoryMode {
-            if case .radio = currentSource { browseMode = .radio }
-            else if browseMode == .radio && !currentSource.isPlex { browseMode = .artists }
+        // Internet Radio only has radio/search content, but every library
+        // source supports the Radio tab. Preserve Radio across source changes.
+        if !browseMode.isHistoryMode, case .radio = currentSource {
+            browseMode = .radio
         }
         reloadData()
         startServerNameScroll()

--- a/Sources/NullPlayer/Windows/PlexBrowser/PlexBrowserView.swift
+++ b/Sources/NullPlayer/Windows/PlexBrowser/PlexBrowserView.swift
@@ -1805,20 +1805,11 @@ class PlexBrowserView: NSView {
         isLoading = false
         stopLoadingAnimation()
         
-        // Sync browse mode with radio source while preserving global Data mode.
+        // Internet Radio only has radio/search content, but every library
+        // source supports the Radio tab. Preserve Radio across source changes.
         if !browseMode.isHistoryMode {
             if case .radio = currentSource {
-                // When switching to Internet Radio source, automatically switch to radio tab
                 browseMode = .radio
-            } else if browseMode == .radio, case .local = currentSource {
-                // When switching sources from radio tab, default back to artists for non-Plex.
-                browseMode = .artists
-            } else if browseMode == .radio, case .subsonic = currentSource {
-                browseMode = .artists
-            } else if browseMode == .radio, case .jellyfin = currentSource {
-                browseMode = .artists
-            } else if browseMode == .radio, case .emby = currentSource {
-                browseMode = .artists
             }
         }
         


### PR DESCRIPTION
## Summary
- preserve the Library Browser Radio tab when switching between library sources
- keep Internet Radio forcing the Radio tab because it only supports radio/search content
- document this fix and the previously merged internet-radio sorting fix in the changelog

Closes #225.

## Testing
- swift test

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Radio tab selection is now preserved when switching between library sources instead of reverting to the default view
  * Internet radio column sorting now works correctly across all library browsers

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/ad-repo/nullplayer/pull/237?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->