### PR TITLE
Bump version to 0.24.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,6 @@
 # Changelog
 
-## Unreleased
+## 0.24.0
 
 ### New Features
 

--- a/Sources/NullPlayer/Resources/Info.plist
+++ b/Sources/NullPlayer/Resources/Info.plist
@@ -15,7 +15,7 @@
     <key>CFBundleIconFile</key>
     <string>AppIcon</string>
     <key>CFBundleShortVersionString</key>
-    <string>0.23.0</string>
+    <string>0.24.0</string>
     <key>CFBundleVersion</key>
     <string>1</string>
     <key>LSMinimumSystemVersion</key>


### PR DESCRIPTION
## Summary
- Bump `CFBundleShortVersionString` to 0.24.0
- Rename CHANGELOG `Unreleased` section to `0.24.0`

🤖 Generated with [Claude Code](https://claude.com/claude-code)