### PR TITLE
Fix sibling .cue expansion to use the opened audio as backing

### DIFF
--- a/Sources/NullPlayer/Audio/AudioEngine.swift
+++ b/Sources/NullPlayer/Audio/AudioEngine.swift
@@ -5561,7 +5561,10 @@ class AudioEngine {
         if let siblingCueURL = CueSheet.siblingCue(for: url) {
             do {
                 let cue = try CueSheet.parse(from: siblingCueURL)
-                return CueSheet.expandToTracks(cue: cue, cueFileURL: siblingCueURL)
+                // The opened audio file IS the backing for a sibling cue — use it directly
+                // rather than the cue's FILE line, which may be stale or a leftover
+                // placeholder pointing at a nonexistent file.
+                return CueSheet.expandToTracks(cue: cue, cueFileURL: siblingCueURL, backingOverride: url)
             } catch {
                 NSLog("AudioEngine: Failed to parse sibling .cue for '%@': %@", url.lastPathComponent, error.localizedDescription)
                 return nil

--- a/Sources/NullPlayer/Data/Models/CueSheet.swift
+++ b/Sources/NullPlayer/Data/Models/CueSheet.swift
@@ -233,14 +233,19 @@ struct CueSheet {
     /// Returns empty array if cue is degenerate (no entries or unusable), which signals
     /// callers to fall back to normal Track-from-URL handling (for sibling-cue case) or
     /// log + no-op (for direct .cue open).
-    static func expandToTracks(cue: CueSheet, cueFileURL: URL) -> [Track] {
+    /// - Parameter backingOverride: When non-nil, used as the backing file instead of the
+    ///   cue's `FILE` line. The sibling-cue case passes the audio file the user actually
+    ///   opened — that file *is* the backing, so a stale/wrong `FILE` line in the cue (e.g.
+    ///   a leftover placeholder) can never pin the rows to a nonexistent file.
+    static func expandToTracks(cue: CueSheet, cueFileURL: URL, backingOverride: URL? = nil) -> [Track] {
         // Guard: if no entries, cue is unusable
         guard !cue.entries.isEmpty else {
             return []
         }
 
-        // Resolve the backing file
-        let backingURL = resolveBackingFile(for: cueFileURL, fileName: cue.fileName)
+        // Resolve the backing file: prefer the explicit override (sibling-cue case),
+        // otherwise honor the cue's FILE line (direct .cue open).
+        let backingURL = backingOverride ?? resolveBackingFile(for: cueFileURL, fileName: cue.fileName)
 
         var tracks: [Track] = []
 

--- a/Tests/NullPlayerAppTests/CueSheetTests.swift
+++ b/Tests/NullPlayerAppTests/CueSheetTests.swift
@@ -388,6 +388,58 @@ final class CueSheetTests: XCTestCase {
         XCTAssertEqual(tracks[0].url.path, absPath)
     }
 
+    func testExpandToTracksBackingOverrideTakesPrecedenceOverFileLine() throws {
+        // The cue's FILE line points at a stale/placeholder name that does not exist.
+        // The sibling-cue path passes the audio file the user actually opened as the
+        // override, which must win so rows never pin to the bogus FILE-line path.
+        let cueContent = """
+        PERFORMER "Artist"
+        TITLE "Album"
+        FILE "Placeholder Name.flac" WAVE
+        TRACK 01 AUDIO
+            TITLE "Track One"
+            INDEX 01 00:00:00
+        TRACK 02 AUDIO
+            TITLE "Track Two"
+            INDEX 01 02:00:00
+        """
+
+        let cueURL = tempDirectory.appendingPathComponent("real-audio.cue")
+        try cueContent.write(to: cueURL, atomically: true, encoding: .utf8)
+        let openedAudioURL = tempDirectory.appendingPathComponent("real-audio.flac")
+
+        let cue = try CueSheet.parse(from: cueURL)
+        let tracks = CueSheet.expandToTracks(cue: cue, cueFileURL: cueURL, backingOverride: openedAudioURL)
+
+        XCTAssertEqual(tracks.count, 2)
+        // Every row points at the opened audio file, NOT the cue's FILE line.
+        for track in tracks {
+            XCTAssertEqual(track.url, openedAudioURL)
+        }
+        // Cue offsets are still applied so playback splits within the real backing.
+        XCTAssertEqual(tracks[0].cueStartOffset, 0)
+        XCTAssertEqual(tracks[1].cueStartOffset, 120)
+    }
+
+    func testExpandToTracksWithoutOverrideStillUsesFileLine() throws {
+        // Direct .cue open (no override) must keep honoring the FILE line.
+        let cueContent = """
+        TITLE "Album"
+        FILE "backing.flac" WAVE
+        TRACK 01 AUDIO
+            TITLE "Track One"
+            INDEX 01 00:00:00
+        """
+
+        let cueURL = tempDirectory.appendingPathComponent("direct.cue")
+        try cueContent.write(to: cueURL, atomically: true, encoding: .utf8)
+
+        let cue = try CueSheet.parse(from: cueURL)
+        let tracks = CueSheet.expandToTracks(cue: cue, cueFileURL: cueURL)
+
+        XCTAssertEqual(tracks[0].url, tempDirectory.appendingPathComponent("backing.flac"))
+    }
+
     func testExpandToTracksEmptyEntriesReturnsEmpty() throws {
         let cueContent = """
         PERFORMER "Artist"


### PR DESCRIPTION
## Problem
Playing an audio file that has a same-basename `.cue` beside it expanded the now-playing rows from the cue's `FILE` line (`CueSheet.resolveBackingFile`), **ignoring the audio file the user actually opened**. If that `FILE` line was stale or a leftover placeholder (e.g. `Rush Tribute Concert.flac`), every row pinned to a path that doesn't exist — surfacing as `Failed to load '…': …no such file (code …)` in the main-window title marquee. Editing the `.cue` afterward couldn't fix an already-expanded queue, and a watch-folder rescan couldn't either (direct-play writes nothing to the library).

## Fix
For a **sibling** cue, the opened audio file *is* the backing — so pass it as a new optional `backingOverride` to `CueSheet.expandToTracks`. The override wins over the `FILE` line. Direct `.cue`-open is unchanged and still honors the `FILE` line (it has no other backing to use).

- `CueSheet.expandToTracks(cue:cueFileURL:backingOverride:)` — new optional param.
- `AudioEngine.tracksForCueOrSibling` sibling branch passes `backingOverride: url`.

## Tests
- `testExpandToTracksBackingOverrideTakesPrecedenceOverFileLine` — override wins; cue offsets still applied.
- `testExpandToTracksWithoutOverrideStillUsesFileLine` — direct open unchanged.
- Full suite: 157 existing + 2 new pass; `swift build` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Bug Fixes**
  * Improved handling of cue files located alongside audio files. The player now correctly resolves the audio file backing for cue sheet track expansion, ensuring proper playback when a cue file is paired with its corresponding audio file.

* **Tests**
  * Added test coverage for cue file backing resolution behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->