### PR TITLE
Fix non-Retina display bugs: classic skin blue tones (#256) & modern Data tab blur (#257)

### DIFF
--- a/Sources/NullPlayer/Skin/SkinLoader.swift
+++ b/Sources/NullPlayer/Skin/SkinLoader.swift
@@ -67,22 +67,11 @@ class SkinLoader {
         // Some skins extract to a subdirectory - detect and use it if present
         let skinDirectory = findSkinDirectory(in: directory)
         let fileIndex = buildCaseInsensitiveFileIndex(in: skinDirectory)
-        
-        // Check if we're on a non-Retina display
-        let isNonRetina = (NSScreen.main?.backingScaleFactor ?? 2.0) < 1.5
-        
+
         // Helper to load BMP with true case-insensitive filename matching
         func loadImage(_ name: String) -> NSImage? {
             guard let url = resolveFileURL(named: name, ext: "bmp", in: fileIndex) else { return nil }
-            if var image = loadBMP(from: url) {
-                // On non-Retina displays, convert blue-tinted pixels to grayscale
-                // to prevent blue line artifacts
-                if isNonRetina {
-                    image = processForNonRetina(image)
-                }
-                return image
-            }
-            return nil
+            return loadBMP(from: url)
         }
         
         // Load playlist colors
@@ -204,54 +193,6 @@ class SkinLoader {
             print("Failed to load BMP from \(url): \(error)")
             return nil
         }
-    }
-    
-    /// Process an image for non-Retina displays by converting blue-tinted pixels to grayscale.
-    /// This prevents blue line artifacts that appear on 1x displays due to sub-pixel rendering.
-    private func processForNonRetina(_ image: NSImage) -> NSImage {
-        guard let tiffData = image.tiffRepresentation,
-              let bitmap = NSBitmapImageRep(data: tiffData) else {
-            return image
-        }
-        
-        let width = bitmap.pixelsWide
-        let height = bitmap.pixelsHigh
-        
-        for y in 0..<height {
-            for x in 0..<width {
-                guard let color = bitmap.colorAt(x: x, y: y) else { continue }
-                
-                let r = Int(color.redComponent * 255)
-                let g = Int(color.greenComponent * 255)
-                let b = Int(color.blueComponent * 255)
-                
-                // Skip magenta transparency (255, 0, 255)
-                if r == 255 && g == 0 && b == 255 { continue }
-                
-                // Skip near-white/bright pixels
-                if r > 200 && g > 200 && b > 200 { continue }
-                
-                // Skip warm colors (red/yellow/orange dominant)
-                if r > b && g >= b { continue }
-                
-                // Skip green-dominant pixels (used for indicators like stereo, mono)
-                if g > r && g > b { continue }
-                
-                // This pixel has blue tint - convert to grayscale
-                if b > r && b > g {
-                    let gray = Int(Double(r) * 0.299 + Double(g) * 0.587 + Double(b) * 0.114)
-                    let newColor = NSColor(calibratedRed: CGFloat(gray)/255.0,
-                                           green: CGFloat(gray)/255.0,
-                                           blue: CGFloat(gray)/255.0,
-                                           alpha: color.alphaComponent)
-                    bitmap.setColor(newColor, atX: x, y: y)
-                }
-            }
-        }
-        
-        let newImage = NSImage(size: image.size)
-        newImage.addRepresentation(bitmap)
-        return newImage
     }
     
     private func loadPlaylistColors(from directory: URL) -> PlaylistColors {

--- a/Sources/NullPlayer/Windows/ModernLibraryBrowser/ModernLibraryBrowserView.swift
+++ b/Sources/NullPlayer/Windows/ModernLibraryBrowser/ModernLibraryBrowserView.swift
@@ -775,8 +775,8 @@ class ModernLibraryBrowserView: NSView {
                                         headerTitle: "Library Data")
         let hostingView = NSHostingView(rootView: rootView)
         hostingView.wantsLayer = true
-        hostingView.layer?.backgroundColor = NSColor.clear.cgColor
-        hostingView.layer?.isOpaque = false
+        hostingView.layer?.backgroundColor = skin.backgroundColor.withAlphaComponent(1.0).cgColor
+        hostingView.layer?.isOpaque = true
         hostingView.appearance = skinAppearance(for: skin)
         hostingView.setAccessibilityIdentifier("modernLibraryBrowser.data")
         hostingView.setAccessibilityLabel("Library Data")
@@ -6443,6 +6443,7 @@ class ModernLibraryBrowserView: NSView {
                                                         skinTextColor: Color(skin.textColor),
                                                         headerTitle: "Library Data")
         historyHostingView?.appearance = skinAppearance(for: skin)
+        historyHostingView?.layer?.backgroundColor = skin.backgroundColor.withAlphaComponent(1.0).cgColor
         invalidateServerBarFontCache()
         updateCornerMask()
         updateEmbeddedSubviewFrames()

--- a/skills/non-retina-fixes/SKILL.md
+++ b/skills/non-retina-fixes/SKILL.md
@@ -35,42 +35,7 @@ Visible lines at tile boundaries occurred because:
 
 ## Working Solutions
 
-### 1. Runtime Image Processing in SkinLoader
-
-**Approach**: Process skin images at load time, converting blue-tinted pixels to grayscale only on non-Retina displays.
-
-**Implementation** in `SkinLoader.swift`:
-
-```swift
-private func loadSkin(from directory: URL) throws -> Skin {
-    // Check if we're on a non-Retina display
-    let isNonRetina = (NSScreen.main?.backingScaleFactor ?? 2.0) < 1.5
-    
-    func loadImage(_ name: String) -> NSImage? {
-        // ... load BMP ...
-        if var image = loadBMP(from: url) {
-            if isNonRetina {
-                image = processForNonRetina(image)
-            }
-            return image
-        }
-    }
-}
-
-private func processForNonRetina(_ image: NSImage) -> NSImage {
-    // Convert blue-tinted pixels to grayscale while preserving:
-    // - Magenta transparency (255, 0, 255)
-    // - Bright/white pixels
-    // - Warm colors (red/yellow/orange)
-    
-    for each pixel:
-        if b > r || b > g:  // Has blue tint
-            gray = luminance(r, g, b)
-            set pixel to (gray, gray, gray)
-}
-```
-
-### 2. Rounded Coordinates for Text/Scroll
+### 1. Rounded Coordinates for Text/Scroll
 
 Round pixel coordinates to integers on non-Retina displays to prevent sub-pixel positioning artifacts.
 
@@ -82,7 +47,7 @@ let roundedScrollOffset = backingScale < 1.5 ? round(scrollOffset) : scrollOffse
 
 **Why it works**: Prevents text "shimmering" during scroll.
 
-### 3. NSImage-Based Title Bar Rendering
+### 2. NSImage-Based Title Bar Rendering
 
 Use NSImage-based sprite drawing instead of CGImage with `interpolationQuality = .none`.
 
@@ -99,7 +64,7 @@ drawSprite(from: pleditImage, sourceRect: leftCorner,
 
 **Why it works**: NSImage-based drawing uses default interpolation which blends pixel edges smoothly.
 
-### 4. Playlist Window Tile Seam Fixes
+### 3. Playlist Window Tile Seam Fixes
 
 **Problem**: Vertical and horizontal line artifacts at tile boundaries on non-Retina displays.
 
@@ -164,7 +129,7 @@ while y >= contentTop - tileHeight {
 - Bottom-to-top tiling places partial tiles where they're less visible
 - Overlap ensures tiles blend together
 
-### 5. Targeted Redraw for Visualizer Animation
+### 4. Targeted Redraw for Visualizer Animation
 
 **Problem**: Album Art Visualizer running at 60fps caused title bar/menu items to shimmer on non-Retina displays when marking entire view for redraw.
 
@@ -186,7 +151,7 @@ self.setNeedsDisplay(contentRect)
 
 **Why it works**: Only the animated area gets redrawn, menu items remain stable.
 
-### 6. Targeted Redraw for Loading Animation
+### 5. Targeted Redraw for Loading Animation
 
 **Solution**: Apply the same targeted redraw approach to the loading spinner animation.
 
@@ -207,16 +172,15 @@ self.setNeedsDisplay(listRect)
 
 ## Files Changed
 
-1. **`Skin/SkinLoader.swift`** - Added `processForNonRetina()` for blue-to-grayscale conversion
-2. **`Skin/SkinRenderer.swift`** - NSImage rendering for title bars, playlist tile fixes
-3. **`Windows/PlexBrowser/PlexBrowserView.swift`** - Rounded coordinates, targeted redraws
-4. **`Windows/Playlist/PlaylistView.swift`** - Rounded scroll offset
+1. **`Skin/SkinRenderer.swift`** - NSImage rendering for title bars, playlist tile fixes
+2. **`Windows/PlexBrowser/PlexBrowserView.swift`** - Rounded coordinates, targeted redraws
+3. **`Windows/Playlist/PlaylistView.swift`** - Rounded scroll offset
 
 ## Key Learnings
 
 1. **Don't disable anti-aliasing** - It actually helps blend problematic pixels
 2. **Avoid modifying BMP files** - Format differences cause rendering issues
-3. **Runtime processing is safer** - Keeps original assets intact
+3. **Blanket color conversion is risky** - The blue-to-grayscale conversion (issue #256) was removed because it discolored legitimate blue tones across all classic skins on 1× displays. If blue-line artifacts resurface, address them via the anti-aliasing and rounded-coordinate strategies documented in sections 1–5 above, not by mangling pixel colors.
 4. **NSImage vs CGImage matters** - CGImage with `.none` makes edges harsh
 5. **Tile seams need multiple strategies** - Background fill, overlap, draw order
 6. **Non-Retina fixes must be conditional** - Always check `backingScaleFactor < 1.5`


### PR DESCRIPTION
## Summary

Two confirmed non-Retina (1×) display bugs, both gated behind `backingScaleFactor < 1.5` code paths that never run on the maintainer's Retina display.

### #256 — Classic skins lose blue tones on 1× displays
`SkinLoader.processForNonRetina()` ran only on non-Retina displays and converted **every** blue-dominant pixel to grayscale in **every** classic skin sprite. Originally a narrow workaround for faint blue-line artifacts in the default skin, it stripped legitimate blue from all skins (e.g. `base-2.91.wsz`) — exactly the reported symptom. Removed entirely; `loadImage` now returns the loaded BMP unmodified on all displays.

### #257 — Modern "Data" tab blurry on 1× displays
The Data tab is the only modern Library Browser tab built from SwiftUI via `NSHostingView`. Its layer was clear/non-opaque, which disables AppKit font smoothing and blurs text/charts on 1× displays (masked on Retina). Now uses an opaque skin background + `isOpaque = true`, mirroring the classic `PlexBrowserView` twin, and keeps the color in sync on skin change.

## Changes
| File | Change |
|------|--------|
| `Skin/SkinLoader.swift` | Removed `isNonRetina` check and the `processForNonRetina(_:)` method; `loadImage` returns the BMP unmodified |
| `Windows/ModernLibraryBrowser/ModernLibraryBrowserView.swift` | Opaque Data-tab hosting layer in `makeHistoryHostingView()`; synced on skin change in `modernSkinDidChange()` |
| `skills/non-retina-fixes/SKILL.md` | Retracted the removed approach, renumbered sections, added Key Learnings note |

## Testing
- `swift build` ✅ compiles
- `swift test` ✅ 89 passed, 0 failures
- Retina behavior unchanged (these paths never ran there)

## Caveats
- Final visual confirmation needs a real **1× display** — neither maintainer machine is non-Retina.
- #256's separately-reported "missing buttons" / sprite-scaling artifacts are **out of scope** (general 1× scaling, tracked separately).
- If #257 blur persists on hardware, fallback is setting `layer?.contentsScale` to the window backing scale.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

**Bug Fixes**
- Fixed BMP asset loading in skins with case-insensitive filename matching
- Resolved library browser history view display styling to properly match the current skin's background colors

**Improvements**
- Library browser history view now automatically updates when switching between skins
- Enhanced non-Retina display rendering strategy

**Documentation**
- Updated rendering optimization guidelines for non-Retina displays, including coordinate rounding and improved animation redraw techniques

<!-- end of auto-generated comment: release notes by coderabbit.ai -->