### PR TITLE
Fix popup dialogs hidden behind always-on-top windows (#254)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,11 @@
 # Changelog
 
+## 0.26.0
+
+### Bug Fixes
+
+- **Popup dialogs no longer hide behind always-on-top windows (#254)** — with **Always on Top** enabled, opening a popup dialog (e.g. *Add Radio Station*) appeared to do nothing: the dialog opened at the normal window level, *below* the main window which had been raised to the floating level, so it was completely obscured until the main window was dragged aside. These transient dialogs now open at the `.modalPanel` level so they always sit above the app's floating windows, matching the tag-editor and Plex link dialogs that already did this. Covers Add/Edit Radio Station, the Subsonic/Jellyfin/Emby link and server-list sheets, the watch-folder manager, and the auto-tag album candidate picker.
+
 ## 0.25.0
 
 ### New Features

--- a/Sources/NullPlayer/Emby/EmbyLinkSheet.swift
+++ b/Sources/NullPlayer/Emby/EmbyLinkSheet.swift
@@ -115,6 +115,7 @@ class EmbyLinkSheet: NSWindowController, NSWindowDelegate {
 
     func showDialog(completion: @escaping (EmbyServer?) -> Void) {
         completionHandler = completion
+        window?.level = .modalPanel  // Ensure dialog appears above always-on-top floating windows (issue #254)
         window?.center()
         showWindow(nil)
         window?.makeKey()
@@ -311,6 +312,7 @@ class EmbyServerListSheet: NSWindowController, NSWindowDelegate, NSTableViewData
 
     func showDialog(completion: @escaping (EmbyServer?) -> Void) {
         completionHandler = completion
+        window?.level = .modalPanel  // Ensure dialog appears above always-on-top floating windows (issue #254)
         window?.center()
         showWindow(nil)
         window?.makeKey()

--- a/Sources/NullPlayer/Jellyfin/JellyfinLinkSheet.swift
+++ b/Sources/NullPlayer/Jellyfin/JellyfinLinkSheet.swift
@@ -115,6 +115,7 @@ class JellyfinLinkSheet: NSWindowController, NSWindowDelegate {
     
     func showDialog(completion: @escaping (JellyfinServer?) -> Void) {
         completionHandler = completion
+        window?.level = .modalPanel  // Ensure dialog appears above always-on-top floating windows (issue #254)
         window?.center()
         showWindow(nil)
         window?.makeKey()
@@ -311,6 +312,7 @@ class JellyfinServerListSheet: NSWindowController, NSWindowDelegate, NSTableView
     
     func showDialog(completion: @escaping (JellyfinServer?) -> Void) {
         completionHandler = completion
+        window?.level = .modalPanel  // Ensure dialog appears above always-on-top floating windows (issue #254)
         window?.center()
         showWindow(nil)
         window?.makeKey()

--- a/Sources/NullPlayer/Resources/Info.plist
+++ b/Sources/NullPlayer/Resources/Info.plist
@@ -15,7 +15,7 @@
     <key>CFBundleIconFile</key>
     <string>AppIcon</string>
     <key>CFBundleShortVersionString</key>
-    <string>0.25.0</string>
+    <string>0.26.0</string>
     <key>CFBundleVersion</key>
     <string>1</string>
     <key>LSMinimumSystemVersion</key>

--- a/Sources/NullPlayer/Subsonic/SubsonicLinkSheet.swift
+++ b/Sources/NullPlayer/Subsonic/SubsonicLinkSheet.swift
@@ -115,6 +115,7 @@ class SubsonicLinkSheet: NSWindowController, NSWindowDelegate {
     
     func showDialog(completion: @escaping (SubsonicServer?) -> Void) {
         completionHandler = completion
+        window?.level = .modalPanel  // Ensure dialog appears above always-on-top floating windows (issue #254)
         window?.center()
         showWindow(nil)
         window?.makeKey()
@@ -314,6 +315,7 @@ class SubsonicServerListSheet: NSWindowController, NSWindowDelegate, NSTableView
     
     func showDialog(completion: @escaping (SubsonicServer?) -> Void) {
         completionHandler = completion
+        window?.level = .modalPanel  // Ensure dialog appears above always-on-top floating windows (issue #254)
         window?.center()
         showWindow(nil)
         window?.makeKey()

--- a/Sources/NullPlayer/Windows/Common/WatchFolderManagerDialog.swift
+++ b/Sources/NullPlayer/Windows/Common/WatchFolderManagerDialog.swift
@@ -25,6 +25,7 @@ final class WatchFolderManagerWindow: NSWindowController, NSWindowDelegate,
         }
         let controller = WatchFolderManagerWindow(onLibraryChanged: onLibraryChanged)
         shared = controller
+        controller.window?.level = .modalPanel  // Ensure dialog appears above always-on-top floating windows (issue #254)
         controller.window?.center()
         controller.window?.makeKeyAndOrderFront(nil)
         NSApp.activate(ignoringOtherApps: true)

--- a/Sources/NullPlayer/Windows/ModernLibraryBrowser/AutoTagAlbumCandidatePanel.swift
+++ b/Sources/NullPlayer/Windows/ModernLibraryBrowser/AutoTagAlbumCandidatePanel.swift
@@ -39,6 +39,7 @@ final class AutoTagAlbumCandidatePanel: NSWindow, NSTableViewDataSource, NSTable
     }
 
     func runSelectionModal() -> AutoTagAlbumCandidate? {
+        level = .modalPanel  // Ensure dialog appears above always-on-top floating windows (issue #254)
         center()
         makeKeyAndOrderFront(nil)
         let response = NSApp.runModal(for: self)

--- a/Sources/NullPlayer/Windows/Radio/AddRadioStationSheet.swift
+++ b/Sources/NullPlayer/Windows/Radio/AddRadioStationSheet.swift
@@ -97,6 +97,7 @@ class AddRadioStationSheet: NSWindowController, NSWindowDelegate {
     
     func showDialog(completion: @escaping (RadioStation?) -> Void) {
         completionHandler = completion
+        window?.level = .modalPanel  // Ensure dialog appears above always-on-top floating windows (issue #254)
         window?.center()
         showWindow(nil)
         window?.makeKeyAndOrderFront(nil)


### PR DESCRIPTION
Fixes #254.

## Problem
With **Always on Top** enabled, opening a popup dialog (e.g. *Add Radio Station*) appeared to do nothing. The main app windows are raised to the `.floating` window level when always-on-top is active, but these transient dialogs opened at the default `.normal` level — so they were drawn *below* the main window and stayed hidden until the user dragged the main window aside.

## Fix
Set the affected dialogs to the `.modalPanel` level when they are shown, so they always sit above the app's floating windows. This matches the established pattern already used by the tag editors (`EditTagsPanel`, `EditAlbumTagsPanel`, `EditVideoTagsPanel`, `TagsPanel`) and `PlexLinkSheet`, which already carried the comment _"Ensure dialog appears above floating windows."_

Dialogs updated (those that lacked an explicit level):
- Add/Edit Radio Station (`AddRadioStationSheet`) — the case reported in the issue
- Subsonic link + server-list sheets
- Jellyfin link + server-list sheets
- Emby link + server-list sheets
- Watch-folder manager (`WatchFolderManagerDialog`)
- Auto-tag album candidate picker (`AutoTagAlbumCandidatePanel`)

Version bumped to 0.26.0; CHANGELOG updated.

## Testing
- `swift build` clean.
- Manual QA: enable Always on Top, then open each dialog and confirm it appears in front of the main window.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed popup dialogs appearing behind always-on-top floating windows. Affected dialogs—including server configuration sheets, watch folder manager, radio station dialogs, and album candidate picker—now display properly above floating panels.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->