### PR TITLE
Preserve Sonos cast session on stop

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -21,6 +21,7 @@
 
 ### Bug Fixes
 
+- **Sonos cast session preserved on Stop and end-of-playlist** — pressing the player Stop button or reaching the end of a playlist now sends Stop to Sonos without disconnecting the active Sonos target or ungrouping rooms, so the next compatible track can resume on the same speaker/group. Chromecast and non-Sonos DLNA still use the existing full-disconnect behavior.
 - **Library source switching from Radio fixed** — selecting a different source while the Library Browser is on the Radio tab now keeps the Radio tab active and loads that source's library-radio view instead of forcing the browser back to Artists. Fixed in both classic and modern library browsers.
 - **Internet radio column sorting fixed** — radio station columns now sort correctly in both classic and modern library browsers, including rating-aware sorting without repeated rating-store lookups during comparisons.
 

--- a/Sources/NullPlayer/Audio/AudioEngine.swift
+++ b/Sources/NullPlayer/Audio/AudioEngine.swift
@@ -2023,7 +2023,7 @@ class AudioEngine {
             RadioManager.shared.stop()
         }
         
-        // If casting is active (or in .loaded pre-cast phase), end the cast session
+        // If casting is active (or in .loaded pre-cast phase), apply the active device's stop policy.
         let castSession = CastManager.shared.activeSession
         NSLog("AudioEngine.stop(): isCastingActive=%d, activeSession=%@, currentCast=%@",
               isCastingActive ? 1 : 0,
@@ -2998,7 +2998,7 @@ class AudioEngine {
                 }
                 if !foundCompatibleTrack {
                     Task {
-                        await CastManager.shared.stopCasting()
+                        await CastManager.shared.softStopForActiveDevice()
                         await MainActor.run { self.isAdvancingCastTrack = false }
                     }
                     return
@@ -3048,7 +3048,7 @@ class AudioEngine {
                 }
                 if !foundCompatibleTrack {
                     Task {
-                        await CastManager.shared.stopCasting()
+                        await CastManager.shared.softStopForActiveDevice()
                         await MainActor.run { self.isAdvancingCastTrack = false }
                     }
                     return
@@ -3092,7 +3092,7 @@ class AudioEngine {
                 }
                 guard currentIndex < playlist.count else {
                     Task {
-                        await CastManager.shared.stopCasting()
+                        await CastManager.shared.softStopForActiveDevice()
                         await MainActor.run { self.isAdvancingCastTrack = false }
                     }
                     return
@@ -3124,9 +3124,9 @@ class AudioEngine {
                     await MainActor.run { self.isAdvancingCastTrack = false }
                 }
             } else {
-                // End of playlist - stop casting
+                // End of playlist - apply the active device's stop policy.
                 Task {
-                    await CastManager.shared.stopCasting()
+                    await CastManager.shared.softStopForActiveDevice()
                     await MainActor.run { self.isAdvancingCastTrack = false }
                 }
             }

--- a/Sources/NullPlayer/Casting/CastManager.swift
+++ b/Sources/NullPlayer/Casting/CastManager.swift
@@ -1981,7 +1981,7 @@ class CastManager {
     /// Sonos stops playback but keeps the session active so the next track can reuse the same target.
     /// Chromecast and non-Sonos UPnP/DLNA preserve the existing full-disconnect behavior.
     func softStopForActiveDevice() async {
-        if upnpManager.activeSession?.device.type == .sonos {
+        if activeSession?.device.type == .sonos {
             do {
                 try await stopPlayback()
             } catch {

--- a/Sources/NullPlayer/Casting/CastManager.swift
+++ b/Sources/NullPlayer/Casting/CastManager.swift
@@ -1977,9 +1977,25 @@ class CastManager {
         // Skip MainActor state cleanup - app is terminating anyway
     }
     
-    /// Handle stop button — always ends the cast session for all device types
-    func handleStopForActiveDevice() async {
+    /// Soft-stop policy for end-of-playlist and the Stop button.
+    /// Sonos stops playback but keeps the session active so the next track can reuse the same target.
+    /// Chromecast and non-Sonos UPnP/DLNA preserve the existing full-disconnect behavior.
+    func softStopForActiveDevice() async {
+        if upnpManager.activeSession?.device.type == .sonos {
+            do {
+                try await stopPlayback()
+            } catch {
+                NSLog("CastManager.softStopForActiveDevice: stopPlayback failed: %@", error.localizedDescription)
+            }
+            return
+        }
+
         await stopCasting()
+    }
+
+    /// Handle stop button using the active device's soft-stop policy.
+    func handleStopForActiveDevice() async {
+        await softStopForActiveDevice()
     }
     
     /// Stop playback on the cast device but keep the session active

--- a/skills/sonos-casting/SKILL.md
+++ b/skills/sonos-casting/SKILL.md
@@ -14,7 +14,7 @@ This guide covers Sonos speaker discovery, casting, and multi-room grouping in N
    - Top menu bar → **Output → Sonos**
 2. Check the rooms you want to cast to (checkboxes stay open for multi-select)
 3. Click **🟢 Start Casting** to begin playback
-4. Click **🔴 Stop Casting** to end the session
+4. Click **🔴 Stop Casting** from the Sonos menu to fully end the cast session
 
 ## Discovery Methods
 
@@ -145,7 +145,12 @@ While casting is active:
 
 ### Stopping a Cast
 
-Click **🔴 Stop Casting** to:
+There are two intentional stop paths:
+
+- **Player Stop button / end-of-playlist**: sends `Stop` to Sonos but keeps `upnpManager.activeSession`, selected rooms, group membership, and LocalMediaServer registrations intact. The next compatible track reuses the same Sonos target without re-selecting rooms. This path is `AudioEngine.stop()` or `castTrackDidFinish()` → `CastManager.softStopForActiveDevice()` → `stopPlayback()`.
+- **Sonos menu 🔴 Stop Casting**: fully tears down the cast session via `CastManager.stopCasting()`.
+
+Click **🔴 Stop Casting** to fully disconnect:
 - Ungroup all member rooms (each becomes standalone)
 - Stop playback on the coordinator
 - Clear all room selections
@@ -422,8 +427,10 @@ If you see "Sonos rejected the command":
 - At Sonos cast start, `activeSession.position = startPosition` and `activeSession.playbackStartDate = Date()` must both be set immediately (Sonos has no status updates to set them later).
 - Each PLAYING poll must update both fields. Check `CastManager: Sonos poll — state=PLAYING` logs.
 
-### Stop Button Doesn't End Cast
-- `handleStopForActiveDevice` must call `await stopCasting()` for all device types. If it only calls `stopPlayback()`, the session stays alive.
+### Player Stop Keeps Session Alive
+- This is expected for Sonos when using the player Stop button: `handleStopForActiveDevice()` calls `softStopForActiveDevice()`, which stops Sonos playback but leaves the session active.
+- Use the Sonos menu **🔴 Stop Casting** action when a full disconnect is required.
+- Chromecast and non-Sonos DLNA should still route through `stopCasting()` from `softStopForActiveDevice()`.
 
 ### Casting Stops Unexpectedly
 1. Check if Sonos speaker went to sleep (idle timeout)


### PR DESCRIPTION
## Summary
- add a Sonos-only soft-stop policy for player Stop and end-of-playlist paths
- route Sonos-incompatible end-of-list branches through the same policy
- document the behavior in the changelog and Sonos casting skill

## Tests
- swift test

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Sonos cast sessions are preserved when stopping playback or reaching the end of a playlist, so the next compatible track can resume on the same speaker/group. Chromecast and non‑Sonos DLNA continue to fully disconnect.

* **Documentation**
  * Clarified casting docs: player Stop preserves the Sonos session; use the Sonos menu Stop to fully disconnect.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/ad-repo/nullplayer/pull/238?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->