### PR TITLE
Add Friture-style Audio Analysis window (modern UI)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,13 @@
 # Changelog
 
+## 0.26.0
+
+### New Features
+
+- **Audio Analysis window — Friture-style multi-pane analyzer** — a new modern-UI **Audio Analysis** window (Window menu / right-click → **Audio Analysis**) gives a real-time, multi-pane view of what's playing, modeled on [Friture](https://friture.org). A segmented picker switches between three panes: a **Scope** (oscilloscope) drawing the live mono waveform; a **Levels** meter showing per-channel peak and RMS in dBFS with color-coded headroom; and a **Spectrogram** — a scrolling Metal waterfall that maps each frame's FFT magnitudes through a perceptually-uniform Viridis color ramp (low frequencies at the bottom, time scrolling right-to-left). The window docks and snaps with Main/EQ/Playlist/Spectrum, restores its frame with **Remember State on Quit**, and remembers the selected pane. Each pane registers as an audio consumer only while it's the visible pane and the window is open, so a hidden or closed window leaves the FFT and audio taps idle (the spectrogram also pauses rendering when the window is minimized). The peak/RMS, octave-band, pitch (autocorrelation), and L/R delay (cross-correlation) routines live in a new, unit-tested pure-Swift DSP module shared for future panes. The window is available in modern UI mode.
+
+- **Stereo PCM analysis path** — the audio engine now publishes separate downsampled left/right PCM buffers (`.audioStereoPCMDataUpdated`) alongside the existing mono mix, gated behind its own consumer set so it costs nothing when no analysis pane is open. Wired through both the local playback engine and the streaming-audio delegate route, so the new panes work for local files and HTTP streams alike.
+
 ## 0.25.0
 
 ### New Features

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -28,6 +28,7 @@ Skills contain detailed technical documentation (`skills/` directory):
 - **visualizations**: Index/router across all visualization sub-skills (comparison table, when-to-use)
 - **main-window-visualization**: Main window's 76×16 vis area — modes, switching, settings
 - **spectrum-analyzer-window**: Dedicated 84-bar spectrum window — docking, geometry, analyzer curve, vis_classic waveform demand
+- **audio-analysis-window**: Friture-style multi-pane Audio Analysis window — Scope/Levels/Spectrogram panes, stereo PCM path, per-pane consumer gating, AudioAnalysisDSP module
 - **gpu-vis-modes**: Per-mode shader internals (Fire/JWST/Lightning/Matrix/Snow/EKG) shared by both windows
 - **album-art-visualizer**: Library Browser ART-mode Core Image effects
 - **projectm-milkdrop**: ProjectM/MilkDrop preset engine + drag-suspend behavior

--- a/Package.swift
+++ b/Package.swift
@@ -152,6 +152,7 @@ let package = Package(
             resources: [
                 .copy("Resources"),
                 .copy("Visualization/SpectrumShaders.metal"),
+                .copy("Visualization/SpectrogramShaders.metal"),
                 .copy("Visualization/FlameShaders.metal"),
                 .copy("Visualization/CosmicShaders.metal"),
                 .copy("Visualization/ElectricityShaders.metal"),

--- a/README.md
+++ b/README.md
@@ -36,6 +36,7 @@
 - Classic V1 UI has full support for classic Winamp skin skins (.wsz files)
 - Modern V2 UI skin system, many v2 skins included. Open format, users can easily make new v2 skins via json
 - Original Spenctrum analysis visualization system
+- Audio Analysis window — Friture-style multi-pane analyzer with a live oscilloscope, stereo peak/RMS level meters, and a scrolling Metal spectrogram (Viridis colormap)
 - Album art visualization system with user selected effects
 - Modern mode with 21-band EQ implementation, Classic mode with standard 10-band EQ
 - Reference Tuning for pitch-shifting local playback and HTTP streams to a different reference frequency, with 432 Hz, 440 Hz, and custom source/target Hz options
@@ -359,4 +360,5 @@ Bundled third-party components:
 **Fonts & assets**
 - **Departure Mono** (SIL OFL-1.1) — bundled font
 - **MilkDrop / projectM presets** — community-authored (attribution in preset filenames)
+- **Viridis colormap** (CC0 / public domain) — spectrogram color ramp, by Stéfan van der Walt and Nathaniel Smith
 - **Bundled skins** — original NullPlayer assets

--- a/Sources/NullPlayer/App/AppStateManager.swift
+++ b/Sources/NullPlayer/App/AppStateManager.swift
@@ -185,6 +185,7 @@ class AppStateManager {
         var isPlexBrowserVisible: Bool
         var isProjectMVisible: Bool
         var isSpectrumVisible: Bool = false
+        var isAudioAnalysisVisible: Bool = false
         var isWaveformVisible: Bool = false
         
         // Window frames (as strings for NSRect compatibility)
@@ -194,6 +195,7 @@ class AppStateManager {
         var plexBrowserWindowFrame: String?
         var projectMWindowFrame: String?
         var spectrumWindowFrame: String?
+        var audioAnalysisWindowFrame: String?
         var waveformWindowFrame: String?
         var isProjectMFullscreen: Bool = false
         
@@ -256,8 +258,8 @@ class AppStateManager {
         // MARK: - Custom Decoding for Backward Compatibility
         
         enum CodingKeys: String, CodingKey {
-            case isPlaylistVisible, isEqualizerVisible, isPlexBrowserVisible, isProjectMVisible, isSpectrumVisible, isWaveformVisible
-            case mainWindowFrame, playlistWindowFrame, equalizerWindowFrame, plexBrowserWindowFrame, projectMWindowFrame, spectrumWindowFrame, waveformWindowFrame, isProjectMFullscreen
+            case isPlaylistVisible, isEqualizerVisible, isPlexBrowserVisible, isProjectMVisible, isSpectrumVisible, isAudioAnalysisVisible, isWaveformVisible
+            case mainWindowFrame, playlistWindowFrame, equalizerWindowFrame, plexBrowserWindowFrame, projectMWindowFrame, spectrumWindowFrame, audioAnalysisWindowFrame, waveformWindowFrame, isProjectMFullscreen
             case volume, balance, shuffleEnabled, repeatEnabled, gaplessPlaybackEnabled, volumeNormalizationEnabled
             case sweetFadeEnabled, sweetFadeDuration
             case eqEnabled, eqAutoEnabled, eqPreamp, eqBands
@@ -280,6 +282,7 @@ class AppStateManager {
             isPlexBrowserVisible = try container.decode(Bool.self, forKey: .isPlexBrowserVisible)
             isProjectMVisible = try container.decode(Bool.self, forKey: .isProjectMVisible)
             isSpectrumVisible = try container.decodeIfPresent(Bool.self, forKey: .isSpectrumVisible) ?? false
+            isAudioAnalysisVisible = try container.decodeIfPresent(Bool.self, forKey: .isAudioAnalysisVisible) ?? false
             isWaveformVisible = try container.decodeIfPresent(Bool.self, forKey: .isWaveformVisible) ?? false
             
             // Window frames
@@ -289,6 +292,7 @@ class AppStateManager {
             plexBrowserWindowFrame = try container.decodeIfPresent(String.self, forKey: .plexBrowserWindowFrame)
             projectMWindowFrame = try container.decodeIfPresent(String.self, forKey: .projectMWindowFrame)
             spectrumWindowFrame = try container.decodeIfPresent(String.self, forKey: .spectrumWindowFrame)
+            audioAnalysisWindowFrame = try container.decodeIfPresent(String.self, forKey: .audioAnalysisWindowFrame)
             waveformWindowFrame = try container.decodeIfPresent(String.self, forKey: .waveformWindowFrame)
             isProjectMFullscreen = try container.decodeIfPresent(Bool.self, forKey: .isProjectMFullscreen) ?? false
             
@@ -355,6 +359,7 @@ class AppStateManager {
             isPlexBrowserVisible: Bool,
             isProjectMVisible: Bool,
             isSpectrumVisible: Bool = false,
+            isAudioAnalysisVisible: Bool = false,
             isWaveformVisible: Bool = false,
             mainWindowFrame: String?,
             playlistWindowFrame: String?,
@@ -362,6 +367,7 @@ class AppStateManager {
             plexBrowserWindowFrame: String?,
             projectMWindowFrame: String?,
             spectrumWindowFrame: String? = nil,
+            audioAnalysisWindowFrame: String? = nil,
             waveformWindowFrame: String? = nil,
             isProjectMFullscreen: Bool = false,
             volume: Float,
@@ -396,6 +402,7 @@ class AppStateManager {
             self.isPlexBrowserVisible = isPlexBrowserVisible
             self.isProjectMVisible = isProjectMVisible
             self.isSpectrumVisible = isSpectrumVisible
+            self.isAudioAnalysisVisible = isAudioAnalysisVisible
             self.isWaveformVisible = isWaveformVisible
             self.mainWindowFrame = mainWindowFrame
             self.playlistWindowFrame = playlistWindowFrame
@@ -403,6 +410,7 @@ class AppStateManager {
             self.plexBrowserWindowFrame = plexBrowserWindowFrame
             self.projectMWindowFrame = projectMWindowFrame
             self.spectrumWindowFrame = spectrumWindowFrame
+            self.audioAnalysisWindowFrame = audioAnalysisWindowFrame
             self.waveformWindowFrame = waveformWindowFrame
             self.isProjectMFullscreen = isProjectMFullscreen
             self.volume = volume
@@ -483,6 +491,7 @@ class AppStateManager {
             isPlexBrowserVisible: wm.isPlexBrowserVisible,
             isProjectMVisible: wm.isProjectMVisible,
             isSpectrumVisible: wm.isSpectrumVisible,
+            isAudioAnalysisVisible: wm.isAudioAnalysisVisible,
             isWaveformVisible: wm.isWaveformVisible,
             
             // Window frames
@@ -493,6 +502,7 @@ class AppStateManager {
             // Don't save frame when fullscreen (it would be screen bounds)
             projectMWindowFrame: wm.isProjectMVisible && !wm.isProjectMFullscreen ? wm.projectMWindowFrame.map { NSStringFromRect($0) } : nil,
             spectrumWindowFrame: wm.spectrumWindowFrame.map { NSStringFromRect($0) },
+            audioAnalysisWindowFrame: wm.audioAnalysisWindowFrame.map { NSStringFromRect($0) },
             waveformWindowFrame: nil,
             isProjectMFullscreen: wm.isProjectMFullscreen,
             
@@ -718,6 +728,7 @@ class AppStateManager {
         let browserFrame = modeMatches ? state.plexBrowserWindowFrame.flatMap({ NSRectFromString($0) }) : nil
         let projectMFrame = modeMatches ? state.projectMWindowFrame.flatMap({ NSRectFromString($0) }) : nil
         let spectrumFrame = modeMatches ? state.spectrumWindowFrame.flatMap({ NSRectFromString($0) }) : nil
+        let audioAnalysisFrame = modeMatches ? state.audioAnalysisWindowFrame.flatMap({ NSRectFromString($0) }) : nil
         let waveformFrame = modeMatches ? state.waveformWindowFrame.flatMap({ NSRectFromString($0) }) : nil
         let projectMPresetIndex = state.projectMPresetIndex
         let visualizationEngineType = UserDefaults.standard.string(forKey: "visualizationEngineType")
@@ -744,6 +755,9 @@ class AppStateManager {
             }
             if state.isSpectrumVisible {
                 wm.showSpectrum(at: spectrumFrame)
+            }
+            if state.isAudioAnalysisVisible {
+                wm.showAudioAnalysis(at: audioAnalysisFrame)
             }
             if state.isWaveformVisible {
                 wm.showWaveform(at: waveformFrame)

--- a/Sources/NullPlayer/App/AudioAnalysisWindowProviding.swift
+++ b/Sources/NullPlayer/App/AudioAnalysisWindowProviding.swift
@@ -1,0 +1,20 @@
+import AppKit
+
+/// Protocol abstracting the audio analysis window.
+/// Both modern and classic (if added) implementations conform to this protocol.
+/// `WindowManager` holds a reference to whichever is active.
+///
+/// Audio Analysis windows are modern-only in this MVP.
+protocol AudioAnalysisWindowProviding: AnyObject {
+    /// The underlying window
+    var window: NSWindow? { get }
+
+    /// Show the window
+    func showWindow(_ sender: Any?)
+
+    /// Notify that the skin has changed and views should redraw
+    func skinDidChange()
+
+    /// Stop rendering when window is hidden via orderOut (saves CPU)
+    func stopRenderingForHide()
+}

--- a/Sources/NullPlayer/App/ContextMenuBuilder.swift
+++ b/Sources/NullPlayer/App/ContextMenuBuilder.swift
@@ -85,7 +85,7 @@ class ContextMenuBuilder {
         menu.addItem(buildWindowItem("Equalizer", visible: wm.isEqualizerVisible, action: #selector(MenuActions.toggleEQ)))
         menu.addItem(buildWindowItem("Playlist Editor", visible: wm.isPlaylistVisible, action: #selector(MenuActions.togglePlaylist)))
         menu.addItem(buildWindowItem("Spectrum Analyzer", visible: wm.isSpectrumVisible, action: #selector(MenuActions.toggleSpectrum)))
-        if wm.isModernUIEnabled {
+        if wm.isRunningModernUI {
             menu.addItem(buildWindowItem("Audio Analysis", visible: wm.isAudioAnalysisVisible, action: #selector(MenuActions.toggleAudioAnalysis)))
         }
         menu.addItem(buildWindowItem("Waveform", visible: wm.isWaveformVisible, action: #selector(MenuActions.toggleWaveform)))

--- a/Sources/NullPlayer/App/ContextMenuBuilder.swift
+++ b/Sources/NullPlayer/App/ContextMenuBuilder.swift
@@ -85,6 +85,9 @@ class ContextMenuBuilder {
         menu.addItem(buildWindowItem("Equalizer", visible: wm.isEqualizerVisible, action: #selector(MenuActions.toggleEQ)))
         menu.addItem(buildWindowItem("Playlist Editor", visible: wm.isPlaylistVisible, action: #selector(MenuActions.togglePlaylist)))
         menu.addItem(buildWindowItem("Spectrum Analyzer", visible: wm.isSpectrumVisible, action: #selector(MenuActions.toggleSpectrum)))
+        if wm.isModernUIEnabled {
+            menu.addItem(buildWindowItem("Audio Analysis", visible: wm.isAudioAnalysisVisible, action: #selector(MenuActions.toggleAudioAnalysis)))
+        }
         menu.addItem(buildWindowItem("Waveform", visible: wm.isWaveformVisible, action: #selector(MenuActions.toggleWaveform)))
         menu.addItem(buildWindowItem("Library Browser", visible: wm.isPlexBrowserVisible, action: #selector(MenuActions.togglePlexBrowser)))
         if wm.isRunningModernUI {
@@ -2894,6 +2897,10 @@ class MenuActions: NSObject {
     
     @objc func toggleSpectrum() {
         WindowManager.shared.toggleSpectrum()
+    }
+
+    @objc func toggleAudioAnalysis() {
+        WindowManager.shared.toggleAudioAnalysis()
     }
 
     @objc func toggleWaveform() {

--- a/Sources/NullPlayer/App/WindowManager.swift
+++ b/Sources/NullPlayer/App/WindowManager.swift
@@ -363,6 +363,9 @@ class WindowManager {
     /// Spectrum analyzer window controller (classic or modern, accessed via protocol)
     private var spectrumWindowController: SpectrumWindowProviding?
 
+    /// Audio analysis window controller (modern-only, accessed via protocol)
+    private var audioAnalysisWindowController: AudioAnalysisWindowProviding?
+
     /// Shared vis_classic bridge — created on first use, driven by audioWaveform576DataUpdated notifications.
     private(set) var sharedVisClassicBridge: VisClassicBridge?
 
@@ -678,6 +681,7 @@ class WindowManager {
         if let w = equalizerWindowController?.window, w.isVisible, w !== window { visibleWindows.append(w) }
         if let w = playlistWindowController?.window, w.isVisible, w !== window { visibleWindows.append(w) }
         if let w = spectrumWindowController?.window, w.isVisible, w !== window { visibleWindows.append(w) }
+        if let w = audioAnalysisWindowController?.window, w.isVisible, w !== window { visibleWindows.append(w) }
         if let w = waveformWindowController?.window, w.isVisible, w !== window { visibleWindows.append(w) }
         
         // Sort top-to-bottom (highest minY first, since macOS Y increases upward)
@@ -1647,6 +1651,57 @@ class WindowManager {
         }
         notifyMainWindowVisibilityChanged()
         _ = tightenClassicCenterStackIfNeeded()
+        postLayoutChangeNotification()
+        updateDockedChildWindows()
+    }
+
+    // MARK: - Audio Analysis Window
+
+    func showAudioAnalysis(at restoredFrame: NSRect? = nil) {
+        guard isModernUIEnabled else { return }
+
+        let isNewWindow = audioAnalysisWindowController == nil
+        if isNewWindow {
+            audioAnalysisWindowController = ModernAudioAnalysisWindowController()
+        }
+
+        if let window = audioAnalysisWindowController?.window {
+            if let frame = restoredFrame, frame != .zero {
+                window.setFrame(frame, display: true)
+            } else {
+                positionSubWindow(window)
+            }
+        }
+
+        audioAnalysisWindowController?.showWindow(nil)
+        applyAlwaysOnTopToWindow(audioAnalysisWindowController?.window)
+        notifyMainWindowVisibilityChanged()
+        postLayoutChangeNotification()
+    }
+
+    var isAudioAnalysisVisible: Bool {
+        audioAnalysisWindowController?.window?.isVisible == true
+    }
+
+    /// Get the Audio Analysis window frame (for state saving)
+    var audioAnalysisWindowFrame: NSRect? {
+        return audioAnalysisWindowController?.window?.frame
+    }
+
+    func toggleAudioAnalysis() {
+        guard isModernUIEnabled else { return }
+
+        if let controller = audioAnalysisWindowController,
+           let window = controller.window,
+           window.isVisible {
+            let closingFrame = window.frame
+            controller.stopRenderingForHide()
+            window.orderOut(nil)
+            slideUpWindowsBelow(closingFrame: closingFrame)
+        } else {
+            showAudioAnalysis()
+        }
+        notifyMainWindowVisibilityChanged()
         postLayoutChangeNotification()
         updateDockedChildWindows()
     }
@@ -3564,10 +3619,11 @@ class WindowManager {
         if let w = videoPlayerWindowController?.window, w.isVisible { windows.append(w) }
         if let w = projectMWindowController?.window, w.isVisible { windows.append(w) }
         if let w = spectrumWindowController?.window, w.isVisible { windows.append(w) }
+        if let w = audioAnalysisWindowController?.window, w.isVisible { windows.append(w) }
         if let w = waveformWindowController?.window, w.isVisible { windows.append(w) }
         return windows
     }
-    
+
     /// Get windows that participate in docking/snapping together (classic skin windows)
     private func dockableWindows() -> [NSWindow] {
         var windows: [NSWindow] = []
@@ -3575,6 +3631,7 @@ class WindowManager {
         if let w = playlistWindowController?.window, w.isVisible { windows.append(w) }
         if let w = equalizerWindowController?.window, w.isVisible { windows.append(w) }
         if let w = spectrumWindowController?.window, w.isVisible { windows.append(w) }
+        if let w = audioAnalysisWindowController?.window, w.isVisible { windows.append(w) }
         if let w = waveformWindowController?.window, w.isVisible { windows.append(w) }
         return windows
     }

--- a/Sources/NullPlayer/App/WindowManager.swift
+++ b/Sources/NullPlayer/App/WindowManager.swift
@@ -331,7 +331,8 @@ class WindowManager {
         let isSubWindow = window === equalizerWindowController?.window ||
                           window === playlistWindowController?.window ||
                           window === spectrumWindowController?.window ||
-                          window === waveformWindowController?.window
+                          window === waveformWindowController?.window ||
+                          window === audioAnalysisWindowController?.window
         if isSubWindow && isWindowDocked(window) {
             return true
         }
@@ -1666,9 +1667,11 @@ class WindowManager {
         }
 
         if let window = audioAnalysisWindowController?.window {
+            applyCenterStackSizingConstraints(window, kind: .audioAnalysis)
             if let frame = restoredFrame, frame != .zero {
-                window.setFrame(frame, display: true)
+                window.setFrame(normalizedCenterStackRestoredFrame(frame, kind: .audioAnalysis), display: true)
             } else {
+                applyDefaultCenterStackFrameForCurrentHT(window, kind: .audioAnalysis)
                 positionSubWindow(window)
             }
         }
@@ -2318,6 +2321,32 @@ class WindowManager {
             }
         }
         
+        // Audio Analysis window - position below previous stack window (modern-only).
+        if let audioAnalysisWindow = audioAnalysisWindowController?.window {
+            let minHeight = expectedMainHeightForCurrentHT(mainWindowController?.window)
+            let minWidth = ModernSkinElements.spectrumMinSize.width
+            audioAnalysisWindow.minSize = NSSize(width: minWidth, height: minHeight)
+            audioAnalysisWindow.maxSize = NSSize(width: CGFloat.greatestFiniteMagnitude, height: CGFloat.greatestFiniteMagnitude)
+
+            let currentFrame = audioAnalysisWindow.frame
+            let heightScaleMultiplier: CGFloat = isDoubleSize ? classicScaleMultiplier : classicInverseScaleMultiplier
+            let widthScaleMultiplier: CGFloat = isDoubleSize ? classicScaleMultiplier : classicInverseScaleMultiplier
+            let newHeight = max(minHeight, currentFrame.height * heightScaleMultiplier)
+            let newWidth = max(minWidth, currentFrame.width * widthScaleMultiplier)
+            if audioAnalysisWindow.isVisible {
+                let analysisFrame = NSRect(
+                    x: mainFrame.minX,
+                    y: nextY - newHeight,
+                    width: newWidth,
+                    height: newHeight
+                )
+                audioAnalysisWindow.setFrame(analysisFrame, display: true, animate: false)
+                nextY = analysisFrame.minY
+            } else {
+                audioAnalysisWindow.setContentSize(NSSize(width: newWidth, height: newHeight))
+            }
+        }
+
         // Side windows - match the vertical stack height and reposition
         let stackTopY = mainFrame.maxY
         let stackHeight = stackTopY - nextY
@@ -2459,6 +2488,7 @@ class WindowManager {
         case playlist
         case spectrum
         case waveform
+        case audioAnalysis
     }
 
     private func centerStackWindowKind(for window: NSWindow) -> CenterStackWindowKind? {
@@ -2466,6 +2496,7 @@ class WindowManager {
         if window === playlistWindowController?.window { return .playlist }
         if window === spectrumWindowController?.window { return .spectrum }
         if window === waveformWindowController?.window { return .waveform }
+        if window === audioAnalysisWindowController?.window { return .audioAnalysis }
         return nil
     }
 
@@ -2501,6 +2532,10 @@ class WindowManager {
         case .waveform:
             window.minSize = NSSize(width: ModernSkinElements.waveformMinSize.width, height: targetHeight)
             window.maxSize = NSSize(width: CGFloat.greatestFiniteMagnitude, height: CGFloat.greatestFiniteMagnitude)
+        case .audioAnalysis:
+            // Matches the center-stack width; stretchable in height like spectrum/playlist.
+            window.minSize = NSSize(width: ModernSkinElements.spectrumMinSize.width, height: targetHeight)
+            window.maxSize = NSSize(width: CGFloat.greatestFiniteMagnitude, height: CGFloat.greatestFiniteMagnitude)
         }
     }
 
@@ -2531,7 +2566,7 @@ class WindowManager {
         switch kind {
         case .equalizer, .spectrum:
             normalized.size.height = target
-        case .playlist, .waveform:
+        case .playlist, .waveform, .audioAnalysis:
             // Accept legacy compact saved frames but normalize to current full-height minimum.
             normalized.size.height = max(target, normalized.height)
         }

--- a/Sources/NullPlayer/App/WindowManager.swift
+++ b/Sources/NullPlayer/App/WindowManager.swift
@@ -245,6 +245,7 @@ class WindowManager {
             let subWindows = [equalizerWindowController?.window,
                               playlistWindowController?.window,
                               spectrumWindowController?.window,
+                              audioAnalysisWindowController?.window,
                               waveformWindowController?.window].compactMap { $0 }
             var windowsBelow: [NSWindow] = []
             var frontier: [NSRect] = [mainWindow.frame]
@@ -305,6 +306,7 @@ class WindowManager {
                            equalizerWindowController as? NSWindowController,
                            playlistWindowController as? NSWindowController,
                            spectrumWindowController as? NSWindowController,
+                           audioAnalysisWindowController as? NSWindowController,
                            waveformWindowController as? NSWindowController,
                            projectMWindowController as? NSWindowController,
                            plexBrowserWindowController as? NSWindowController] {
@@ -732,6 +734,7 @@ class WindowManager {
         let subWindows = [equalizerWindowController?.window,
                           playlistWindowController?.window,
                           spectrumWindowController?.window,
+                          audioAnalysisWindowController?.window,
                           waveformWindowController?.window].compactMap { $0 }
 
         // BFS: find windows directly docked below closingFrame, then those below them
@@ -1659,7 +1662,7 @@ class WindowManager {
     // MARK: - Audio Analysis Window
 
     func showAudioAnalysis(at restoredFrame: NSRect? = nil) {
-        guard isModernUIEnabled else { return }
+        guard isRunningModernUI else { return }
 
         let isNewWindow = audioAnalysisWindowController == nil
         if isNewWindow {
@@ -1692,7 +1695,7 @@ class WindowManager {
     }
 
     func toggleAudioAnalysis() {
-        guard isModernUIEnabled else { return }
+        guard isRunningModernUI else { return }
 
         if let controller = audioAnalysisWindowController,
            let window = controller.window,
@@ -2389,6 +2392,7 @@ class WindowManager {
         videoPlayerWindowController?.window?.level = level
         projectMWindowController?.window?.level = level
         spectrumWindowController?.window?.level = level
+        audioAnalysisWindowController?.window?.level = level
         waveformWindowController?.window?.level = level
     }
     
@@ -2408,6 +2412,7 @@ class WindowManager {
             equalizerWindowController?.window,
             playlistWindowController?.window,
             spectrumWindowController?.window,
+            audioAnalysisWindowController?.window,
             waveformWindowController?.window,
             videoPlayerWindowController?.window,
             projectMWindowController?.window,
@@ -2433,6 +2438,7 @@ class WindowManager {
         let subWindows = [equalizerWindowController?.window,
                           playlistWindowController?.window,
                           spectrumWindowController?.window,
+                          audioAnalysisWindowController?.window,
                           waveformWindowController?.window].compactMap { $0 }
         var docked: [NSWindow] = []
         var frontier: [NSRect] = [mainFrame]
@@ -3692,6 +3698,7 @@ class WindowManager {
                window === playlistWindowController?.window ||
                window === equalizerWindowController?.window ||
                window === spectrumWindowController?.window ||
+               window === audioAnalysisWindowController?.window ||
                window === waveformWindowController?.window
     }
     

--- a/Sources/NullPlayer/Audio/AudioEngine.swift
+++ b/Sources/NullPlayer/Audio/AudioEngine.swift
@@ -4333,9 +4333,10 @@ class AudioEngine {
             streamingPlayer?.delegate = self
             streamingPlayer?.spectrumNeeded = spectrumNeeded
             streamingPlayer?.waveformNeeded = waveformNeeded
+            streamingPlayer?.stereoNeeded = stereoNeeded
             streamingPlayer?.isModernUIEnabled = isModernUIEnabled
         }
-        
+
         // Sync EQ settings from main EQ to streaming player
         syncEQToStreamingPlayer()
         
@@ -5150,6 +5151,7 @@ class AudioEngine {
         streamingPlayer?.delegate = self
         streamingPlayer?.spectrumNeeded = spectrumNeeded
         streamingPlayer?.waveformNeeded = waveformNeeded
+        streamingPlayer?.stereoNeeded = stereoNeeded
         streamingPlayer?.isModernUIEnabled = isModernUIEnabled
         // crossfadeStreamingPlayer (old primary) already has nil delegate from above
         

--- a/Sources/NullPlayer/Audio/AudioEngine.swift
+++ b/Sources/NullPlayer/Audio/AudioEngine.swift
@@ -14,6 +14,10 @@ extension Notification.Name {
     /// userInfo contains: "pcm" ([Float]), "sampleRate" (Double)
     static let audioPCMDataUpdated = Notification.Name("audioPCMDataUpdated")
 
+    /// Posted when new stereo PCM audio data is available for analysis
+    /// userInfo contains: "left" ([Float]), "right" ([Float]), "sampleRate" (Double)
+    static let audioStereoPCMDataUpdated = Notification.Name("audioStereoPCMDataUpdated")
+
     /// Posted when new spectrum data is available for visualization
     /// userInfo contains: "spectrum" ([Float]) - 75 bands normalized 0-1
     static let audioSpectrumDataUpdated = Notification.Name("audioSpectrumDataUpdated")
@@ -461,9 +465,12 @@ class AudioEngine {
 
     /// Spectrum consumers — FFT is skipped entirely when this set is empty
     private var spectrumConsumers = Set<String>()
-    
+
     /// Live waveform consumers — 576-sample waveform chunk generation is skipped entirely when this set is empty.
     private var waveformConsumers = Set<String>()
+
+    /// Stereo PCM consumers — stereo tap is skipped entirely when this set is empty
+    private var stereoConsumers = Set<String>()
 
     /// Cached value of modernUIEnabled to avoid 60x/sec UserDefaults reads
     private var isModernUIEnabled: Bool
@@ -496,6 +503,18 @@ class AudioEngine {
 
     var waveformNeeded: Bool { !waveformConsumers.isEmpty }
 
+    func addStereoConsumer(_ id: String) {
+        stereoConsumers.insert(id)
+        streamingPlayer?.stereoNeeded = !stereoConsumers.isEmpty
+    }
+
+    func removeStereoConsumer(_ id: String) {
+        stereoConsumers.remove(id)
+        streamingPlayer?.stereoNeeded = !stereoConsumers.isEmpty
+    }
+
+    var stereoNeeded: Bool { !stereoConsumers.isEmpty }
+
     // MARK: - Pre-allocated FFT Buffers (Memory Optimization)
 
     /// Pre-allocated buffers to avoid per-callback allocations
@@ -509,7 +528,10 @@ class AudioEngine {
     private var fftLogMagnitudes = [Float](repeating: 0, count: 1024)
     private var fftNewSpectrum = [Float](repeating: 0, count: 75)
     private var fftPcmSamples = [Float](repeating: 0, count: 512)
-    
+    /// Pre-allocated stereo PCM buffers (512 samples each for left and right channels)
+    private var stereoPcmLeft = [Float](repeating: 0, count: 512)
+    private var stereoPcmRight = [Float](repeating: 0, count: 512)
+
     /// Pre-computed frequency weights for spectrum analyzer (light compensation)
     private let spectrumFrequencyWeights: [Float] = {
         // Generate weights for 75 bands spanning 20Hz-20kHz logarithmically
@@ -1450,7 +1472,7 @@ class AudioEngine {
     }
     
     private func processAudioBuffer(_ buffer: AVAudioPCMBuffer) {
-        guard spectrumNeeded || waveformNeeded else { return }
+        guard spectrumNeeded || waveformNeeded || stereoNeeded else { return }
         guard let channelData = buffer.floatChannelData else { return }
 
         let frameCount = Int(buffer.frameLength)
@@ -1522,7 +1544,41 @@ class AudioEngine {
                 self.pcmData = pcmForMain
             }
         }
-        
+
+        // Publish stereo PCM data when needed (independent of spectrum)
+        if stereoNeeded && frameCount >= 512 {
+            let pcmSize = 512
+            let pcmStride = frameCount / pcmSize
+            // Extract and downsample left and right channels
+            if channelCount == 1 {
+                // Mono: duplicate to both channels
+                for i in 0..<pcmSize {
+                    let sample = channelData[0][i * pcmStride]
+                    stereoPcmLeft[i] = sample
+                    stereoPcmRight[i] = sample
+                }
+            } else {
+                // Stereo: separate channels
+                for i in 0..<pcmSize {
+                    stereoPcmLeft[i] = channelData[0][i * pcmStride]
+                    stereoPcmRight[i] = channelData[1][i * pcmStride]
+                }
+            }
+
+            // Post notification with left/right copies
+            let leftCopy = Array(stereoPcmLeft)
+            let rightCopy = Array(stereoPcmRight)
+            NotificationCenter.default.post(
+                name: .audioStereoPCMDataUpdated,
+                object: self,
+                userInfo: [
+                    "left": leftCopy,
+                    "right": rightCopy,
+                    "sampleRate": bufferSampleRate
+                ]
+            )
+        }
+
         // Apply Hann window - use pre-allocated buffers
         vDSP_hann_window(&fftWindow, vDSP_Length(fftSize), Int32(vDSP_HANN_NORM))
         vDSP_vmul(fftSamples, 1, fftWindow, 1, &fftSamples, 1, vDSP_Length(fftSize))
@@ -5962,7 +6018,7 @@ extension AudioEngine: StreamingAudioPlayerDelegate {
         for i in copyCount..<pcmData.count {
             pcmData[i] = 0
         }
-        
+
         // Post notification for low-latency visualization
         // Use pcmData (not samples) to ensure consistency with stored property
         pcmUserInfo["pcm"] = pcmData
@@ -5973,7 +6029,20 @@ extension AudioEngine: StreamingAudioPlayerDelegate {
             userInfo: pcmUserInfo
         )
     }
-    
+
+    func streamingPlayerDidUpdateStereoPCM(left: [Float], right: [Float], sampleRate: Double) {
+        // Forward stereo PCM data from streaming player for analysis
+        NotificationCenter.default.post(
+            name: .audioStereoPCMDataUpdated,
+            object: self,
+            userInfo: [
+                "left": left,
+                "right": right,
+                "sampleRate": sampleRate
+            ]
+        )
+    }
+
     func streamingPlayerDidDetectFormat(sampleRate: Int, channels: Int) {
         // Update current track with format info detected from the stream
         // This fills in sample rate for Plex tracks which don't have it in metadata

--- a/Sources/NullPlayer/Audio/AudioEngine.swift
+++ b/Sources/NullPlayer/Audio/AudioEngine.swift
@@ -1489,62 +1489,6 @@ class AudioEngine {
             )
         }
 
-        guard spectrumNeeded, frameCount >= fftSize, let fftSetup = fftSetup else { return }
-        
-        // Throttle updates to 60Hz max to prevent memory buildup
-        let now = CFAbsoluteTimeGetCurrent()
-        let shouldUpdate = now - lastSpectrumUpdateTime >= spectrumUpdateInterval
-        guard shouldUpdate else { return }
-        lastSpectrumUpdateTime = now
-        
-        // Get audio samples (mono mix if stereo) - use pre-allocated buffer
-        if channelCount == 1 {
-            memcpy(&fftSamples, channelData[0], fftSize * MemoryLayout<Float>.size)
-        } else {
-            // Mix stereo to mono
-            for i in 0..<fftSize {
-                fftSamples[i] = (channelData[0][i] + channelData[1][i]) / 2.0
-            }
-        }
-        
-        // Feed BPM detector with raw mono samples before windowing.
-        fftSamples.withUnsafeBufferPointer { ptr in
-            if let base = ptr.baseAddress {
-                bpmDetector.process(samples: base, count: fftSize, sampleRate: buffer.format.sampleRate)
-            }
-        }
-        
-        // Store raw PCM data for waveform visualization (before windowing)
-        // Downsample to 512 samples for efficient storage and lowest latency
-        let pcmSize = 512
-        let pcmStride = fftSize / pcmSize
-        for i in 0..<pcmSize {
-            fftPcmSamples[i] = fftSamples[i * pcmStride]
-        }
-        
-        // Post notification for low-latency visualization (direct from audio tap)
-        // Copy to avoid data races since we reuse the buffer
-        let pcmCopy = Array(fftPcmSamples)
-        pcmUserInfo["pcm"] = pcmCopy
-        pcmUserInfo["sampleRate"] = bufferSampleRate
-        NotificationCenter.default.post(
-            name: .audioPCMDataUpdated,
-            object: self,
-            userInfo: pcmUserInfo
-        )
-
-        // Also store in property for legacy access - coalesce dispatches
-        if !pendingPcmUpdate {
-            pendingPcmUpdate = true
-            let pcmForMain = pcmCopy
-            DispatchQueue.main.async { [weak self] in
-                guard let self = self else { return }
-                self.pendingPcmUpdate = false
-                self.pcmSampleRate = bufferSampleRate
-                self.pcmData = pcmForMain
-            }
-        }
-
         // Publish stereo PCM data when needed (independent of spectrum)
         if stereoNeeded && frameCount >= 512 {
             let pcmSize = 512
@@ -1577,6 +1521,62 @@ class AudioEngine {
                     "sampleRate": bufferSampleRate
                 ]
             )
+        }
+
+        guard spectrumNeeded, frameCount >= fftSize, let fftSetup = fftSetup else { return }
+
+        // Throttle updates to 60Hz max to prevent memory buildup
+        let now = CFAbsoluteTimeGetCurrent()
+        let shouldUpdate = now - lastSpectrumUpdateTime >= spectrumUpdateInterval
+        guard shouldUpdate else { return }
+        lastSpectrumUpdateTime = now
+
+        // Get audio samples (mono mix if stereo) - use pre-allocated buffer
+        if channelCount == 1 {
+            memcpy(&fftSamples, channelData[0], fftSize * MemoryLayout<Float>.size)
+        } else {
+            // Mix stereo to mono
+            for i in 0..<fftSize {
+                fftSamples[i] = (channelData[0][i] + channelData[1][i]) / 2.0
+            }
+        }
+
+        // Feed BPM detector with raw mono samples before windowing.
+        fftSamples.withUnsafeBufferPointer { ptr in
+            if let base = ptr.baseAddress {
+                bpmDetector.process(samples: base, count: fftSize, sampleRate: buffer.format.sampleRate)
+            }
+        }
+
+        // Store raw PCM data for waveform visualization (before windowing)
+        // Downsample to 512 samples for efficient storage and lowest latency
+        let pcmSize = 512
+        let pcmStride = fftSize / pcmSize
+        for i in 0..<pcmSize {
+            fftPcmSamples[i] = fftSamples[i * pcmStride]
+        }
+
+        // Post notification for low-latency visualization (direct from audio tap)
+        // Copy to avoid data races since we reuse the buffer
+        let pcmCopy = Array(fftPcmSamples)
+        pcmUserInfo["pcm"] = pcmCopy
+        pcmUserInfo["sampleRate"] = bufferSampleRate
+        NotificationCenter.default.post(
+            name: .audioPCMDataUpdated,
+            object: self,
+            userInfo: pcmUserInfo
+        )
+
+        // Also store in property for legacy access - coalesce dispatches
+        if !pendingPcmUpdate {
+            pendingPcmUpdate = true
+            let pcmForMain = pcmCopy
+            DispatchQueue.main.async { [weak self] in
+                guard let self = self else { return }
+                self.pendingPcmUpdate = false
+                self.pcmSampleRate = bufferSampleRate
+                self.pcmData = pcmForMain
+            }
         }
 
         // Apply Hann window - use pre-allocated buffers

--- a/Sources/NullPlayer/Audio/StreamingAudioPlayer.swift
+++ b/Sources/NullPlayer/Audio/StreamingAudioPlayer.swift
@@ -448,58 +448,6 @@ class StreamingAudioPlayer {
             )
         }
 
-        guard spectrumNeeded, frameCount >= fftSize, let fftSetup = fftSetup else { return }
-
-        // Get audio samples (mono mix if stereo) - use pre-allocated buffer
-        if channelCount == 1 {
-            memcpy(&fftSamples, channelData[0], fftSize * MemoryLayout<Float>.size)
-        } else {
-            // Mix stereo to mono
-            for i in 0..<fftSize {
-                fftSamples[i] = (channelData[0][i] + channelData[1][i]) / 2.0
-            }
-        }
-
-        // Compensate for volume so visualization is volume-independent
-        // The frameFiltering tap captures audio after volume is applied, so we divide by volume
-        // to recover the original signal level for visualization purposes
-        if volumeCompensation > 1.0 {
-            var compensation = volumeCompensation
-            vDSP_vsmul(fftSamples, 1, &compensation, &fftSamples, 1, vDSP_Length(fftSize))
-        }
-
-        // Throttle updates to 60Hz max to prevent memory buildup
-        let now = CFAbsoluteTimeGetCurrent()
-        let shouldUpdate = now - lastSpectrumUpdateTime >= spectrumUpdateInterval
-        guard shouldUpdate else { return }
-        lastSpectrumUpdateTime = now
-        
-        // Feed BPM detector with raw mono samples before windowing.
-        fftSamples.withUnsafeBufferPointer { ptr in
-            if let base = ptr.baseAddress {
-                bpmDetector.process(samples: base, count: fftSize, sampleRate: buffer.format.sampleRate)
-            }
-        }
-        
-        // Forward PCM data for projectM visualization
-        // Downsample to 512 samples for efficient visualization and lowest latency
-        let pcmSize = 512
-        let stride = fftSize / pcmSize
-        for i in 0..<pcmSize {
-            fftPcmSamples[i] = fftSamples[i * stride]
-        }
-        
-        // Coalesce PCM updates to prevent main queue buildup
-        if !pendingPcmUpdate {
-            pendingPcmUpdate = true
-            let pcmCopy = Array(fftPcmSamples)
-            DispatchQueue.main.async { [weak self] in
-                guard let self = self else { return }
-                self.pendingPcmUpdate = false
-                self.delegate?.streamingPlayerDidUpdatePCM(pcmCopy)
-            }
-        }
-
         // Publish stereo PCM data when needed (independent of spectrum)
         if stereoNeeded && frameCount >= 512 {
             let pcmSize = 512
@@ -538,6 +486,58 @@ class StreamingAudioPlayer {
                     self.pendingStereoPcmUpdate = false
                     self.delegate?.streamingPlayerDidUpdateStereoPCM(left: leftCopy, right: rightCopy, sampleRate: sampleRateDouble)
                 }
+            }
+        }
+
+        guard spectrumNeeded, frameCount >= fftSize, let fftSetup = fftSetup else { return }
+
+        // Get audio samples (mono mix if stereo) - use pre-allocated buffer
+        if channelCount == 1 {
+            memcpy(&fftSamples, channelData[0], fftSize * MemoryLayout<Float>.size)
+        } else {
+            // Mix stereo to mono
+            for i in 0..<fftSize {
+                fftSamples[i] = (channelData[0][i] + channelData[1][i]) / 2.0
+            }
+        }
+
+        // Compensate for volume so visualization is volume-independent
+        // The frameFiltering tap captures audio after volume is applied, so we divide by volume
+        // to recover the original signal level for visualization purposes
+        if volumeCompensation > 1.0 {
+            var compensation = volumeCompensation
+            vDSP_vsmul(fftSamples, 1, &compensation, &fftSamples, 1, vDSP_Length(fftSize))
+        }
+
+        // Throttle updates to 60Hz max to prevent memory buildup
+        let now = CFAbsoluteTimeGetCurrent()
+        let shouldUpdate = now - lastSpectrumUpdateTime >= spectrumUpdateInterval
+        guard shouldUpdate else { return }
+        lastSpectrumUpdateTime = now
+
+        // Feed BPM detector with raw mono samples before windowing.
+        fftSamples.withUnsafeBufferPointer { ptr in
+            if let base = ptr.baseAddress {
+                bpmDetector.process(samples: base, count: fftSize, sampleRate: buffer.format.sampleRate)
+            }
+        }
+
+        // Forward PCM data for projectM visualization
+        // Downsample to 512 samples for efficient visualization and lowest latency
+        let pcmSize = 512
+        let stride = fftSize / pcmSize
+        for i in 0..<pcmSize {
+            fftPcmSamples[i] = fftSamples[i * stride]
+        }
+
+        // Coalesce PCM updates to prevent main queue buildup
+        if !pendingPcmUpdate {
+            pendingPcmUpdate = true
+            let pcmCopy = Array(fftPcmSamples)
+            DispatchQueue.main.async { [weak self] in
+                guard let self = self else { return }
+                self.pendingPcmUpdate = false
+                self.delegate?.streamingPlayerDidUpdatePCM(pcmCopy)
             }
         }
 

--- a/Sources/NullPlayer/Audio/StreamingAudioPlayer.swift
+++ b/Sources/NullPlayer/Audio/StreamingAudioPlayer.swift
@@ -10,6 +10,7 @@ protocol StreamingAudioPlayerDelegate: AnyObject {
     func streamingPlayerDidFinishPlaying()
     func streamingPlayerDidUpdateSpectrum(_ levels: [Float])
     func streamingPlayerDidUpdatePCM(_ samples: [Float])
+    func streamingPlayerDidUpdateStereoPCM(left: [Float], right: [Float], sampleRate: Double)
     func streamingPlayerDidDetectFormat(sampleRate: Int, channels: Int)
     func streamingPlayerDidEncounterError(_ error: AudioPlayerError)
     func streamingPlayerDidReceiveMetadata(_ metadata: [String: String])
@@ -41,9 +42,12 @@ class StreamingAudioPlayer {
 
     /// Whether spectrum FFT should run — bridged from AudioEngine.spectrumNeeded
     var spectrumNeeded: Bool = false
-    
+
     /// Whether 576-sample waveform frames should be generated for consumers like vis_classic or the stream waveform window.
     var waveformNeeded: Bool = false
+
+    /// Whether stereo PCM data should be produced — bridged from AudioEngine.stereoNeeded
+    var stereoNeeded: Bool = false
 
     /// Cached value of modernUIEnabled to avoid 60x/sec UserDefaults reads
     var isModernUIEnabled: Bool = UserDefaults.standard.bool(forKey: "modernUIEnabled")
@@ -138,6 +142,11 @@ class StreamingAudioPlayer {
     private var fftMagnitudes = [Float](repeating: 0, count: 1024)
     private var fftNewSpectrum = [Float](repeating: 0, count: 75)
     private var fftPcmSamples = [Float](repeating: 0, count: 512)
+    /// Pre-allocated stereo PCM buffers (512 samples each for left and right channels)
+    private var stereoPcmLeft = [Float](repeating: 0, count: 512)
+    private var stereoPcmRight = [Float](repeating: 0, count: 512)
+    /// Flag to coalesce stereo PCM main queue dispatches
+    private var pendingStereoPcmUpdate = false
     private var waveformLeftU8 = [UInt8](repeating: 128, count: 576)
     private var waveformRightU8 = [UInt8](repeating: 128, count: 576)
     private var waveformUserInfo: [String: Any] = [:]
@@ -408,7 +417,7 @@ class StreamingAudioPlayer {
         // Skip FFT processing when paused or stopped to save CPU
         // The frame filter still receives buffers but we don't need to process them
         guard state == .playing else { return }
-        guard spectrumNeeded || waveformNeeded else { return }
+        guard spectrumNeeded || waveformNeeded || stereoNeeded else { return }
 
         guard let channelData = buffer.floatChannelData else { return }
         
@@ -488,6 +497,47 @@ class StreamingAudioPlayer {
                 guard let self = self else { return }
                 self.pendingPcmUpdate = false
                 self.delegate?.streamingPlayerDidUpdatePCM(pcmCopy)
+            }
+        }
+
+        // Publish stereo PCM data when needed (independent of spectrum)
+        if stereoNeeded && frameCount >= 512 {
+            let pcmSize = 512
+            let stride = frameCount / pcmSize
+            // Extract and downsample left and right channels
+            if channelCount == 1 {
+                // Mono: duplicate to both channels
+                for i in 0..<pcmSize {
+                    let sample = channelData[0][i * stride]
+                    stereoPcmLeft[i] = sample
+                    stereoPcmRight[i] = sample
+                }
+            } else {
+                // Stereo: separate channels
+                for i in 0..<pcmSize {
+                    stereoPcmLeft[i] = channelData[0][i * stride]
+                    stereoPcmRight[i] = channelData[1][i * stride]
+                }
+            }
+
+            // Apply volume compensation (same as spectrum path)
+            if volumeCompensation > 1.0 {
+                var compensation = volumeCompensation
+                vDSP_vsmul(stereoPcmLeft, 1, &compensation, &stereoPcmLeft, 1, vDSP_Length(pcmSize))
+                vDSP_vsmul(stereoPcmRight, 1, &compensation, &stereoPcmRight, 1, vDSP_Length(pcmSize))
+            }
+
+            // Coalesce stereo PCM updates to prevent main queue buildup
+            if !pendingStereoPcmUpdate {
+                pendingStereoPcmUpdate = true
+                let leftCopy = Array(stereoPcmLeft)
+                let rightCopy = Array(stereoPcmRight)
+                let sampleRateDouble = Double(buffer.format.sampleRate)
+                DispatchQueue.main.async { [weak self] in
+                    guard let self = self else { return }
+                    self.pendingStereoPcmUpdate = false
+                    self.delegate?.streamingPlayerDidUpdateStereoPCM(left: leftCopy, right: rightCopy, sampleRate: sampleRateDouble)
+                }
             }
         }
 

--- a/Sources/NullPlayer/Resources/ThirdPartyLicenses/ThirdPartyNotices.txt
+++ b/Sources/NullPlayer/Resources/ThirdPartyLicenses/ThirdPartyNotices.txt
@@ -6060,3 +6060,34 @@ If you believe a bundled asset infringes your rights, please open an issue on
 the project repository so it can be removed or re-attributed.
 
 
+================================================================================
+Viridis colormap
+================================================================================
+License:    CC0-1.0
+Copyright:  Copyright waived — Stéfan van der Walt and Nathaniel Smith (public domain via CC0)
+Source:     https://github.com/BIDS/colormap
+Version:    bundled constants
+
+Viridis colormap
+================
+
+NullPlayer's Audio Analysis spectrogram pane colors its waterfall using the
+"viridis" perceptually-uniform colormap (a small set of sampled RGB control
+points reproduced in the spectrogram Metal shader).
+
+The viridis colormap was created by Stéfan van der Walt (@stefanv) and
+Nathaniel Smith (@njsmith) for the matplotlib project and dedicated to the
+public domain.
+
+Source: https://github.com/BIDS/colormap
+
+License: Creative Commons CC0 1.0 Universal (Public Domain Dedication)
+
+  To the extent possible under law, the authors have waived all copyright and
+  related or neighboring rights to the viridis colormap. The work is published
+  from the United States.
+
+  The full text of the CC0 1.0 dedication is available at:
+  https://creativecommons.org/publicdomain/zero/1.0/legalcode
+
+

--- a/Sources/NullPlayer/Resources/ThirdPartyLicenses/Viridis_NOTICE.txt
+++ b/Sources/NullPlayer/Resources/ThirdPartyLicenses/Viridis_NOTICE.txt
@@ -1,0 +1,21 @@
+Viridis colormap
+================
+
+NullPlayer's Audio Analysis spectrogram pane colors its waterfall using the
+"viridis" perceptually-uniform colormap (a small set of sampled RGB control
+points reproduced in the spectrogram Metal shader).
+
+The viridis colormap was created by Stéfan van der Walt (@stefanv) and
+Nathaniel Smith (@njsmith) for the matplotlib project and dedicated to the
+public domain.
+
+Source: https://github.com/BIDS/colormap
+
+License: Creative Commons CC0 1.0 Universal (Public Domain Dedication)
+
+  To the extent possible under law, the authors have waived all copyright and
+  related or neighboring rights to the viridis colormap. The work is published
+  from the United States.
+
+  The full text of the CC0 1.0 dedication is available at:
+  https://creativecommons.org/publicdomain/zero/1.0/legalcode

--- a/Sources/NullPlayer/Visualization/SpectrogramShaders.metal
+++ b/Sources/NullPlayer/Visualization/SpectrogramShaders.metal
@@ -1,0 +1,84 @@
+#include <metal_stdlib>
+using namespace metal;
+
+// MARK: - Constants & Structs
+
+constant float PI = 3.14159265359;
+
+struct VertexOut {
+    float4 position [[position]];
+    float2 texCoord;
+};
+
+// MARK: - Vertex Shader
+
+// Generates a fullscreen quad (two triangles) from the vertex id alone, so no
+// vertex buffer or vertex descriptor is required. texCoord.y = 0 maps to the
+// bottom of the screen so low-frequency bands (texture row 0) render at the bottom.
+vertex VertexOut spectrogramVertexShader(uint vid [[vertex_id]]) {
+    const float2 positions[6] = {
+        float2(-1.0, -1.0), float2(1.0, -1.0), float2(-1.0, 1.0),
+        float2(-1.0,  1.0), float2(1.0, -1.0), float2( 1.0, 1.0)
+    };
+    const float2 texCoords[6] = {
+        float2(0.0, 0.0), float2(1.0, 0.0), float2(0.0, 1.0),
+        float2(0.0, 1.0), float2(1.0, 0.0), float2(1.0, 1.0)
+    };
+
+    VertexOut out;
+    out.position = float4(positions[vid], 0.0, 1.0);
+    out.texCoord = texCoords[vid];
+    return out;
+}
+
+// MARK: - Color Lookup Functions
+
+// Viridis colormap: perceptually uniform gradient
+// Maps normalized dB value (0.0 to 1.0) to RGB color
+float3 viridisColormap(float value) {
+    // Clamp to [0, 1]
+    value = clamp(value, 0.0, 1.0);
+
+    // Viridis colors sampled at key points
+    float3 colors[5] = {
+        float3(0.267004, 0.004874, 0.329415),  // Dark purple (0%)
+        float3(0.282623, 0.140461, 0.469470),  // Purple (25%)
+        float3(0.253935, 0.265254, 0.529983),  // Blue (50%)
+        float3(0.206756, 0.371758, 0.553806),  // Cyan (75%)
+        float3(0.993248, 0.906157, 0.143936)   // Yellow (100%)
+    };
+
+    float idx = value * 4.0;
+    int i = int(floor(idx));
+    float t = fract(idx);
+
+    i = clamp(i, 0, 3);
+    return mix(colors[i], colors[i + 1], smoothstep(0.0, 1.0, t));
+}
+
+// MARK: - Fragment Shader (Spectrogram)
+
+fragment float4 spectrogramFragmentShader(
+    VertexOut in [[stage_in]],
+    texture2d<float> historyTexture [[texture(0)]]  // Scrolling spectrogram history
+) {
+    constexpr sampler textureSampler(coord::normalized,
+                                     address::clamp_to_edge,
+                                     filter::linear);
+
+    // Sample history texture at current UV
+    // Texture is laid out with frequency (band) on Y axis, time (history) on X axis
+    // Low frequencies at bottom (Y=0), high at top (Y=1)
+    float2 texCoord = in.texCoord;
+
+    // Scroll time axis slightly (optional fade)
+    float historyValue = historyTexture.sample(textureSampler, texCoord).r;
+
+    // Fade history to create trailing effect
+    historyValue *= 0.95;
+
+    // Apply colormap based on magnitude
+    float3 color = viridisColormap(historyValue);
+
+    return float4(color, 1.0);
+}

--- a/Sources/NullPlayer/Windows/ModernAudioAnalysis/LevelsPaneView.swift
+++ b/Sources/NullPlayer/Windows/ModernAudioAnalysis/LevelsPaneView.swift
@@ -1,7 +1,7 @@
 import SwiftUI
 import NullPlayerCore
 
-/// Levels pane — displays stereo peak and RMS meters
+/// Levels pane — displays stereo peak and RMS meters as vertical bars that fill the window.
 struct LevelsPaneView: View {
     @State private var leftPeakDB: Float = -120
     @State private var rightPeakDB: Float = -120
@@ -9,39 +9,23 @@ struct LevelsPaneView: View {
     @State private var rightRMSDB: Float = -120
 
     var body: some View {
-        VStack(spacing: 16) {
-            Text("LEVELS")
-                .font(.system(size: 12, weight: .semibold, design: .monospaced))
-                .foregroundColor(.white)
-                .frame(maxWidth: .infinity, alignment: .leading)
-                .padding(.horizontal, 12)
-                .padding(.top, 12)
-
-            HStack(spacing: 24) {
-                VStack(spacing: 12) {
-                    Text("LEFT")
-                        .font(.system(size: 10, weight: .semibold, design: .monospaced))
-                        .foregroundColor(.cyan)
-
-                    MeterView(label: "Peak", value: leftPeakDB)
-                    MeterView(label: "RMS", value: leftRMSDB)
-                }
-                .frame(maxWidth: .infinity)
-
-                VStack(spacing: 12) {
-                    Text("RIGHT")
-                        .font(.system(size: 10, weight: .semibold, design: .monospaced))
-                        .foregroundColor(Color(red: 1, green: 0, blue: 1))
-
-                    MeterView(label: "Peak", value: rightPeakDB)
-                    MeterView(label: "RMS", value: rightRMSDB)
-                }
-                .frame(maxWidth: .infinity)
-            }
-            .padding(.horizontal, 12)
-
-            Spacer()
+        HStack(spacing: 24) {
+            ChannelMetersView(
+                name: "LEFT",
+                nameColor: .cyan,
+                peakDB: leftPeakDB,
+                rmsDB: leftRMSDB
+            )
+            ChannelMetersView(
+                name: "RIGHT",
+                nameColor: Color(red: 1, green: 0, blue: 1),
+                peakDB: rightPeakDB,
+                rmsDB: rightRMSDB
+            )
         }
+        .padding(.horizontal, 16)
+        .padding(.vertical, 12)
+        .frame(maxWidth: .infinity, maxHeight: .infinity)
         .background(Color.black)
         .onReceive(NotificationCenter.default.publisher(for: .audioStereoPCMDataUpdated).receive(on: DispatchQueue.main)) { notification in
             guard let userInfo = notification.userInfo,
@@ -56,12 +40,36 @@ struct LevelsPaneView: View {
     }
 }
 
-struct MeterView: View {
+/// One channel: a label above a pair of full-height Peak/RMS vertical meters.
+private struct ChannelMetersView: View {
+    let name: String
+    let nameColor: Color
+    let peakDB: Float
+    let rmsDB: Float
+
+    var body: some View {
+        VStack(spacing: 8) {
+            Text(name)
+                .font(.system(size: 10, weight: .semibold, design: .monospaced))
+                .foregroundColor(nameColor)
+
+            HStack(spacing: 16) {
+                VerticalMeterView(label: "Peak", value: peakDB)
+                VerticalMeterView(label: "RMS", value: rmsDB)
+            }
+            .frame(maxWidth: .infinity, maxHeight: .infinity)
+        }
+        .frame(maxWidth: .infinity, maxHeight: .infinity)
+    }
+}
+
+/// A single vertical level meter that fills the available height.
+struct VerticalMeterView: View {
     let label: String
     let value: Float
 
     private var normalizedValue: CGFloat {
-        CGFloat((value + 120) / 120)  // Map -120 to 0 dB → 0.0 to 1.0
+        CGFloat(max(0, min(1, (value + 120) / 120)))  // -120…0 dB → 0…1
     }
 
     private var meterColor: Color {
@@ -71,34 +79,32 @@ struct MeterView: View {
     }
 
     var body: some View {
-        VStack(spacing: 4) {
-            HStack(spacing: 8) {
-                Text(label)
-                    .font(.system(size: 9, weight: .semibold, design: .monospaced))
-                    .foregroundColor(.gray)
-                    .frame(width: 40, alignment: .leading)
-
-                GeometryReader { geo in
-                    ZStack(alignment: .leading) {
-                        RoundedRectangle(cornerRadius: 2)
-                            .fill(Color(white: 0.3))
-
-                        RoundedRectangle(cornerRadius: 2)
-                            .fill(meterColor)
-                            .frame(width: geo.size.width * normalizedValue)
-                    }
+        VStack(spacing: 6) {
+            GeometryReader { geo in
+                ZStack(alignment: .bottom) {
+                    RoundedRectangle(cornerRadius: 3)
+                        .fill(Color(white: 0.18))
+                    RoundedRectangle(cornerRadius: 3)
+                        .fill(meterColor)
+                        .frame(height: geo.size.height * normalizedValue)
                 }
-                .frame(height: 12)
-
-                Text(String(format: "%.1f", value))
-                    .font(.system(size: 9, weight: .semibold, design: .monospaced))
-                    .foregroundColor(.white)
-                    .frame(width: 50, alignment: .trailing)
             }
+            .frame(maxWidth: 44, maxHeight: .infinity)
+
+            Text(label)
+                .font(.system(size: 9, weight: .semibold, design: .monospaced))
+                .foregroundColor(.gray)
+
+            Text(String(format: "%.1f", value))
+                .font(.system(size: 9, weight: .semibold, design: .monospaced))
+                .foregroundColor(.white)
+                .monospacedDigit()
         }
+        .frame(maxWidth: .infinity)
     }
 }
 
 #Preview {
     LevelsPaneView()
+        .frame(width: 275, height: 220)
 }

--- a/Sources/NullPlayer/Windows/ModernAudioAnalysis/LevelsPaneView.swift
+++ b/Sources/NullPlayer/Windows/ModernAudioAnalysis/LevelsPaneView.swift
@@ -1,0 +1,104 @@
+import SwiftUI
+import NullPlayerCore
+
+/// Levels pane — displays stereo peak and RMS meters
+struct LevelsPaneView: View {
+    @State private var leftPeakDB: Float = -120
+    @State private var rightPeakDB: Float = -120
+    @State private var leftRMSDB: Float = -120
+    @State private var rightRMSDB: Float = -120
+
+    var body: some View {
+        VStack(spacing: 16) {
+            Text("LEVELS")
+                .font(.system(size: 12, weight: .semibold, design: .monospaced))
+                .foregroundColor(.white)
+                .frame(maxWidth: .infinity, alignment: .leading)
+                .padding(.horizontal, 12)
+                .padding(.top, 12)
+
+            HStack(spacing: 24) {
+                VStack(spacing: 12) {
+                    Text("LEFT")
+                        .font(.system(size: 10, weight: .semibold, design: .monospaced))
+                        .foregroundColor(.cyan)
+
+                    MeterView(label: "Peak", value: leftPeakDB)
+                    MeterView(label: "RMS", value: leftRMSDB)
+                }
+                .frame(maxWidth: .infinity)
+
+                VStack(spacing: 12) {
+                    Text("RIGHT")
+                        .font(.system(size: 10, weight: .semibold, design: .monospaced))
+                        .foregroundColor(Color(red: 1, green: 0, blue: 1))
+
+                    MeterView(label: "Peak", value: rightPeakDB)
+                    MeterView(label: "RMS", value: rightRMSDB)
+                }
+                .frame(maxWidth: .infinity)
+            }
+            .padding(.horizontal, 12)
+
+            Spacer()
+        }
+        .background(Color.black)
+        .onReceive(NotificationCenter.default.publisher(for: .audioStereoPCMDataUpdated).receive(on: DispatchQueue.main)) { notification in
+            guard let userInfo = notification.userInfo,
+                  let left = userInfo["left"] as? [Float],
+                  let right = userInfo["right"] as? [Float] else { return }
+
+            leftPeakDB = AudioAnalysisDSP.peakDBFS(left)
+            rightPeakDB = AudioAnalysisDSP.peakDBFS(right)
+            leftRMSDB = AudioAnalysisDSP.rmsDBFS(left)
+            rightRMSDB = AudioAnalysisDSP.rmsDBFS(right)
+        }
+    }
+}
+
+struct MeterView: View {
+    let label: String
+    let value: Float
+
+    private var normalizedValue: CGFloat {
+        CGFloat((value + 120) / 120)  // Map -120 to 0 dB → 0.0 to 1.0
+    }
+
+    private var meterColor: Color {
+        if value > -6 { return .red }
+        if value > -12 { return .yellow }
+        return .green
+    }
+
+    var body: some View {
+        VStack(spacing: 4) {
+            HStack(spacing: 8) {
+                Text(label)
+                    .font(.system(size: 9, weight: .semibold, design: .monospaced))
+                    .foregroundColor(.gray)
+                    .frame(width: 40, alignment: .leading)
+
+                GeometryReader { geo in
+                    ZStack(alignment: .leading) {
+                        RoundedRectangle(cornerRadius: 2)
+                            .fill(Color(white: 0.3))
+
+                        RoundedRectangle(cornerRadius: 2)
+                            .fill(meterColor)
+                            .frame(width: geo.size.width * normalizedValue)
+                    }
+                }
+                .frame(height: 12)
+
+                Text(String(format: "%.1f", value))
+                    .font(.system(size: 9, weight: .semibold, design: .monospaced))
+                    .foregroundColor(.white)
+                    .frame(width: 50, alignment: .trailing)
+            }
+        }
+    }
+}
+
+#Preview {
+    LevelsPaneView()
+}

--- a/Sources/NullPlayer/Windows/ModernAudioAnalysis/ModernAudioAnalysisView.swift
+++ b/Sources/NullPlayer/Windows/ModernAudioAnalysis/ModernAudioAnalysisView.swift
@@ -8,6 +8,10 @@ class ModernAudioAnalysisView: NSView {
     private var renderer: ModernSkinRenderer!
     private var hostingController: NSHostingController<AudioAnalysisContentView>?
 
+    /// Selected-pane state shared with the SwiftUI content; driven by the right-click menu.
+    private let model = AudioAnalysisModel(
+        selectedPane: UserDefaults.standard.integer(forKey: "audioAnalysisSelectedPane"))
+
     private var adjacentEdges: AdjacentEdges = [] { didSet { updateCornerMask() } }
     private var sharpCorners: CACornerMask = [] { didSet { updateCornerMask() } }
     private var edgeOcclusionSegments: EdgeOcclusionSegments = .empty
@@ -79,16 +83,42 @@ class ModernAudioAnalysisView: NSView {
     }
 
     private func setupContentView() {
-        let contentView = AudioAnalysisContentView(nsView: self)
+        let skin = ModernSkinEngine.shared.currentSkin ?? ModernSkinLoader.shared.loadDefault()
+        let contentView = AudioAnalysisContentView(nsView: self, model: model, skinTextColor: Color(skin.textColor))
         let hostingController = NSHostingController(rootView: contentView)
 
         addSubview(hostingController.view)
-        hostingController.view.frame = bounds
-        hostingController.view.autoresizingMask = [.width, .height]
+        hostingController.view.autoresizingMask = []  // Manual frame updates in layout()
         hostingController.view.wantsLayer = true
         hostingController.view.layer?.isOpaque = false
+        // Adapt SwiftUI controls (segmented picker) to the skin's light/dark theme
+        hostingController.view.appearance = skinAppearance(for: skin)
 
         self.hostingController = hostingController
+        layoutHostingView()
+    }
+
+    /// Content rect inside the chrome (inside the border, below the title bar).
+    private func contentAreaRect() -> NSRect {
+        NSRect(
+            x: borderWidth,
+            y: borderWidth,
+            width: max(0, bounds.width - borderWidth * 2),
+            height: max(0, bounds.height - titleBarHeight - borderWidth)
+        )
+    }
+
+    private func layoutHostingView() {
+        hostingController?.view.frame = contentAreaRect()
+    }
+
+    /// Pick an aqua/darkAqua appearance based on the skin background brightness so the
+    /// SwiftUI segmented picker and system controls match the skin theme.
+    private func skinAppearance(for skin: ModernSkin) -> NSAppearance? {
+        var r: CGFloat = 0, g: CGFloat = 0, b: CGFloat = 0, a: CGFloat = 0
+        skin.backgroundColor.usingColorSpace(.deviceRGB)?.getRed(&r, green: &g, blue: &b, alpha: &a)
+        let brightness = 0.299 * r + 0.587 * g + 0.114 * b
+        return NSAppearance(named: brightness < 0.5 ? .darkAqua : .aqua)
     }
 
     // MARK: - Drawing
@@ -144,6 +174,9 @@ class ModernAudioAnalysisView: NSView {
     func skinDidChange() {
         let skin = ModernSkinEngine.shared.currentSkin ?? ModernSkinLoader.shared.loadDefault()
         renderer = ModernSkinRenderer(skin: skin)
+        hostingController?.view.appearance = skinAppearance(for: skin)
+        hostingController?.rootView = AudioAnalysisContentView(nsView: self, model: model, skinTextColor: Color(skin.textColor))
+        layoutHostingView()
         updateCornerMask()
         needsDisplay = true
     }
@@ -268,10 +301,41 @@ class ModernAudioAnalysisView: NSView {
         }
     }
 
+    // MARK: - Context Menu
+
+    override func menu(for event: NSEvent) -> NSMenu? {
+        let menu = NSMenu()
+
+        for (index, title) in AudioAnalysisModel.paneTitles.enumerated() {
+            let item = NSMenuItem(title: title, action: #selector(selectPane(_:)), keyEquivalent: "")
+            item.target = self
+            item.tag = index
+            item.state = (model.selectedPane == index) ? .on : .off
+            menu.addItem(item)
+        }
+
+        menu.addItem(NSMenuItem.separator())
+
+        let closeItem = NSMenuItem(title: "Close", action: #selector(closeWindow(_:)), keyEquivalent: "")
+        closeItem.target = self
+        menu.addItem(closeItem)
+
+        return menu
+    }
+
+    @objc private func selectPane(_ sender: NSMenuItem) {
+        model.selectedPane = sender.tag
+    }
+
+    @objc private func closeWindow(_ sender: Any?) {
+        window?.close()
+    }
+
     // MARK: - Layout
 
     override func layout() {
         super.layout()
+        layoutHostingView()
         updateCornerMask()
     }
 
@@ -294,49 +358,44 @@ class ModernAudioAnalysisView: NSView {
     }
 }
 
+// MARK: - Pane Selection Model
+
+/// Shared selected-pane state. The NSView's right-click context menu mutates it; the
+/// SwiftUI content observes it. Pane selection is NOT an in-window control (matches the
+/// Spectrum window, which selects its mode via the right-click menu).
+final class AudioAnalysisModel: ObservableObject {
+    @Published var selectedPane: Int
+
+    /// Pane titles, indexed by tag. Used for both the content switch and the context menu.
+    static let paneTitles = ["Scope", "Levels", "Spectrogram"]
+
+    init(selectedPane: Int) {
+        self.selectedPane = min(max(0, selectedPane), Self.paneTitles.count - 1)
+    }
+}
+
 // MARK: - SwiftUI Content View
 
 struct AudioAnalysisContentView: View {
     weak var nsView: ModernAudioAnalysisView?
-
-    @State private var selectedPane: Int = 0  // 0: Scope, 1: Levels, 2: Spectrogram
+    @ObservedObject var model: AudioAnalysisModel
+    var skinTextColor: Color = .primary
 
     var body: some View {
-        VStack(spacing: 0) {
-            // Pane selector
-            Picker("", selection: $selectedPane) {
-                Text("Scope").tag(0)
-                Text("Levels").tag(1)
-                Text("Spectrogram").tag(2)
+        // No in-window controls — the pane fills the content area; selection is via the
+        // window's right-click context menu (see ModernAudioAnalysisView.menu(for:)).
+        ZStack {
+            switch model.selectedPane {
+            case 1:  LevelsPaneView()
+            case 2:  SpectrogramPaneView()
+            default: ScopePaneView()
             }
-            .pickerStyle(.segmented)
-            .padding(.horizontal, 12)
-            .padding(.vertical, 8)
-
-            // Pane content
-            ZStack {
-                if selectedPane == 0 {
-                    ScopePaneView()
-                } else if selectedPane == 1 {
-                    LevelsPaneView()
-                } else {
-                    SpectrogramPaneView()
-                }
-            }
-            .frame(maxWidth: .infinity, maxHeight: .infinity)
         }
-        .background(Color.black)
-        .onAppear {
-            // Load saved pane selection
-            selectedPane = UserDefaults.standard.integer(forKey: "audioAnalysisSelectedPane")
-            // Register consumer for the initial pane
-            updateConsumerForPane(selectedPane)
-        }
-        .onChange(of: selectedPane) {
-            // Save pane selection
-            UserDefaults.standard.set(selectedPane, forKey: "audioAnalysisSelectedPane")
-            // Update consumers when pane changes
-            updateConsumerForPane(selectedPane)
+        .frame(maxWidth: .infinity, maxHeight: .infinity)
+        .onAppear { updateConsumerForPane(model.selectedPane) }
+        .onChange(of: model.selectedPane) {
+            UserDefaults.standard.set(model.selectedPane, forKey: "audioAnalysisSelectedPane")
+            updateConsumerForPane(model.selectedPane)
         }
     }
 

--- a/Sources/NullPlayer/Windows/ModernAudioAnalysis/ModernAudioAnalysisView.swift
+++ b/Sources/NullPlayer/Windows/ModernAudioAnalysis/ModernAudioAnalysisView.swift
@@ -1,0 +1,351 @@
+import AppKit
+import SwiftUI
+
+/// Container view for the Audio Analysis window with pane selection
+class ModernAudioAnalysisView: NSView {
+    weak var controller: NSWindowController?
+
+    private var renderer: ModernSkinRenderer!
+    private var hostingController: NSHostingController<AudioAnalysisContentView>?
+
+    private var adjacentEdges: AdjacentEdges = [] { didSet { updateCornerMask() } }
+    private var sharpCorners: CACornerMask = [] { didSet { updateCornerMask() } }
+    private var edgeOcclusionSegments: EdgeOcclusionSegments = .empty
+
+    private var isHighlighted = false
+    private var pressedButton: String?
+    private var isDraggingWindow = false
+    private var windowDragStartPoint: NSPoint = .zero
+
+    private var scale: CGFloat { ModernSkinElements.scaleFactor }
+
+    private var titleBarHeight: CGFloat {
+        let hide = WindowManager.shared.effectiveHideTitleBars(for: self.window)
+        return hide ? borderWidth : ModernSkinElements.titleBarBaseHeight * scale
+    }
+
+    private var borderWidth: CGFloat { ModernSkinElements.spectrumBorderWidth }
+
+    // MARK: - Initialization
+
+    override init(frame: NSRect) {
+        super.init(frame: frame)
+        commonInit()
+    }
+
+    required init?(coder: NSCoder) {
+        super.init(coder: coder)
+        commonInit()
+    }
+
+    private func commonInit() {
+        wantsLayer = true
+        layer?.isOpaque = false
+
+        // Initialize renderer
+        let skin = ModernSkinEngine.shared.currentSkin ?? ModernSkinLoader.shared.loadDefault()
+        renderer = ModernSkinRenderer(skin: skin)
+
+        // Create and add SwiftUI content view
+        setupContentView()
+
+        // Observe notifications
+        NotificationCenter.default.addObserver(
+            self,
+            selector: #selector(modernSkinDidChange),
+            name: ModernSkinEngine.skinDidChangeNotification,
+            object: nil
+        )
+        NotificationCenter.default.addObserver(
+            self,
+            selector: #selector(doubleSizeChanged),
+            name: .doubleSizeDidChange,
+            object: nil
+        )
+        NotificationCenter.default.addObserver(
+            self,
+            selector: #selector(windowLayoutDidChange),
+            name: .windowLayoutDidChange,
+            object: nil
+        )
+        NotificationCenter.default.addObserver(
+            self,
+            selector: #selector(connectedWindowHighlightDidChange(_:)),
+            name: .connectedWindowHighlightDidChange,
+            object: nil
+        )
+
+        updateCornerMask()
+    }
+
+    private func setupContentView() {
+        let contentView = AudioAnalysisContentView(nsView: self)
+        let hostingController = NSHostingController(rootView: contentView)
+
+        addSubview(hostingController.view)
+        hostingController.view.frame = bounds
+        hostingController.view.autoresizingMask = [.width, .height]
+        hostingController.view.wantsLayer = true
+        hostingController.view.layer?.isOpaque = false
+
+        self.hostingController = hostingController
+    }
+
+    // MARK: - Drawing
+
+    override func draw(_ dirtyRect: NSRect) {
+        guard let context = NSGraphicsContext.current?.cgContext else { return }
+
+        // Draw window background
+        renderer.drawWindowBackground(
+            in: bounds,
+            context: context,
+            adjacentEdges: adjacentEdges,
+            sharpCorners: sharpCorners,
+            backgroundOpacity: renderer.skin.spectrumWindowBackgroundOpacity
+        )
+
+        // Draw window border
+        renderer.drawWindowBorder(
+            in: bounds,
+            context: context,
+            adjacentEdges: adjacentEdges,
+            sharpCorners: sharpCorners,
+            occlusionSegments: edgeOcclusionSegments
+        )
+
+        // Draw title bar
+        if !WindowManager.shared.effectiveHideTitleBars(for: self.window) {
+            renderer.drawTitleBar(
+                in: ModernSkinElements.spectrumTitleBar.defaultRect,
+                title: "AUDIO ANALYSIS",
+                prefix: "spectrum_",
+                context: context
+            )
+
+            // Draw close button
+            let closeState = (pressedButton == "spectrum_btn_close") ? "pressed" : "normal"
+            renderer.drawWindowControlButton(
+                "spectrum_btn_close",
+                state: closeState,
+                in: ModernSkinElements.spectrumBtnClose.defaultRect,
+                context: context
+            )
+        }
+
+        if isHighlighted {
+            NSColor.white.withAlphaComponent(0.15).setFill()
+            bounds.fill()
+        }
+    }
+
+    // MARK: - Skin Changes
+
+    func skinDidChange() {
+        let skin = ModernSkinEngine.shared.currentSkin ?? ModernSkinLoader.shared.loadDefault()
+        renderer = ModernSkinRenderer(skin: skin)
+        updateCornerMask()
+        needsDisplay = true
+    }
+
+    @objc private func modernSkinDidChange() {
+        skinDidChange()
+    }
+
+    @objc private func doubleSizeChanged() {
+        skinDidChange()
+    }
+
+    @objc private func windowLayoutDidChange() {
+        guard let window = window else { return }
+        let newEdges = WindowManager.shared.computeAdjacentEdges(for: window)
+        let newSharp = WindowManager.shared.computeSharpCorners(for: window)
+        let newSegments = WindowManager.shared.computeEdgeOcclusionSegments(for: window)
+        let seamless = min(1.0, max(0.0, ModernSkinEngine.shared.currentSkin?.config.window.seamlessDocking ?? 0))
+        let shouldHaveShadow = !(seamless > 0 && !newEdges.isEmpty)
+
+        if window.hasShadow != shouldHaveShadow {
+            window.hasShadow = shouldHaveShadow
+            window.invalidateShadow()
+        }
+
+        if newEdges != adjacentEdges || newSharp != sharpCorners || newSegments != edgeOcclusionSegments {
+            adjacentEdges = newEdges
+            sharpCorners = newSharp
+            edgeOcclusionSegments = newSegments
+            needsDisplay = true
+            needsLayout = true
+        }
+    }
+
+    @objc private func connectedWindowHighlightDidChange(_ notification: Notification) {
+        let highlighted = notification.userInfo?["highlightedWindows"] as? Set<NSWindow> ?? []
+        let newValue = highlighted.contains { $0 === window }
+        if isHighlighted != newValue {
+            isHighlighted = newValue
+            needsDisplay = true
+        }
+    }
+
+    // MARK: - Hit Testing & Mouse Events
+
+    private var titleBarViewRect: NSRect {
+        NSRect(x: 0, y: bounds.height - titleBarHeight, width: bounds.width, height: titleBarHeight)
+    }
+
+    private func hitTestTitleBar(at point: NSPoint) -> Bool {
+        if WindowManager.shared.effectiveHideTitleBars(for: self.window) {
+            return point.y >= bounds.height - 6
+        }
+        let closeWidth: CGFloat = 25 * scale
+        return point.y >= bounds.height - titleBarHeight &&
+               point.x < bounds.width - closeWidth
+    }
+
+    private func hitTestCloseButton(at point: NSPoint) -> Bool {
+        if WindowManager.shared.effectiveHideTitleBars(for: self.window) { return false }
+        let closeRect = renderer.scaledRect(ModernSkinElements.spectrumBtnClose.defaultRect)
+        let hitRect = closeRect.insetBy(dx: -4, dy: -4)
+        return hitRect.contains(point)
+    }
+
+    override func acceptsFirstMouse(for event: NSEvent?) -> Bool {
+        return true
+    }
+
+    override func mouseDown(with event: NSEvent) {
+        let point = convert(event.locationInWindow, from: nil)
+
+        // Check close button
+        if hitTestCloseButton(at: point) {
+            pressedButton = "spectrum_btn_close"
+            needsDisplay = true
+            return
+        }
+
+        // Check title bar
+        if hitTestTitleBar(at: point) {
+            isDraggingWindow = true
+            windowDragStartPoint = event.locationInWindow
+            if let window = window {
+                WindowManager.shared.windowWillStartDragging(window, fromTitleBar: true)
+            }
+            return
+        }
+    }
+
+    override func mouseDragged(with event: NSEvent) {
+        if isDraggingWindow, let window = window {
+            let currentPoint = event.locationInWindow
+            let deltaX = currentPoint.x - windowDragStartPoint.x
+            let deltaY = currentPoint.y - windowDragStartPoint.y
+
+            var newOrigin = window.frame.origin
+            newOrigin.x += deltaX
+            newOrigin.y += deltaY
+
+            newOrigin = WindowManager.shared.windowWillMove(window, to: newOrigin)
+            window.setFrameOrigin(newOrigin)
+        }
+    }
+
+    override func mouseUp(with event: NSEvent) {
+        let point = convert(event.locationInWindow, from: nil)
+
+        if isDraggingWindow {
+            isDraggingWindow = false
+            if let window = window {
+                WindowManager.shared.windowDidFinishDragging(window)
+            }
+        }
+
+        if let pressed = pressedButton {
+            if pressed == "spectrum_btn_close" && hitTestCloseButton(at: point) {
+                window?.close()
+            }
+            pressedButton = nil
+            needsDisplay = true
+        }
+    }
+
+    // MARK: - Layout
+
+    override func layout() {
+        super.layout()
+        updateCornerMask()
+    }
+
+    private func updateCornerMask() {
+        guard let layer = self.layer else { return }
+
+        let cornerRadius = (ModernSkinEngine.shared.currentSkin ?? ModernSkinLoader.shared.loadDefault())
+            .config.window.cornerRadius ?? 0
+        layer.cornerRadius = cornerRadius
+        layer.masksToBounds = cornerRadius > 0
+
+        guard cornerRadius > 0 else {
+            layer.maskedCorners = []
+            return
+        }
+
+        let allCorners: CACornerMask = [.layerMinXMinYCorner, .layerMaxXMinYCorner,
+                                        .layerMinXMaxYCorner, .layerMaxXMaxYCorner]
+        layer.maskedCorners = allCorners.subtracting(sharpCorners)
+    }
+}
+
+// MARK: - SwiftUI Content View
+
+struct AudioAnalysisContentView: View {
+    weak var nsView: ModernAudioAnalysisView?
+
+    @State private var selectedPane: Int = 0  // 0: Scope, 1: Levels, 2: Spectrogram
+
+    var body: some View {
+        VStack(spacing: 0) {
+            // Pane selector
+            Picker("", selection: $selectedPane) {
+                Text("Scope").tag(0)
+                Text("Levels").tag(1)
+                Text("Spectrogram").tag(2)
+            }
+            .pickerStyle(.segmented)
+            .padding(.horizontal, 12)
+            .padding(.vertical, 8)
+
+            // Pane content
+            ZStack {
+                if selectedPane == 0 {
+                    ScopePaneView()
+                } else if selectedPane == 1 {
+                    LevelsPaneView()
+                } else {
+                    SpectrogramPaneView()
+                }
+            }
+            .frame(maxWidth: .infinity, maxHeight: .infinity)
+        }
+        .background(Color.black)
+        .onAppear {
+            // Load saved pane selection
+            selectedPane = UserDefaults.standard.integer(forKey: "audioAnalysisSelectedPane")
+            // Register consumer for the initial pane
+            updateConsumerForPane(selectedPane)
+        }
+        .onChange(of: selectedPane) {
+            // Save pane selection
+            UserDefaults.standard.set(selectedPane, forKey: "audioAnalysisSelectedPane")
+            // Update consumers when pane changes
+            updateConsumerForPane(selectedPane)
+        }
+    }
+
+    private func updateConsumerForPane(_ paneIndex: Int) {
+        guard let nsView = nsView,
+              let window = nsView.window,
+              let windowController = window.windowController as? ModernAudioAnalysisWindowController else {
+            return
+        }
+        windowController.setVisiblePane(paneIndex)
+    }
+}

--- a/Sources/NullPlayer/Windows/ModernAudioAnalysis/ModernAudioAnalysisView.swift
+++ b/Sources/NullPlayer/Windows/ModernAudioAnalysis/ModernAudioAnalysisView.swift
@@ -12,6 +12,8 @@ class ModernAudioAnalysisView: NSView {
     private let model = AudioAnalysisModel(
         selectedPane: UserDefaults.standard.integer(forKey: "audioAnalysisSelectedPane"))
 
+    var selectedPane: Int { model.selectedPane }
+
     private var adjacentEdges: AdjacentEdges = [] { didSet { updateCornerMask() } }
     private var sharpCorners: CACornerMask = [] { didSet { updateCornerMask() } }
     private var edgeOcclusionSegments: EdgeOcclusionSegments = .empty
@@ -331,6 +333,19 @@ class ModernAudioAnalysisView: NSView {
         window?.close()
     }
 
+    func setRenderingPaused(_ paused: Bool) {
+        func update(in view: NSView) {
+            if let spectrogram = view as? SpectrogramMetalView {
+                spectrogram.setRenderingPaused(paused)
+            }
+            for subview in view.subviews {
+                update(in: subview)
+            }
+        }
+
+        update(in: self)
+    }
+
     // MARK: - Layout
 
     override func layout() {
@@ -392,7 +407,6 @@ struct AudioAnalysisContentView: View {
             }
         }
         .frame(maxWidth: .infinity, maxHeight: .infinity)
-        .onAppear { updateConsumerForPane(model.selectedPane) }
         .onChange(of: model.selectedPane) {
             UserDefaults.standard.set(model.selectedPane, forKey: "audioAnalysisSelectedPane")
             updateConsumerForPane(model.selectedPane)

--- a/Sources/NullPlayer/Windows/ModernAudioAnalysis/ModernAudioAnalysisWindowController.swift
+++ b/Sources/NullPlayer/Windows/ModernAudioAnalysis/ModernAudioAnalysisWindowController.swift
@@ -80,11 +80,14 @@ class ModernAudioAnalysisWindowController: NSWindowController, AudioAnalysisWind
     override func showWindow(_ sender: Any?) {
         super.showWindow(sender)
         analysisView.needsDisplay = true
+        analysisView.setRenderingPaused(false)
+        setVisiblePane(analysisView.selectedPane)
         startRendering()
     }
 
     func stopRenderingForHide() {
-        // Stop any display link rendering if needed
+        analysisView.setRenderingPaused(true)
+        deregisterAllConsumers()
     }
 
     // MARK: - Public Methods
@@ -192,12 +195,16 @@ extension ModernAudioAnalysisWindowController: NSWindowDelegate {
     }
 
     func windowDidDeminiaturize(_ notification: Notification) {
+        setVisiblePane(analysisView.selectedPane)
+        analysisView.setRenderingPaused(false)
         startRendering()
     }
 
     func windowWillClose(_ notification: Notification) {
-        // CRITICAL: Deregister ALL consumers to prevent idle FFT + stereo processing
-        deregisterAllConsumers()
+        if let window {
+            WindowManager.shared.handleCenterStackWindowWillClose(window)
+        }
+        stopRenderingForHide()
         WindowManager.shared.notifyMainWindowVisibilityChanged()
     }
 }

--- a/Sources/NullPlayer/Windows/ModernAudioAnalysis/ModernAudioAnalysisWindowController.swift
+++ b/Sources/NullPlayer/Windows/ModernAudioAnalysis/ModernAudioAnalysisWindowController.swift
@@ -22,7 +22,9 @@ class ModernAudioAnalysisWindowController: NSWindowController, AudioAnalysisWind
 
     convenience init() {
         let scale = ModernSkinElements.scaleFactor
-        let defaultSize = NSSize(width: 600 * scale, height: 400 * scale)
+        // Match the center-stack windows (same width as the main window). WindowManager
+        // normalizes the exact frame via applyDefaultCenterStackFrameForCurrentHT on show.
+        let defaultSize = ModernSkinElements.spectrumWindowSize
 
         let window = BorderlessWindow(
             contentRect: NSRect(origin: .zero, size: defaultSize),
@@ -51,7 +53,8 @@ class ModernAudioAnalysisWindowController: NSWindowController, AudioAnalysisWind
         window.backgroundColor = .clear
         window.isOpaque = false
         window.hasShadow = true
-        window.minSize = NSSize(width: 400, height: 300)
+        // Center-stack minimum; WindowManager.applyCenterStackSizingConstraints refines this on show.
+        window.minSize = ModernSkinElements.spectrumMinSize
         window.title = "NullPlayer Audio Analysis"
 
         // Prevent window from being released when closed - we reuse the same controller

--- a/Sources/NullPlayer/Windows/ModernAudioAnalysis/ModernAudioAnalysisWindowController.swift
+++ b/Sources/NullPlayer/Windows/ModernAudioAnalysis/ModernAudioAnalysisWindowController.swift
@@ -1,0 +1,200 @@
+import AppKit
+
+/// Controller for the standalone Audio Analysis window (modern skin).
+/// Conforms to `AudioAnalysisWindowProviding` for WindowManager integration.
+///
+/// This controller has ZERO dependencies on the classic skin system.
+class ModernAudioAnalysisWindowController: NSWindowController, AudioAnalysisWindowProviding {
+
+    // MARK: - Properties
+
+    private var analysisView: ModernAudioAnalysisView!
+
+    // Consumer IDs for audio data subscriptions
+    private let scopeConsumerId = "audioAnalysis.scope"
+    private let levelsConsumerId = "audioAnalysis.levels"
+    private let spectrogramConsumerId = "audioAnalysis.spectrogram"
+
+    // Current active consumers
+    private var activeConsumers: Set<String> = []
+
+    // MARK: - Initialization
+
+    convenience init() {
+        let scale = ModernSkinElements.scaleFactor
+        let defaultSize = NSSize(width: 600 * scale, height: 400 * scale)
+
+        let window = BorderlessWindow(
+            contentRect: NSRect(origin: .zero, size: defaultSize),
+            styleMask: [.borderless],
+            backing: .buffered,
+            defer: false
+        )
+        window.allowedResizeEdges = [.bottom, .left, .right]
+        window.titleBarHeight = ModernSkinElements.titleBarBaseHeight * scale
+
+        // Enable fullscreen support
+        window.collectionBehavior = [.fullScreenPrimary, .managed]
+
+        self.init(window: window)
+
+        setupWindow()
+        setupView()
+    }
+
+    // MARK: - Setup
+
+    private func setupWindow() {
+        guard let window = window else { return }
+
+        window.isMovableByWindowBackground = false
+        window.backgroundColor = .clear
+        window.isOpaque = false
+        window.hasShadow = true
+        window.minSize = NSSize(width: 400, height: 300)
+        window.title = "NullPlayer Audio Analysis"
+
+        // Prevent window from being released when closed - we reuse the same controller
+        window.isReleasedWhenClosed = false
+
+        window.center()
+        window.delegate = self
+
+        // Set accessibility identifier
+        window.setAccessibilityIdentifier("ModernAudioAnalysisWindow")
+        window.setAccessibilityLabel("NullPlayer Audio Analysis Window")
+    }
+
+    private func setupView() {
+        analysisView = ModernAudioAnalysisView(frame: NSRect(origin: .zero, size: ModernSkinElements.spectrumWindowSize))
+        analysisView.controller = self
+        analysisView.autoresizingMask = [.width, .height]
+        window?.contentView = analysisView
+    }
+
+    // MARK: - Window Display
+
+    override func showWindow(_ sender: Any?) {
+        super.showWindow(sender)
+        analysisView.needsDisplay = true
+        startRendering()
+    }
+
+    func stopRenderingForHide() {
+        // Stop any display link rendering if needed
+    }
+
+    // MARK: - Public Methods
+
+    func skinDidChange() {
+        analysisView.skinDidChange()
+    }
+
+    /// Sets the visible pane index and updates consumers accordingly.
+    /// Called by the SwiftUI view when the pane selection changes.
+    func setVisiblePane(_ index: Int) {
+        updateConsumers(forVisiblePanes: [index])
+    }
+
+    // MARK: - Consumer Management
+
+    private func updateConsumers(forVisiblePanes panes: Set<Int>) {
+        let engine = WindowManager.shared.audioEngine
+
+        // Scope pane (0) needs spectrum consumer for PCM data
+        if panes.contains(0) {
+            if !activeConsumers.contains(scopeConsumerId) {
+                engine.addSpectrumConsumer(scopeConsumerId)
+                activeConsumers.insert(scopeConsumerId)
+            }
+        } else {
+            if activeConsumers.contains(scopeConsumerId) {
+                engine.removeSpectrumConsumer(scopeConsumerId)
+                activeConsumers.remove(scopeConsumerId)
+            }
+        }
+
+        // Levels pane (1) needs stereo consumer for PCM peak/RMS
+        if panes.contains(1) {
+            if !activeConsumers.contains(levelsConsumerId) {
+                engine.addStereoConsumer(levelsConsumerId)
+                activeConsumers.insert(levelsConsumerId)
+            }
+        } else {
+            if activeConsumers.contains(levelsConsumerId) {
+                engine.removeStereoConsumer(levelsConsumerId)
+                activeConsumers.remove(levelsConsumerId)
+            }
+        }
+
+        // Spectrogram pane (2) needs spectrum consumer for FFT magnitudes
+        if panes.contains(2) {
+            if !activeConsumers.contains(spectrogramConsumerId) {
+                engine.addSpectrumConsumer(spectrogramConsumerId)
+                activeConsumers.insert(spectrogramConsumerId)
+            }
+        } else {
+            if activeConsumers.contains(spectrogramConsumerId) {
+                engine.removeSpectrumConsumer(spectrogramConsumerId)
+                activeConsumers.remove(spectrogramConsumerId)
+            }
+        }
+    }
+
+    private func startRendering() {
+        // The pane views handle their own rendering (CVDisplayLink, Metal, etc.)
+        // This is a placeholder for future rendering coordination if needed
+    }
+
+    private func deregisterAllConsumers() {
+        let engine = WindowManager.shared.audioEngine
+        for consumerId in activeConsumers {
+            if consumerId == scopeConsumerId {
+                engine.removeSpectrumConsumer(consumerId)
+            } else if consumerId == levelsConsumerId {
+                engine.removeStereoConsumer(consumerId)
+            } else if consumerId == spectrogramConsumerId {
+                engine.removeSpectrumConsumer(consumerId)
+            }
+        }
+        activeConsumers.removeAll()
+    }
+}
+
+// MARK: - NSWindowDelegate
+
+extension ModernAudioAnalysisWindowController: NSWindowDelegate {
+    func windowDidMove(_ notification: Notification) {
+        guard let window = window else { return }
+        let newOrigin = WindowManager.shared.windowWillMove(window, to: window.frame.origin)
+        WindowManager.shared.applySnappedPosition(window, to: newOrigin)
+    }
+
+    func windowDidResize(_ notification: Notification) {
+        analysisView.needsDisplay = true
+        WindowManager.shared.postWindowLayoutDidChange()
+    }
+
+    func windowDidBecomeKey(_ notification: Notification) {
+        analysisView.needsDisplay = true
+        WindowManager.shared.bringAllWindowsToFront(keepingWindowOnTop: window)
+    }
+
+    func windowDidResignKey(_ notification: Notification) {
+        analysisView.needsDisplay = true
+    }
+
+    func windowDidMiniaturize(_ notification: Notification) {
+        stopRenderingForHide()
+    }
+
+    func windowDidDeminiaturize(_ notification: Notification) {
+        startRendering()
+    }
+
+    func windowWillClose(_ notification: Notification) {
+        // CRITICAL: Deregister ALL consumers to prevent idle FFT + stereo processing
+        deregisterAllConsumers()
+        WindowManager.shared.notifyMainWindowVisibilityChanged()
+    }
+}

--- a/Sources/NullPlayer/Windows/ModernAudioAnalysis/ScopePaneView.swift
+++ b/Sources/NullPlayer/Windows/ModernAudioAnalysis/ScopePaneView.swift
@@ -1,0 +1,113 @@
+import AppKit
+import SwiftUI
+
+/// Oscilloscope view — displays waveform in real-time
+struct ScopePaneView: NSViewRepresentable {
+    func makeNSView(context: Context) -> NSView {
+        return ScopeCanvasView()
+    }
+
+    func updateNSView(_ nsView: NSView, context: Context) {
+        // View handles all updates via notifications
+    }
+}
+
+/// Canvas-based oscilloscope renderer
+class ScopeCanvasView: NSView {
+    private var pcmData: [Float] = []
+    private var sampleRate: Double = 44100
+    private var pcmObserver: NSObjectProtocol?
+
+    override init(frame: NSRect) {
+        super.init(frame: frame)
+        commonInit()
+    }
+
+    required init?(coder: NSCoder) {
+        super.init(coder: coder)
+        commonInit()
+    }
+
+    private func commonInit() {
+        wantsLayer = true
+        layer?.backgroundColor = NSColor.black.cgColor
+
+        // Observe PCM data updates from the audio engine
+        pcmObserver = NotificationCenter.default.addObserver(
+            forName: .audioPCMDataUpdated,
+            object: nil,
+            queue: .main
+        ) { [weak self] notification in
+            guard let userInfo = notification.userInfo,
+                  let pcm = userInfo["pcm"] as? [Float],
+                  let sampleRate = userInfo["sampleRate"] as? Double else { return }
+            self?.pcmData = pcm
+            self?.sampleRate = sampleRate
+            self?.needsDisplay = true
+        }
+    }
+
+    deinit {
+        if let observer = pcmObserver {
+            NotificationCenter.default.removeObserver(observer)
+        }
+    }
+
+    override func draw(_ dirtyRect: NSRect) {
+        super.draw(dirtyRect)
+
+        guard let context = NSGraphicsContext.current?.cgContext else { return }
+
+        // Background
+        NSColor.black.setFill()
+        bounds.fill()
+
+        guard !pcmData.isEmpty else { return }
+
+        // Draw waveform
+        drawWaveform(in: context)
+    }
+
+    private func drawWaveform(in context: CGContext) {
+        let width = bounds.width
+        let height = bounds.height
+        let centerY = height / 2
+
+        // Grid lines (optional)
+        context.setStrokeColor(NSColor.darkGray.cgColor)
+        context.setLineWidth(0.5)
+        for i in 1..<4 {
+            let y = CGFloat(i) * (height / 4)
+            context.move(to: CGPoint(x: 0, y: y))
+            context.addLine(to: CGPoint(x: width, y: y))
+        }
+        context.strokePath()
+
+        // Waveform line
+        context.setStrokeColor(NSColor.green.cgColor)
+        context.setLineWidth(1.5)
+
+        let samplesPerPixel = max(1, pcmData.count / Int(width))
+        var isFirstPoint = true
+
+        for x in 0..<Int(width) {
+            let sampleIndex = min(x * samplesPerPixel, pcmData.count - 1)
+            let sample = pcmData[sampleIndex]
+
+            // Clamp sample to [-1, 1] and map to screen coordinates
+            let clampedSample = max(-1.0, min(1.0, sample))
+            let screenY = centerY - CGFloat(clampedSample) * (centerY - 4)
+
+            let point = CGPoint(x: CGFloat(x), y: screenY)
+
+            if isFirstPoint {
+                context.move(to: point)
+                isFirstPoint = false
+            } else {
+                context.addLine(to: point)
+            }
+        }
+
+        context.strokePath()
+    }
+}

--- a/Sources/NullPlayer/Windows/ModernAudioAnalysis/SpectrogramPaneView.swift
+++ b/Sources/NullPlayer/Windows/ModernAudioAnalysis/SpectrogramPaneView.swift
@@ -22,7 +22,6 @@ class SpectrogramMetalView: NSView {
     private var pipelineState: MTLRenderPipelineState?
     private var historyTexture: MTLTexture?
     private var spectrumObserver: NSObjectProtocol?
-    private var observers: [NSObjectProtocol] = []
 
     // Scrolling history buffer (width × height, each pixel is a spectrum sample over time)
     private var historyBuffer: [Float] = []
@@ -46,9 +45,6 @@ class SpectrogramMetalView: NSView {
 
     deinit {
         if let observer = spectrumObserver {
-            NotificationCenter.default.removeObserver(observer)
-        }
-        for observer in observers {
             NotificationCenter.default.removeObserver(observer)
         }
     }
@@ -116,7 +112,7 @@ class SpectrogramMetalView: NSView {
             height: historyHeight,
             mipmapped: false
         )
-        textureDesc.usage = [.shaderRead, .shaderWrite]
+        textureDesc.usage = .shaderRead
         historyTexture = device.makeTexture(descriptor: textureDesc)
 
         // Subscribe to spectrum updates (on main thread)
@@ -128,24 +124,6 @@ class SpectrogramMetalView: NSView {
             self?.handleSpectrumUpdate(notification)
         }
 
-        // Observe window minimize/deminiaturize for pause/resume
-        let miniObserver = NotificationCenter.default.addObserver(
-            forName: NSWindow.didMiniaturizeNotification,
-            object: nil,
-            queue: .main
-        ) { [weak self] _ in
-            self?.metalView?.isPaused = true
-        }
-        observers.append(miniObserver)
-
-        let deminiObserver = NotificationCenter.default.addObserver(
-            forName: NSWindow.didDeminiaturizeNotification,
-            object: nil,
-            queue: .main
-        ) { [weak self] _ in
-            self?.metalView?.isPaused = false
-        }
-        observers.append(deminiObserver)
     }
 
     private func handleSpectrumUpdate(_ notification: Notification) {
@@ -176,10 +154,11 @@ class SpectrogramMetalView: NSView {
 
     override func viewDidMoveToWindow() {
         super.viewDidMoveToWindow()
-        if window == nil {
-            // View removed from window, pause rendering
-            metalView?.isPaused = true
-        }
+        metalView?.isPaused = window == nil
+    }
+
+    func setRenderingPaused(_ paused: Bool) {
+        metalView?.isPaused = paused
     }
 
     override func layout() {

--- a/Sources/NullPlayer/Windows/ModernAudioAnalysis/SpectrogramPaneView.swift
+++ b/Sources/NullPlayer/Windows/ModernAudioAnalysis/SpectrogramPaneView.swift
@@ -79,9 +79,19 @@ class SpectrogramMetalView: NSView {
         // Create command queue
         commandQueue = device.makeCommandQueue()
 
-        // Load shaders
-        guard let library = device.makeDefaultLibrary() else {
-            NSLog("AudioAnalysis: Failed to load shader library")
+        // Load shader source from the resource bundle and compile at runtime.
+        // makeDefaultLibrary() returns nil in SPM executables — match SpectrumAnalyzerView.
+        guard let shaderURL = BundleHelper.url(forResource: "SpectrogramShaders", withExtension: "metal"),
+              let shaderSource = try? String(contentsOf: shaderURL, encoding: .utf8) else {
+            NSLog("AudioAnalysis: Failed to load spectrogram shader source file")
+            return
+        }
+
+        let library: MTLLibrary
+        do {
+            library = try device.makeLibrary(source: shaderSource, options: nil)
+        } catch {
+            NSLog("AudioAnalysis: Failed to compile spectrogram shader library: \(error)")
             return
         }
 
@@ -150,10 +160,9 @@ class SpectrogramMetalView: NSView {
                 historyBuffer[i * historyWidth + (x - 1)] = historyBuffer[i * historyWidth + x]
             }
             if i < bandCount {
-                // Normalize spectrum value to [0, 1] for colormapping (-80 to 0 dBFS)
-                let dbValue = spectrum[i]
-                let normalized = (dbValue + 80) / 80
-                historyBuffer[i * historyWidth + (historyWidth - 1)] = max(0, min(1, normalized))
+                // `spectrum` bands are already normalized 0–1 magnitudes (see
+                // AudioEngine.audioSpectrumDataUpdated) — use them directly for colormapping.
+                historyBuffer[i * historyWidth + (historyWidth - 1)] = max(0, min(1, spectrum[i]))
             } else {
                 historyBuffer[i * historyWidth + (historyWidth - 1)] = 0
             }

--- a/Sources/NullPlayer/Windows/ModernAudioAnalysis/SpectrogramPaneView.swift
+++ b/Sources/NullPlayer/Windows/ModernAudioAnalysis/SpectrogramPaneView.swift
@@ -1,0 +1,208 @@
+import AppKit
+import SwiftUI
+import MetalKit
+
+/// Spectrogram pane — scrolling waterfall visualization
+struct SpectrogramPaneView: NSViewRepresentable {
+    func makeNSView(context: NSViewRepresentableContext<SpectrogramPaneView>) -> NSView {
+        let view = SpectrogramMetalView()
+        return view
+    }
+
+    func updateNSView(_ nsView: NSView, context: NSViewRepresentableContext<SpectrogramPaneView>) {
+        // Metal view handles updates internally
+    }
+}
+
+/// Metal-based spectrogram renderer with scrolling history
+class SpectrogramMetalView: NSView {
+    private var metalView: MTKView?
+    private var device: MTLDevice?
+    private var commandQueue: MTLCommandQueue?
+    private var pipelineState: MTLRenderPipelineState?
+    private var historyTexture: MTLTexture?
+    private var spectrumObserver: NSObjectProtocol?
+    private var observers: [NSObjectProtocol] = []
+
+    // Scrolling history buffer (width × height, each pixel is a spectrum sample over time)
+    private var historyBuffer: [Float] = []
+    private var historyWidth = 1024
+    private var historyHeight = 75  // Match spectrum band count
+
+    override func awakeFromNib() {
+        super.awakeFromNib()
+        setupMetal()
+    }
+
+    override init(frame: NSRect) {
+        super.init(frame: frame)
+        setupMetal()
+    }
+
+    required init?(coder: NSCoder) {
+        super.init(coder: coder)
+        setupMetal()
+    }
+
+    deinit {
+        if let observer = spectrumObserver {
+            NotificationCenter.default.removeObserver(observer)
+        }
+        for observer in observers {
+            NotificationCenter.default.removeObserver(observer)
+        }
+    }
+
+    private func setupMetal() {
+        wantsLayer = true
+        layer?.backgroundColor = NSColor.black.cgColor
+
+        guard let device = MTLCreateSystemDefaultDevice() else {
+            NSLog("AudioAnalysis: Metal device unavailable")
+            return
+        }
+
+        self.device = device
+
+        // Create Metal view with idiomatic paced rendering
+        let mtk = MTKView(frame: bounds, device: device)
+        mtk.delegate = self
+        mtk.framebufferOnly = false
+        mtk.preferredFramesPerSecond = 60
+        mtk.isPaused = false
+        mtk.enableSetNeedsDisplay = false
+        addSubview(mtk)
+        mtk.frame = bounds
+        mtk.autoresizingMask = [.width, .height]
+        metalView = mtk
+
+        // Create command queue
+        commandQueue = device.makeCommandQueue()
+
+        // Load shaders
+        guard let library = device.makeDefaultLibrary() else {
+            NSLog("AudioAnalysis: Failed to load shader library")
+            return
+        }
+
+        let pipelineDescriptor = MTLRenderPipelineDescriptor()
+        pipelineDescriptor.vertexFunction = library.makeFunction(name: "spectrogramVertexShader")
+        pipelineDescriptor.fragmentFunction = library.makeFunction(name: "spectrogramFragmentShader")
+        pipelineDescriptor.colorAttachments[0].pixelFormat = .bgra8Unorm
+
+        do {
+            pipelineState = try device.makeRenderPipelineState(descriptor: pipelineDescriptor)
+        } catch {
+            NSLog("AudioAnalysis: Pipeline creation failed: \(error)")
+        }
+
+        // Initialize history buffer
+        historyBuffer = Array(repeating: 0, count: historyWidth * historyHeight)
+
+        // Create history texture
+        let textureDesc = MTLTextureDescriptor.texture2DDescriptor(
+            pixelFormat: .r32Float,
+            width: historyWidth,
+            height: historyHeight,
+            mipmapped: false
+        )
+        textureDesc.usage = [.shaderRead, .shaderWrite]
+        historyTexture = device.makeTexture(descriptor: textureDesc)
+
+        // Subscribe to spectrum updates (on main thread)
+        spectrumObserver = NotificationCenter.default.addObserver(
+            forName: .audioSpectrumDataUpdated,
+            object: nil,
+            queue: .main
+        ) { [weak self] notification in
+            self?.handleSpectrumUpdate(notification)
+        }
+
+        // Observe window minimize/deminiaturize for pause/resume
+        let miniObserver = NotificationCenter.default.addObserver(
+            forName: NSWindow.didMiniaturizeNotification,
+            object: nil,
+            queue: .main
+        ) { [weak self] _ in
+            self?.metalView?.isPaused = true
+        }
+        observers.append(miniObserver)
+
+        let deminiObserver = NotificationCenter.default.addObserver(
+            forName: NSWindow.didDeminiaturizeNotification,
+            object: nil,
+            queue: .main
+        ) { [weak self] _ in
+            self?.metalView?.isPaused = false
+        }
+        observers.append(deminiObserver)
+    }
+
+    private func handleSpectrumUpdate(_ notification: Notification) {
+        guard let userInfo = notification.userInfo,
+              let spectrum = userInfo["spectrum"] as? [Float],
+              let historyTexture = historyTexture else { return }
+
+        // Shift history left and add new spectrum data on the right
+        let bandCount = min(spectrum.count, historyHeight)
+        for i in 0..<historyHeight {
+            for x in 1..<historyWidth {
+                historyBuffer[i * historyWidth + (x - 1)] = historyBuffer[i * historyWidth + x]
+            }
+            if i < bandCount {
+                // Normalize spectrum value to [0, 1] for colormapping (-80 to 0 dBFS)
+                let dbValue = spectrum[i]
+                let normalized = (dbValue + 80) / 80
+                historyBuffer[i * historyWidth + (historyWidth - 1)] = max(0, min(1, normalized))
+            } else {
+                historyBuffer[i * historyWidth + (historyWidth - 1)] = 0
+            }
+        }
+
+        // Upload buffer to GPU
+        let bytesPerRow = historyWidth * MemoryLayout<Float>.size
+        let region = MTLRegionMake2D(0, 0, historyWidth, historyHeight)
+        historyTexture.replace(region: region, mipmapLevel: 0, withBytes: historyBuffer, bytesPerRow: bytesPerRow)
+    }
+
+    override func viewDidMoveToWindow() {
+        super.viewDidMoveToWindow()
+        if window == nil {
+            // View removed from window, pause rendering
+            metalView?.isPaused = true
+        }
+    }
+
+    override func layout() {
+        super.layout()
+        metalView?.frame = bounds
+    }
+}
+
+extension SpectrogramMetalView: MTKViewDelegate {
+    func mtkView(_ view: MTKView, drawableSizeWillChange size: CGSize) {
+        // Handle size changes
+    }
+
+    func draw(in view: MTKView) {
+        // Guard pipeline, texture, and other critical resources BEFORE creating encoder
+        guard let pipelineState = pipelineState,
+              let historyTexture = historyTexture,
+              let commandBuffer = commandQueue?.makeCommandBuffer(),
+              let renderPassDescriptor = view.currentRenderPassDescriptor,
+              let renderEncoder = commandBuffer.makeRenderCommandEncoder(
+                  descriptor: renderPassDescriptor
+              ) else { return }
+
+        renderEncoder.setRenderPipelineState(pipelineState)
+        renderEncoder.setFragmentTexture(historyTexture, index: 0)
+        renderEncoder.drawPrimitives(type: .triangle, vertexStart: 0, vertexCount: 6)
+        renderEncoder.endEncoding()
+
+        if let drawable = view.currentDrawable {
+            commandBuffer.present(drawable)
+        }
+
+        commandBuffer.commit()
+    }
+}

--- a/Sources/NullPlayerCore/Audio/AudioAnalysisDSP.swift
+++ b/Sources/NullPlayerCore/Audio/AudioAnalysisDSP.swift
@@ -3,7 +3,6 @@ import Accelerate
 
 /// Pure-Swift DSP utilities for audio analysis.
 /// All functions are deterministic with no side effects and no global state — suitable for unit testing.
-/// No per-call heap allocations beyond the caller's responsibility.
 public enum AudioAnalysisDSP {
 
     // MARK: - Level Measurement
@@ -21,7 +20,7 @@ public enum AudioAnalysisDSP {
 
         guard maxAbs > 0 else { return -120.0 }
         let dB = 20.0 * log10(maxAbs)
-        return max(dB, -120.0)
+        return min(0.0, max(dB, -120.0))
     }
 
     /// Calculate RMS (root mean square) level in decibels full-scale (dB FS) from audio samples.
@@ -40,7 +39,7 @@ public enum AudioAnalysisDSP {
         guard meanSquare > 0 else { return -120.0 }
         let rms = sqrt(meanSquare)
         let dB = 20.0 * log10(rms)
-        return max(dB, -120.0)
+        return min(0.0, max(dB, -120.0))
     }
 
     // MARK: - Octave Band Analysis
@@ -71,6 +70,7 @@ public enum AudioAnalysisDSP {
         maxFreq: Double
     ) -> [(centerHz: Double, level: Float)] {
         guard !magnitudes.isEmpty, bandsPerOctave > 0, fftSize > 0 else { return [] }
+        guard minFreq.isFinite, maxFreq.isFinite, sampleRate.isFinite else { return [] }
         guard minFreq > 0, maxFreq > minFreq, sampleRate > 0 else { return [] }
 
         let binWidth = sampleRate / Double(fftSize)
@@ -79,6 +79,7 @@ public enum AudioAnalysisDSP {
         var bands: [(centerHz: Double, level: Float)] = []
 
         let octaveRatio = pow(2.0, 1.0 / Double(bandsPerOctave))
+        guard octaveRatio.isFinite, octaveRatio > 1 else { return [] }
         var freq = minFreq
 
         while freq <= maxFreq {
@@ -86,8 +87,16 @@ public enum AudioAnalysisDSP {
             let lowFreq = centerFreq / sqrt(octaveRatio)
             let highFreq = centerFreq * sqrt(octaveRatio)
 
-            let lowBin = max(0, Int(lowFreq / binWidth))
-            let highBin = min(magnitudes.count - 1, Int(highFreq / binWidth))
+            let lowBinValue = lowFreq / binWidth
+            let highBinValue = highFreq / binWidth
+            guard lowBinValue.isFinite, highBinValue.isFinite,
+                  lowBinValue <= Double(magnitudes.count - 1),
+                  highBinValue >= 0 else {
+                freq *= octaveRatio
+                continue
+            }
+            let lowBin = max(0, Int(lowBinValue))
+            let highBin = min(magnitudes.count - 1, Int(min(highBinValue, Double(magnitudes.count - 1))))
 
             var bandLevel: Float = 0.0
             for bin in lowBin...highBin {
@@ -127,10 +136,16 @@ public enum AudioAnalysisDSP {
         minHz: Double,
         maxHz: Double
     ) -> Double? {
-        guard !samples.isEmpty, minHz > 0, maxHz > minHz, sampleRate > 0 else { return nil }
+        guard !samples.isEmpty, minHz.isFinite, maxHz.isFinite, sampleRate.isFinite else { return nil }
+        guard minHz > 0, maxHz > minHz, sampleRate > 0 else { return nil }
 
-        let minLag = max(1, Int(sampleRate / maxHz))
-        let maxLag = min(samples.count / 2, Int(sampleRate / minHz))
+        let largestUsefulLag = samples.count / 2
+        let minLagValue = sampleRate / maxHz
+        let maxLagValue = sampleRate / minHz
+        guard minLagValue <= Double(largestUsefulLag), maxLagValue >= 1 else { return nil }
+
+        let minLag = max(1, Int(minLagValue))
+        let maxLag = maxLagValue >= Double(largestUsefulLag) ? largestUsefulLag : Int(maxLagValue)
 
         guard minLag <= maxLag else { return nil }
 
@@ -220,6 +235,7 @@ public enum AudioAnalysisDSP {
         // Seed with the zero-lag correlation so perfectly aligned channels report 0;
         // a real delay only wins if its correlation exceeds the aligned case.
         let searchLag = min(maxLagSamples, left.count / 2)
+        guard searchLag > 0 else { return 0 }
 
         var zeroCorr: Float = 0.0
         for i in 0..<left.count {

--- a/Sources/NullPlayerCore/Audio/AudioAnalysisDSP.swift
+++ b/Sources/NullPlayerCore/Audio/AudioAnalysisDSP.swift
@@ -1,0 +1,268 @@
+import Foundation
+import Accelerate
+
+/// Pure-Swift DSP utilities for audio analysis.
+/// All functions are deterministic with no side effects and no global state — suitable for unit testing.
+/// No per-call heap allocations beyond the caller's responsibility.
+public enum AudioAnalysisDSP {
+
+    // MARK: - Level Measurement
+
+    /// Calculate peak decibels full-scale (dB FS) from audio samples.
+    /// - Parameter samples: Array of floating-point audio samples.
+    /// - Returns: Peak level in dB FS, floored at -120 dB for silence.
+    ///
+    /// Formula: 20 * log10(maxAbs(samples)), clamped to [-120, 0] dB.
+    public static func peakDBFS(_ samples: [Float]) -> Float {
+        guard !samples.isEmpty else { return -120.0 }
+
+        var maxAbs: Float = 0.0
+        vDSP_maxmgv(samples, 1, &maxAbs, vDSP_Length(samples.count))
+
+        guard maxAbs > 0 else { return -120.0 }
+        let dB = 20.0 * log10(maxAbs)
+        return max(dB, -120.0)
+    }
+
+    /// Calculate RMS (root mean square) level in decibels full-scale (dB FS) from audio samples.
+    /// - Parameter samples: Array of floating-point audio samples.
+    /// - Returns: RMS level in dB FS, floored at -120 dB for silence.
+    ///
+    /// Formula: 20 * log10(sqrt(mean(samples²))), clamped to [-120, 0] dB.
+    /// Useful for loudness estimation; responds more smoothly than peak to transients.
+    public static func rmsDBFS(_ samples: [Float]) -> Float {
+        guard !samples.isEmpty else { return -120.0 }
+
+        var sum: Float = 0.0
+        vDSP_svesq(samples, 1, &sum, vDSP_Length(samples.count))
+
+        let meanSquare = sum / Float(samples.count)
+        guard meanSquare > 0 else { return -120.0 }
+        let rms = sqrt(meanSquare)
+        let dB = 20.0 * log10(rms)
+        return max(dB, -120.0)
+    }
+
+    // MARK: - Octave Band Analysis
+
+    /// Re-bin linear FFT magnitudes into logarithmic octave or sub-octave bands.
+    ///
+    /// - Parameters:
+    ///   - magnitudes: Linear FFT magnitude spectrum (half-spectrum, typically fftSize/2 elements).
+    ///   - sampleRate: Sample rate of the audio in Hz.
+    ///   - fftSize: FFT size used to compute magnitudes (e.g., 2048).
+    ///   - bandsPerOctave: Bands per octave; common values are 1 (octave), 3 (1/3 octave), 12 (1/12 octave).
+    ///   - minFreq: Lowest center frequency to include (Hz), typically 20.
+    ///   - maxFreq: Highest center frequency to include (Hz), typically 20000.
+    ///
+    /// - Returns: Array of tuples with center frequency (Hz) and level (normalized 0–1).
+    ///
+    /// Returns an empty array if inputs are invalid (empty magnitudes, invalid freq range, etc.).
+    ///
+    /// **Note on frequency resolution:** At 2048-point FFT, 44.1 kHz sample rate, the bin width is ~21.5 Hz.
+    /// Sub-200 Hz bands will have sparse bin coverage and lower frequency resolution. For reliable sub-bass analysis,
+    /// use larger FFT sizes (e.g., 4096 or 8192).
+    public static func octaveBands(
+        magnitudes: [Float],
+        sampleRate: Double,
+        fftSize: Int,
+        bandsPerOctave: Int,
+        minFreq: Double,
+        maxFreq: Double
+    ) -> [(centerHz: Double, level: Float)] {
+        guard !magnitudes.isEmpty, bandsPerOctave > 0, fftSize > 0 else { return [] }
+        guard minFreq > 0, maxFreq > minFreq, sampleRate > 0 else { return [] }
+
+        let binWidth = sampleRate / Double(fftSize)
+        guard binWidth > 0 else { return [] }
+
+        var bands: [(centerHz: Double, level: Float)] = []
+
+        let octaveRatio = pow(2.0, 1.0 / Double(bandsPerOctave))
+        var freq = minFreq
+
+        while freq <= maxFreq {
+            let centerFreq = freq
+            let lowFreq = centerFreq / sqrt(octaveRatio)
+            let highFreq = centerFreq * sqrt(octaveRatio)
+
+            let lowBin = max(0, Int(lowFreq / binWidth))
+            let highBin = min(magnitudes.count - 1, Int(highFreq / binWidth))
+
+            var bandLevel: Float = 0.0
+            for bin in lowBin...highBin {
+                if magnitudes[bin] > bandLevel {
+                    bandLevel = magnitudes[bin]
+                }
+            }
+
+            // Normalize to [0, 1] assuming typical peak magnitudes around 1.0
+            let normalized = min(1.0, max(0.0, bandLevel))
+            bands.append((centerHz: centerFreq, level: normalized))
+
+            freq *= octaveRatio
+        }
+
+        return bands
+    }
+
+    // MARK: - Pitch Estimation
+
+    /// Estimate the fundamental frequency (pitch) of an audio signal using autocorrelation.
+    ///
+    /// - Parameters:
+    ///   - samples: Array of floating-point audio samples. For robust low-frequency detection, use at least
+    ///     a 2048-sample window (typical 44.1 kHz ≈ 46 ms).
+    ///   - sampleRate: Sample rate in Hz.
+    ///   - minHz: Lowest frequency to consider (Hz), typically 50.
+    ///   - maxHz: Highest frequency to consider (Hz), typically 2000 (speech/singing range).
+    ///
+    /// - Returns: Estimated fundamental frequency in Hz, or nil if confidence is low (silence, noise, polyphonic).
+    ///
+    /// Uses normalized autocorrelation; returns nil if the peak autocorrelation is weak (< 0.5 typically indicates noise or polyphony).
+    /// The search is bounded to the lag range corresponding to [minHz, maxHz].
+    public static func estimatePitchHz(
+        samples: [Float],
+        sampleRate: Double,
+        minHz: Double,
+        maxHz: Double
+    ) -> Double? {
+        guard !samples.isEmpty, minHz > 0, maxHz > minHz, sampleRate > 0 else { return nil }
+
+        let minLag = max(1, Int(sampleRate / maxHz))
+        let maxLag = min(samples.count / 2, Int(sampleRate / minHz))
+
+        guard minLag <= maxLag else { return nil }
+
+        // Compute mean and standard deviation for normalization
+        var mean: Float = 0.0
+        vDSP_meanv(samples, 1, &mean, vDSP_Length(samples.count))
+
+        var sumSquares: Float = 0.0
+        for sample in samples {
+            let diff = sample - mean
+            sumSquares += diff * diff
+        }
+        let stdDev = sqrt(sumSquares / Float(samples.count))
+
+        guard stdDev > 1e-6 else { return nil }  // Near silence
+
+        // Normalize samples
+        var normalized = [Float](repeating: 0, count: samples.count)
+        for i in 0..<samples.count {
+            normalized[i] = (samples[i] - mean) / stdDev
+        }
+
+        // Compute autocorrelation at key lags
+        var bestLag = minLag
+        var bestAutocorr: Float = 0.0
+
+        for lag in minLag...maxLag {
+            var autocorr: Float = 0.0
+            for i in 0..<(samples.count - lag) {
+                autocorr += normalized[i] * normalized[i + lag]
+            }
+            autocorr /= Float(samples.count - lag)
+
+            if autocorr > bestAutocorr {
+                bestAutocorr = autocorr
+                bestLag = lag
+            }
+        }
+
+        // Require high confidence (empirical threshold; lower values may work for cleaner signals)
+        guard bestAutocorr > 0.5 else { return nil }
+
+        let pitchHz = sampleRate / Double(bestLag)
+        return pitchHz
+    }
+
+    // MARK: - Cross-Correlation (Delay Estimation)
+
+    /// Estimate the time delay (lag in samples) of the right channel relative to the left using cross-correlation.
+    ///
+    /// - Parameters:
+    ///   - left: Left-channel audio samples.
+    ///   - right: Right-channel audio samples (must be same length as left).
+    ///   - maxLagSamples: Maximum lag to search (samples). Limits the resolvable delay range.
+    ///     Only lags within ±maxLagSamples are considered.
+    ///
+    /// - Returns: Lag in samples (positive = right lags left; negative = left lags right), or 0 if no clear delay detected.
+    ///
+    /// Uses normalized cross-correlation; returns 0 if the peak is weak (similarity < 0.5).
+    /// **Frequency aliasing:** Delays beyond ±maxLagSamples are unresolvable and mapped to ±maxLag.
+    /// For reliable sub-millisecond delay estimation, use high sample rates (≥ 48 kHz).
+    public static func estimateDelaySamples(left: [Float], right: [Float], maxLagSamples: Int) -> Int {
+        guard left.count == right.count, !left.isEmpty, maxLagSamples > 0 else { return 0 }
+
+        // Compute means
+        var leftMean: Float = 0.0
+        var rightMean: Float = 0.0
+        vDSP_meanv(left, 1, &leftMean, vDSP_Length(left.count))
+        vDSP_meanv(right, 1, &rightMean, vDSP_Length(right.count))
+
+        // Compute standard deviations
+        var leftSumSq: Float = 0.0
+        var rightSumSq: Float = 0.0
+        for i in 0..<left.count {
+            let lDiff = left[i] - leftMean
+            let rDiff = right[i] - rightMean
+            leftSumSq += lDiff * lDiff
+            rightSumSq += rDiff * rDiff
+        }
+
+        let leftStd = sqrt(leftSumSq / Float(left.count))
+        let rightStd = sqrt(rightSumSq / Float(right.count))
+
+        guard leftStd > 1e-6, rightStd > 1e-6 else { return 0 }
+
+        // Compute normalized cross-correlation at positive and negative lags.
+        // Seed with the zero-lag correlation so perfectly aligned channels report 0;
+        // a real delay only wins if its correlation exceeds the aligned case.
+        let searchLag = min(maxLagSamples, left.count / 2)
+
+        var zeroCorr: Float = 0.0
+        for i in 0..<left.count {
+            zeroCorr += (left[i] - leftMean) * (right[i] - rightMean)
+        }
+        zeroCorr /= (Float(left.count) * leftStd * rightStd)
+
+        var bestLag = 0
+        var bestCorr: Float = zeroCorr
+
+        // Test positive lags (right lags left)
+        for lag in 1...searchLag {
+            var xcorr: Float = 0.0
+            let limit = left.count - lag
+            for i in 0..<limit {
+                xcorr += (left[i] - leftMean) * (right[i + lag] - rightMean)
+            }
+            xcorr /= (Float(limit) * leftStd * rightStd)
+
+            if xcorr > bestCorr {
+                bestCorr = xcorr
+                bestLag = lag
+            }
+        }
+
+        // Test negative lags (left lags right)
+        for lag in 1...searchLag {
+            var xcorr: Float = 0.0
+            let limit = left.count - lag
+            for i in 0..<limit {
+                xcorr += (left[i + lag] - leftMean) * (right[i] - rightMean)
+            }
+            xcorr /= (Float(limit) * leftStd * rightStd)
+
+            if xcorr > bestCorr {
+                bestCorr = xcorr
+                bestLag = -lag
+            }
+        }
+
+        // Require strong correlation
+        guard bestCorr > 0.5 else { return 0 }
+
+        return bestLag
+    }
+}

--- a/Tests/NullPlayerAppTests/AudioEngineConsumerGatingTests.swift
+++ b/Tests/NullPlayerAppTests/AudioEngineConsumerGatingTests.swift
@@ -2,26 +2,41 @@ import XCTest
 @testable import NullPlayer
 
 final class AudioEngineConsumerGatingTests: XCTestCase {
-    func testSpectrumAndWaveformConsumersAreTrackedSeparately() {
+    func testAnalysisConsumersAreTrackedSeparately() {
         let engine = AudioEngine()
 
         XCTAssertFalse(engine.spectrumNeeded)
         XCTAssertFalse(engine.waveformNeeded)
+        XCTAssertFalse(engine.stereoNeeded)
 
         engine.addSpectrumConsumer("spectrum")
         XCTAssertTrue(engine.spectrumNeeded)
         XCTAssertFalse(engine.waveformNeeded)
+        XCTAssertFalse(engine.stereoNeeded)
 
         engine.addWaveformConsumer("waveform")
         XCTAssertTrue(engine.spectrumNeeded)
         XCTAssertTrue(engine.waveformNeeded)
+        XCTAssertFalse(engine.stereoNeeded)
+
+        engine.addStereoConsumer("stereo")
+        XCTAssertTrue(engine.spectrumNeeded)
+        XCTAssertTrue(engine.waveformNeeded)
+        XCTAssertTrue(engine.stereoNeeded)
 
         engine.removeSpectrumConsumer("spectrum")
         XCTAssertFalse(engine.spectrumNeeded)
         XCTAssertTrue(engine.waveformNeeded)
+        XCTAssertTrue(engine.stereoNeeded)
 
         engine.removeWaveformConsumer("waveform")
         XCTAssertFalse(engine.spectrumNeeded)
         XCTAssertFalse(engine.waveformNeeded)
+        XCTAssertTrue(engine.stereoNeeded)
+
+        engine.removeStereoConsumer("stereo")
+        XCTAssertFalse(engine.spectrumNeeded)
+        XCTAssertFalse(engine.waveformNeeded)
+        XCTAssertFalse(engine.stereoNeeded)
     }
 }

--- a/Tests/NullPlayerCoreTests/AudioAnalysisDSPTests.swift
+++ b/Tests/NullPlayerCoreTests/AudioAnalysisDSPTests.swift
@@ -1,0 +1,515 @@
+import XCTest
+@testable import NullPlayerCore
+
+final class AudioAnalysisDSPTests: XCTestCase {
+
+    // MARK: - peakDBFS Tests
+
+    func testPeakDBFSWithEmptyArray() {
+        let result = AudioAnalysisDSP.peakDBFS([])
+        XCTAssertEqual(result, -120.0)
+    }
+
+    func testPeakDBFSWithAllZeros() {
+        let result = AudioAnalysisDSP.peakDBFS([0, 0, 0, 0, 0])
+        XCTAssertEqual(result, -120.0)
+    }
+
+    func testPeakDBFSWithFullScale() {
+        // Full scale (1.0) should give peak ≈ 0 dB
+        // 20 * log10(1.0) = 0.0
+        let result = AudioAnalysisDSP.peakDBFS([1.0])
+        XCTAssertEqual(result, 0.0, accuracy: 0.01)
+    }
+
+    func testPeakDBFSWithHalfAmplitude() {
+        // 20 * log10(0.5) ≈ -6.02 dB
+        let result = AudioAnalysisDSP.peakDBFS([0.5])
+        XCTAssertEqual(result, -6.02, accuracy: 0.2)
+    }
+
+    func testPeakDBFSWithMixedAmplitudes() {
+        // Max abs should be 0.8, so 20 * log10(0.8) ≈ -1.94 dB
+        let result = AudioAnalysisDSP.peakDBFS([0.1, -0.3, 0.8, -0.2])
+        XCTAssertEqual(result, 20.0 * log10(0.8), accuracy: 0.1)
+    }
+
+    func testPeakDBFSClampedToMinimum() {
+        // Very small amplitude should be clamped to -120
+        let result = AudioAnalysisDSP.peakDBFS([1e-8])
+        XCTAssertEqual(result, -120.0)
+    }
+
+    // MARK: - rmsDBFS Tests
+
+    func testRmsDBFSWithEmptyArray() {
+        let result = AudioAnalysisDSP.rmsDBFS([])
+        XCTAssertEqual(result, -120.0)
+    }
+
+    func testRmsDBFSWithAllZeros() {
+        let result = AudioAnalysisDSP.rmsDBFS([0, 0, 0, 0, 0])
+        XCTAssertEqual(result, -120.0)
+    }
+
+    func testRmsDBFSWithFullScale() {
+        // Full scale RMS of a constant 1.0 is 1.0
+        // 20 * log10(1.0) = 0.0
+        let result = AudioAnalysisDSP.rmsDBFS([1.0, 1.0, 1.0])
+        XCTAssertEqual(result, 0.0, accuracy: 0.01)
+    }
+
+    func testRmsDBFSWithSineWave() {
+        // For a sine wave with amplitude 1.0, RMS ≈ 1.0 / sqrt(2) ≈ 0.707
+        // 20 * log10(0.707) ≈ -3.01 dB
+        let sine = generateSineWave(frequency: 440, duration: 1.0, sampleRate: 44100, amplitude: 1.0)
+        let result = AudioAnalysisDSP.rmsDBFS(sine)
+        XCTAssertEqual(result, -3.01, accuracy: 0.2)
+    }
+
+    func testRmsLessThanPeakForSine() {
+        // RMS should always be less than or equal to peak for audio
+        let sine = generateSineWave(frequency: 1000, duration: 0.5, sampleRate: 44100, amplitude: 0.8)
+        let peak = AudioAnalysisDSP.peakDBFS(sine)
+        let rms = AudioAnalysisDSP.rmsDBFS(sine)
+        XCTAssertLessThan(rms, peak)
+    }
+
+    func testRmsDBFSWithMixedAmplitudes() {
+        let samples: [Float] = [0.5, -0.3, 0.4, -0.2]
+        // mean(square) = (0.25 + 0.09 + 0.16 + 0.04) / 4 = 0.54 / 4 = 0.135
+        // RMS = sqrt(0.135) ≈ 0.367
+        // 20 * log10(0.367) ≈ -8.70
+        let result = AudioAnalysisDSP.rmsDBFS(samples)
+        XCTAssertEqual(result, 20.0 * log10(sqrt(0.135)), accuracy: 0.1)
+    }
+
+    // MARK: - octaveBands Tests
+
+    func testOctaveBandsWithEmptyMagnitudes() {
+        let result = AudioAnalysisDSP.octaveBands(
+            magnitudes: [],
+            sampleRate: 44100,
+            fftSize: 2048,
+            bandsPerOctave: 3,
+            minFreq: 20,
+            maxFreq: 20000
+        )
+        XCTAssertEqual(result.count, 0)
+    }
+
+    func testOctaveBandsWithInvalidBandsPerOctave() {
+        let magnitudes = [Float](repeating: 0.5, count: 1024)
+        let result = AudioAnalysisDSP.octaveBands(
+            magnitudes: magnitudes,
+            sampleRate: 44100,
+            fftSize: 2048,
+            bandsPerOctave: 0,
+            minFreq: 20,
+            maxFreq: 20000
+        )
+        XCTAssertEqual(result.count, 0)
+    }
+
+    func testOctaveBandsWithInvalidFreqRange() {
+        let magnitudes = [Float](repeating: 0.5, count: 1024)
+        // maxFreq <= minFreq should return empty
+        let result = AudioAnalysisDSP.octaveBands(
+            magnitudes: magnitudes,
+            sampleRate: 44100,
+            fftSize: 2048,
+            bandsPerOctave: 3,
+            minFreq: 20000,
+            maxFreq: 20
+        )
+        XCTAssertEqual(result.count, 0)
+    }
+
+    func testOctaveBandsWithZeroMinFreq() {
+        let magnitudes = [Float](repeating: 0.5, count: 1024)
+        let result = AudioAnalysisDSP.octaveBands(
+            magnitudes: magnitudes,
+            sampleRate: 44100,
+            fftSize: 2048,
+            bandsPerOctave: 3,
+            minFreq: 0,
+            maxFreq: 20000
+        )
+        XCTAssertEqual(result.count, 0)
+    }
+
+    func testOctaveBandsWithZeroSampleRate() {
+        let magnitudes = [Float](repeating: 0.5, count: 1024)
+        let result = AudioAnalysisDSP.octaveBands(
+            magnitudes: magnitudes,
+            sampleRate: 0,
+            fftSize: 2048,
+            bandsPerOctave: 3,
+            minFreq: 20,
+            maxFreq: 20000
+        )
+        XCTAssertEqual(result.count, 0)
+    }
+
+    func testOctaveBandsWithSinglePeakAt1000Hz() {
+        // Create a synthetic magnitude spectrum with a peak at ~1000 Hz
+        let fftSize = 2048
+        let sampleRate = 44100.0
+        let binWidth = sampleRate / Double(fftSize)  // ~21.5 Hz per bin
+        let targetFreq = 1000.0
+        let targetBin = Int(targetFreq / binWidth)
+
+        var magnitudes = [Float](repeating: 0.1, count: fftSize / 2)
+        magnitudes[targetBin] = 1.0  // Peak at 1000 Hz
+
+        let result = AudioAnalysisDSP.octaveBands(
+            magnitudes: magnitudes,
+            sampleRate: sampleRate,
+            fftSize: fftSize,
+            bandsPerOctave: 3,
+            minFreq: 100,
+            maxFreq: 10000
+        )
+
+        XCTAssertGreaterThan(result.count, 0, "Should return bands for valid range")
+
+        // Find the band with highest level
+        let maxBand = result.max { $0.level < $1.level }
+        XCTAssertNotNil(maxBand)
+
+        if let maxBand = maxBand {
+            // The peak band's center should be near 1000 Hz
+            XCTAssertLessThan(abs(maxBand.centerHz - 1000.0), 200.0, "Peak band should be close to 1000 Hz")
+        }
+
+        // Frequencies should be monotonically increasing
+        for i in 1..<result.count {
+            XCTAssertGreaterThan(result[i].centerHz, result[i - 1].centerHz)
+        }
+    }
+
+    func testOctaveBandsMonotonicFrequencies() {
+        let magnitudes = [Float](repeating: 0.5, count: 1024)
+        let result = AudioAnalysisDSP.octaveBands(
+            magnitudes: magnitudes,
+            sampleRate: 44100,
+            fftSize: 2048,
+            bandsPerOctave: 1,
+            minFreq: 20,
+            maxFreq: 20000
+        )
+
+        XCTAssertGreaterThan(result.count, 0)
+        for i in 1..<result.count {
+            XCTAssertGreaterThan(result[i].centerHz, result[i - 1].centerHz)
+        }
+    }
+
+    func testOctaveBandsHigherBandsPerOctaveYieldsMoreBands() {
+        let magnitudes = [Float](repeating: 0.5, count: 1024)
+
+        let bands1 = AudioAnalysisDSP.octaveBands(
+            magnitudes: magnitudes,
+            sampleRate: 44100,
+            fftSize: 2048,
+            bandsPerOctave: 1,
+            minFreq: 100,
+            maxFreq: 1600
+        )
+
+        let bands3 = AudioAnalysisDSP.octaveBands(
+            magnitudes: magnitudes,
+            sampleRate: 44100,
+            fftSize: 2048,
+            bandsPerOctave: 3,
+            minFreq: 100,
+            maxFreq: 1600
+        )
+
+        XCTAssertGreaterThan(bands3.count, bands1.count)
+    }
+
+    // MARK: - estimatePitchHz Tests
+
+    func testEstimatePitchHzWithEmptySamples() {
+        let result = AudioAnalysisDSP.estimatePitchHz(
+            samples: [],
+            sampleRate: 44100,
+            minHz: 50,
+            maxHz: 2000
+        )
+        XCTAssertNil(result)
+    }
+
+    func testEstimatePitchHzWithSilence() {
+        let silence = [Float](repeating: 0, count: 2048)
+        let result = AudioAnalysisDSP.estimatePitchHz(
+            samples: silence,
+            sampleRate: 44100,
+            minHz: 50,
+            maxHz: 2000
+        )
+        XCTAssertNil(result)
+    }
+
+    func testEstimatePitchHzWithConstantDC() {
+        // Constant non-zero DC should not have detectable pitch
+        let dc = [Float](repeating: 0.5, count: 2048)
+        let result = AudioAnalysisDSP.estimatePitchHz(
+            samples: dc,
+            sampleRate: 44100,
+            minHz: 50,
+            maxHz: 2000
+        )
+        XCTAssertNil(result)
+    }
+
+    func testEstimatePitchHzWith440HzSine() {
+        // 440 Hz is A4 (concert pitch), 2048 samples at 44100 Hz ≈ 46 ms
+        let samples = generateSineWave(frequency: 440, duration: 0.046, sampleRate: 44100, amplitude: 1.0)
+        let result = AudioAnalysisDSP.estimatePitchHz(
+            samples: Array(samples.prefix(2048)),
+            sampleRate: 44100,
+            minHz: 100,
+            maxHz: 2000
+        )
+
+        XCTAssertNotNil(result)
+        if let pitch = result {
+            // Within ~3% of true frequency
+            let tolerance = 440 * 0.03
+            XCTAssertEqual(pitch, 440, accuracy: tolerance)
+        }
+    }
+
+    func testEstimatePitchHzWith220HzSine() {
+        // 220 Hz is A3
+        let samples = generateSineWave(frequency: 220, duration: 0.046, sampleRate: 44100, amplitude: 1.0)
+        let result = AudioAnalysisDSP.estimatePitchHz(
+            samples: Array(samples.prefix(2048)),
+            sampleRate: 44100,
+            minHz: 100,
+            maxHz: 2000
+        )
+
+        XCTAssertNotNil(result)
+        if let pitch = result {
+            let tolerance = 220 * 0.03
+            XCTAssertEqual(pitch, 220, accuracy: tolerance)
+        }
+    }
+
+    func testEstimatePitchHzWithRandomNoise() {
+        // White noise should not yield a stable pitch
+        let noise = generateDeterministicNoise(count: 2048, seed: 42)
+        let result = AudioAnalysisDSP.estimatePitchHz(
+            samples: noise,
+            sampleRate: 44100,
+            minHz: 50,
+            maxHz: 2000
+        )
+        // Random noise may or may not return nil; the autocorrelation peak should be low.
+        // Accept either nil or an unstable result; we're asserting no stable harmonic.
+        if let pitch = result {
+            // If we got a result, it should not be suspiciously harmonic
+            // (This is a loose check; noise is inherently unpredictable.)
+            _ = pitch
+        }
+    }
+
+    func testEstimatePitchHzInvalidMinMaxHz() {
+        let samples = generateSineWave(frequency: 440, duration: 0.046, sampleRate: 44100, amplitude: 1.0)
+
+        // maxHz <= minHz
+        let result = AudioAnalysisDSP.estimatePitchHz(
+            samples: Array(samples.prefix(2048)),
+            sampleRate: 44100,
+            minHz: 2000,
+            maxHz: 100
+        )
+        XCTAssertNil(result)
+    }
+
+    func testEstimatePitchHzInvalidZeroMinHz() {
+        let samples = generateSineWave(frequency: 440, duration: 0.046, sampleRate: 44100, amplitude: 1.0)
+        let result = AudioAnalysisDSP.estimatePitchHz(
+            samples: Array(samples.prefix(2048)),
+            sampleRate: 44100,
+            minHz: 0,
+            maxHz: 2000
+        )
+        XCTAssertNil(result)
+    }
+
+    func testEstimatePitchHzInvalidZeroSampleRate() {
+        let samples = generateSineWave(frequency: 440, duration: 0.046, sampleRate: 44100, amplitude: 1.0)
+        let result = AudioAnalysisDSP.estimatePitchHz(
+            samples: Array(samples.prefix(2048)),
+            sampleRate: 0,
+            minHz: 50,
+            maxHz: 2000
+        )
+        XCTAssertNil(result)
+    }
+
+    func testEstimatePitchHzLowFreqIn512SampleWindow() {
+        // DOCUMENTED LIMIT: sub-100 Hz in a 512-sample window is unreliable.
+        // For 50 Hz at 44100 Hz sample rate, period = 44100 / 50 = 882 samples.
+        // A 512-sample window captures ~0.58 periods, which is insufficient for autocorrelation
+        // to reliably detect the fundamental. We assert that it either returns nil or a result
+        // that is not within 3% of the true 50 Hz.
+        let samples = generateSineWave(frequency: 50, duration: 512.0 / 44100.0, sampleRate: 44100, amplitude: 1.0)
+        let result = AudioAnalysisDSP.estimatePitchHz(
+            samples: samples,
+            sampleRate: 44100,
+            minHz: 40,
+            maxHz: 200
+        )
+
+        if let pitch = result {
+            // The pitch estimate may be octave-shifted or inaccurate for such a short window at low frequency.
+            // We assert that it's either far off OR the test documents the limitation.
+            let tolerance = 50 * 0.03
+            let isWithinTolerance = abs(pitch - 50) <= tolerance
+            XCTAssertFalse(isWithinTolerance, "Low-freq pitch in 512-sample window should be unreliable")
+        }
+    }
+
+    // MARK: - estimateDelaySamples Tests
+
+    func testEstimateDelaySamplesWithMismatchedLengths() {
+        let left = [Float](repeating: 0.5, count: 100)
+        let right = [Float](repeating: 0.5, count: 50)
+        let result = AudioAnalysisDSP.estimateDelaySamples(left: left, right: right, maxLagSamples: 20)
+        XCTAssertEqual(result, 0)
+    }
+
+    func testEstimateDelaySamplesWithEmptyArrays() {
+        let result = AudioAnalysisDSP.estimateDelaySamples(left: [], right: [], maxLagSamples: 20)
+        XCTAssertEqual(result, 0)
+    }
+
+    func testEstimateDelaySamplesWithZeroMaxLag() {
+        let left = generateSineWave(frequency: 440, duration: 0.01, sampleRate: 44100, amplitude: 1.0)
+        let right = left
+        let result = AudioAnalysisDSP.estimateDelaySamples(left: left, right: right, maxLagSamples: 0)
+        XCTAssertEqual(result, 0)
+    }
+
+    func testEstimateDelaySamplesWithNegativeMaxLag() {
+        let left = generateSineWave(frequency: 440, duration: 0.01, sampleRate: 44100, amplitude: 1.0)
+        let right = left
+        let result = AudioAnalysisDSP.estimateDelaySamples(left: left, right: right, maxLagSamples: -10)
+        XCTAssertEqual(result, 0)
+    }
+
+    func testEstimateDelaySamplesWithZeroDelay() {
+        // Right is identical to left
+        let left = generateSineWave(frequency: 440, duration: 0.01, sampleRate: 44100, amplitude: 1.0)
+        let right = left
+        let result = AudioAnalysisDSP.estimateDelaySamples(left: left, right: right, maxLagSamples: 64)
+        XCTAssertEqual(result, 0)
+    }
+
+    func testEstimateDelaySamplesWithPositiveDelay() {
+        // Right lags left by 10 samples
+        let delay = 10
+        let left = generateSineWave(frequency: 440, duration: 0.01, sampleRate: 44100, amplitude: 1.0)
+
+        var right = [Float](repeating: 0, count: left.count)
+        for i in 0..<left.count {
+            if i >= delay {
+                right[i] = left[i - delay]
+            }
+        }
+
+        let result = AudioAnalysisDSP.estimateDelaySamples(left: left, right: right, maxLagSamples: 64)
+        // Positive = right lags left
+        XCTAssertEqual(result, delay, accuracy: 2)
+    }
+
+    func testEstimateDelaySamplesWithNegativeDelay() {
+        // Left lags right by 15 samples (right leads)
+        let delay = 15
+        let right = generateSineWave(frequency: 440, duration: 0.01, sampleRate: 44100, amplitude: 1.0)
+
+        var left = [Float](repeating: 0, count: right.count)
+        for i in 0..<right.count {
+            if i >= delay {
+                left[i] = right[i - delay]
+            }
+        }
+
+        let result = AudioAnalysisDSP.estimateDelaySamples(left: left, right: right, maxLagSamples: 64)
+        // Negative = left lags right
+        XCTAssertEqual(result, -delay, accuracy: 2)
+    }
+
+    func testEstimateDelaySamplesFrequencyAliasing() {
+        // When true delay exceeds maxLagSamples, the estimate should NOT equal the true delay.
+        // Instead, it should wrap/alias to ±maxLag.
+        let delay = 40
+        let maxLag = 8
+        let left = generateSineWave(frequency: 440, duration: 0.01, sampleRate: 44100, amplitude: 1.0)
+
+        var right = [Float](repeating: 0, count: left.count)
+        for i in 0..<left.count {
+            if i >= delay {
+                right[i] = left[i - delay]
+            }
+        }
+
+        let result = AudioAnalysisDSP.estimateDelaySamples(left: left, right: right, maxLagSamples: maxLag)
+        // Result should not equal the true 40-sample delay
+        XCTAssertNotEqual(result, delay)
+        // Result should be clamped to ±maxLag
+        XCTAssertLessThanOrEqual(abs(result), maxLag)
+    }
+
+    func testEstimateDelaySamplesWithWeakCorrelation() {
+        // Two unrelated signals should return 0 (weak correlation)
+        let left = generateDeterministicNoise(count: 512, seed: 42)
+        let right = generateDeterministicNoise(count: 512, seed: 99)
+
+        let result = AudioAnalysisDSP.estimateDelaySamples(left: left, right: right, maxLagSamples: 64)
+        XCTAssertEqual(result, 0, "Unrelated signals should return 0 correlation")
+    }
+
+    // MARK: - Helper Functions
+
+    /// Generate a sine wave at a specified frequency.
+    /// - Parameters:
+    ///   - frequency: Frequency in Hz
+    ///   - duration: Duration in seconds
+    ///   - sampleRate: Sample rate in Hz
+    ///   - amplitude: Amplitude (default 1.0)
+    /// - Returns: Array of audio samples
+    private func generateSineWave(frequency: Double, duration: Double, sampleRate: Double, amplitude: Float) -> [Float] {
+        let sampleCount = Int(duration * sampleRate)
+        var samples = [Float](repeating: 0, count: sampleCount)
+        let tau = 2.0 * .pi
+        for i in 0..<sampleCount {
+            let t = Double(i) / sampleRate
+            samples[i] = amplitude * Float(sin(tau * frequency * t))
+        }
+        return samples
+    }
+
+    /// Generate deterministic pseudo-random noise using a simple LCG.
+    /// - Parameters:
+    ///   - count: Number of samples
+    ///   - seed: LCG seed for determinism
+    /// - Returns: Array of pseudo-random samples in [-1, 1]
+    private func generateDeterministicNoise(count: Int, seed: UInt32) -> [Float] {
+        var samples = [Float](repeating: 0, count: count)
+        var state = seed
+
+        for i in 0..<count {
+            state = state &* 1103515245 &+ 12345  // LCG constants
+            let normalized = Float(state) / Float(UInt32.max)
+            samples[i] = (normalized * 2.0) - 1.0  // Scale to [-1, 1]
+        }
+
+        return samples
+    }
+}

--- a/Tests/NullPlayerCoreTests/AudioAnalysisDSPTests.swift
+++ b/Tests/NullPlayerCoreTests/AudioAnalysisDSPTests.swift
@@ -40,6 +40,10 @@ final class AudioAnalysisDSPTests: XCTestCase {
         XCTAssertEqual(result, -120.0)
     }
 
+    func testPeakDBFSClampedToFullScale() {
+        XCTAssertEqual(AudioAnalysisDSP.peakDBFS([2.0]), 0.0)
+    }
+
     // MARK: - rmsDBFS Tests
 
     func testRmsDBFSWithEmptyArray() {
@@ -82,6 +86,10 @@ final class AudioAnalysisDSPTests: XCTestCase {
         // 20 * log10(0.367) ≈ -8.70
         let result = AudioAnalysisDSP.rmsDBFS(samples)
         XCTAssertEqual(result, 20.0 * log10(sqrt(0.135)), accuracy: 0.1)
+    }
+
+    func testRmsDBFSClampedToFullScale() {
+        XCTAssertEqual(AudioAnalysisDSP.rmsDBFS([2.0, -2.0]), 0.0)
     }
 
     // MARK: - octaveBands Tests
@@ -149,6 +157,30 @@ final class AudioAnalysisDSPTests: XCTestCase {
             maxFreq: 20000
         )
         XCTAssertEqual(result.count, 0)
+    }
+
+    func testOctaveBandsRejectsNonFiniteParameters() {
+        let magnitudes = [Float](repeating: 0.5, count: 16)
+        XCTAssertTrue(AudioAnalysisDSP.octaveBands(
+            magnitudes: magnitudes,
+            sampleRate: .infinity,
+            fftSize: 32,
+            bandsPerOctave: 3,
+            minFreq: 20,
+            maxFreq: 20000
+        ).isEmpty)
+    }
+
+    func testOctaveBandsSkipsBandsAboveAvailableSpectrum() {
+        let result = AudioAnalysisDSP.octaveBands(
+            magnitudes: [0.5],
+            sampleRate: 44100,
+            fftSize: 2048,
+            bandsPerOctave: 3,
+            minFreq: 1000,
+            maxFreq: 2000
+        )
+        XCTAssertTrue(result.isEmpty)
     }
 
     func testOctaveBandsWithSinglePeakAt1000Hz() {
@@ -308,13 +340,7 @@ final class AudioAnalysisDSPTests: XCTestCase {
             minHz: 50,
             maxHz: 2000
         )
-        // Random noise may or may not return nil; the autocorrelation peak should be low.
-        // Accept either nil or an unstable result; we're asserting no stable harmonic.
-        if let pitch = result {
-            // If we got a result, it should not be suspiciously harmonic
-            // (This is a loose check; noise is inherently unpredictable.)
-            _ = pitch
-        }
+        XCTAssertNil(result, "Deterministic white noise should not produce a stable pitch")
     }
 
     func testEstimatePitchHzInvalidMinMaxHz() {
@@ -352,6 +378,16 @@ final class AudioAnalysisDSPTests: XCTestCase {
         XCTAssertNil(result)
     }
 
+    func testEstimatePitchHzRejectsNonFiniteParameters() {
+        let samples = [Float](repeating: 0.5, count: 2048)
+        XCTAssertNil(AudioAnalysisDSP.estimatePitchHz(
+            samples: samples,
+            sampleRate: .infinity,
+            minHz: 50,
+            maxHz: 2000
+        ))
+    }
+
     func testEstimatePitchHzLowFreqIn512SampleWindow() {
         // DOCUMENTED LIMIT: sub-100 Hz in a 512-sample window is unreliable.
         // For 50 Hz at 44100 Hz sample rate, period = 44100 / 50 = 882 samples.
@@ -386,6 +422,11 @@ final class AudioAnalysisDSPTests: XCTestCase {
 
     func testEstimateDelaySamplesWithEmptyArrays() {
         let result = AudioAnalysisDSP.estimateDelaySamples(left: [], right: [], maxLagSamples: 20)
+        XCTAssertEqual(result, 0)
+    }
+
+    func testEstimateDelaySamplesWithSingleSample() {
+        let result = AudioAnalysisDSP.estimateDelaySamples(left: [1], right: [1], maxLagSamples: 1)
         XCTAssertEqual(result, 0)
     }
 

--- a/scripts/third_party_components.tsv
+++ b/scripts/third_party_components.tsv
@@ -47,3 +47,4 @@ fft-nullsoft	Nullsoft FFT	BSD-3-Clause	Copyright 2005-2013 Nullsoft, Inc.	https:
 departuremono	Departure Mono	OFL-1.1	Copyright (c) 2024 Helena Zhang	https://departuremono.com	1.422	Fonts/DepartureMono-LICENSE.txt	-
 milkdrop-presets	MilkDrop / projectM presets	community (see notice)	Various MilkDrop / projectM preset authors	https://github.com/projectM-visualizer/presets-cream-of-the-crop	bundled assets	ThirdPartyLicenses/MilkDropPresets_NOTICE.txt	-
 bundled-skins	Bundled skins and visual assets	project-original	NullPlayer project	https://github.com/ad-repo/nullplayer	bundled assets	ThirdPartyLicenses/BundledSkins_NOTICE.txt	-
+viridis	Viridis colormap	CC0-1.0	Copyright waived — Stéfan van der Walt and Nathaniel Smith (public domain via CC0)	https://github.com/BIDS/colormap	bundled constants	ThirdPartyLicenses/Viridis_NOTICE.txt	-

--- a/skills/audio-analysis-window/SKILL.md
+++ b/skills/audio-analysis-window/SKILL.md
@@ -1,0 +1,75 @@
+---
+name: audio-analysis-window
+description: The modern-UI Audio Analysis window — a Friture-style multi-pane analyzer (Scope, Levels, Spectrogram), the stereo PCM path that feeds it, per-pane consumer gating, and the shared AudioAnalysisDSP module. Use when modifying the analysis window, its panes, the spectrogram shader, or the stereo/DSP plumbing.
+---
+
+# Audio Analysis Window
+
+A modern-UI-only window offering a Friture-style (https://friture.org) real-time view of the
+playing audio. A SwiftUI segmented picker switches between panes; exactly one pane is visible at
+a time. Modeled on the `ModernSpectrum` window pattern and has **zero** dependencies on the
+classic skin system.
+
+## Accessing
+
+- Window menu / right-click main window → **Audio Analysis** (guarded by `isModernUIEnabled`)
+- Available in **modern UI mode only**.
+
+## Panes (MVP)
+
+| Pane | Source notification | Consumer it registers | Render |
+|------|--------------------|----------------------|--------|
+| **Scope** (oscilloscope) | `.audioPCMDataUpdated` (`userInfo["pcm"]` 512 mono) | spectrum | CoreGraphics (`NSView`) |
+| **Levels** (peak/RMS) | `.audioStereoPCMDataUpdated` (`left`/`right` 512) | stereo | SwiftUI bars |
+| **Spectrogram** (waterfall) | `.audioSpectrumDataUpdated` (`spectrum` 75 bands) | spectrum | Metal (`MTKView`) |
+
+`.audioPCMDataUpdated` is posted *inside* the spectrum block, so the Scope pane registers a
+**spectrum** consumer (not a dedicated PCM one) to make mono PCM flow.
+
+Deferred (DSP exists, panes not built): Octave spectrum, Pitch tracker, Delay estimator.
+
+## Architecture
+
+- **Window**: `Windows/ModernAudioAnalysis/ModernAudioAnalysisWindowController.swift` (conforms to
+  `App/AudioAnalysisWindowProviding.swift`) + `ModernAudioAnalysisView.swift` (SwiftUI host + picker).
+- **Panes**: `ScopePaneView.swift`, `LevelsPaneView.swift`, `SpectrogramPaneView.swift`.
+- **Shader**: `Visualization/SpectrogramShaders.metal` — fullscreen quad generated from
+  `[[vertex_id]]` (no vertex buffer), samples an `r32Float` history texture, Viridis colormap LUT.
+  Low frequencies at the bottom (texCoord.y = 0).
+- **DSP**: `Sources/NullPlayerCore/Audio/AudioAnalysisDSP.swift` — pure-Swift, unit-tested
+  (`Tests/NullPlayerCoreTests/AudioAnalysisDSPTests.swift`): `peakDBFS`, `rmsDBFS`, `octaveBands`,
+  `estimatePitchHz` (autocorrelation), `estimateDelaySamples` (L/R cross-correlation).
+- **Stereo path**: `Audio/AudioEngine.swift` and `Audio/StreamingAudioPlayer.swift` publish
+  `.audioStereoPCMDataUpdated` (downsampled L/R) gated by `addStereoConsumer`/`removeStereoConsumer`/
+  `stereoNeeded`, mirroring the spectrum/waveform consumer pattern. Wired in **both** the local
+  engine and the streaming delegate (`streamingPlayerDidUpdateStereoPCM(left:right:sampleRate:)`).
+
+## Consumer gating (CPU)
+
+`ModernAudioAnalysisView` calls `controller.setVisiblePane(_:)` on `.onAppear` and
+`.onChange(of:selectedPane)`; the controller registers exactly the visible pane's consumer and
+`windowWillClose` calls `deregisterAllConsumers()`. A hidden/closed window must leave the FFT and
+stereo path idle. The spectrogram also pauses its `MTKView` (`isPaused`) on window miniaturize and
+when removed from its window.
+
+## Persistence
+
+Window frame saved in `AppStateManager` session state (`audioAnalysisWindowFrame`, gated by
+`savedInModernMode`); the selected pane persists via `UserDefaults`. Docks/snaps with
+Main/EQ/Playlist/Spectrum via `WindowManager`.
+
+## Gotchas
+
+- **Notifications post from the audio thread.** Observers must marshal to main: AppKit observers
+  use `addObserver(forName:object:queue:.main)`; the SwiftUI Levels pane uses
+  `.publisher(for:).receive(on: DispatchQueue.main)`. Mutating SwiftUI `@State` off-main is a bug.
+- **Metal**: guard `pipelineState` and `historyTexture` **before** creating the command encoder
+  (see [metal-gotchas](../metal-gotchas/SKILL.md)); watch the render-to-texture y-flip. The
+  spectrogram uses paced `MTKView` drawing (`preferredFramesPerSecond`), not a manual timer loop.
+- **Modern independence**: files under `Windows/ModernAudioAnalysis/` must not import from `Skin/`
+  or `Windows/MainWindow/`.
+- **Two playback paths**: any new tap data must be emitted by both `AudioEngine` and the
+  `StreamingAudioPlayer` delegate route, or streaming silently misses it.
+
+See [visualizations](../visualizations/SKILL.md) for the visualization index and
+[spectrum-analyzer-window](../spectrum-analyzer-window/SKILL.md) for the related spectrum window.

--- a/skills/audio-analysis-window/SKILL.md
+++ b/skills/audio-analysis-window/SKILL.md
@@ -12,14 +12,15 @@ playing audio. Exactly one pane is visible at a time; the pane is selected via t
 
 ## Accessing
 
-- Window menu / right-click main window → **Audio Analysis** (guarded by `isModernUIEnabled`)
+- Window menu / main window right-click context menu → **Audio Analysis** (guarded by
+  `isRunningModernUI`)
 - Available in **modern UI mode only**.
 
 ## Window chrome & sizing
 
 - **Center-stack window.** Registered as `CenterStackWindowKind.audioAnalysis` in `WindowManager`.
-  It opens at the **same width as the main window**, docks/snaps flush in the vertical stack, and is
-  stretchable in height like the spectrum/playlist windows. `showAudioAnalysis` applies
+  It opens at the **same width as the main window**, docks/snaps flush in the vertical stack and is
+  vertically stretchable like spectrum/playlist windows. `showAudioAnalysis` applies
   `applyCenterStackSizingConstraints` / `applyDefaultCenterStackFrameForCurrentHT` /
   `normalizedCenterStackRestoredFrame` exactly like `showSpectrum`. The controller's default size is
   `ModernSkinElements.spectrumWindowSize`.
@@ -74,11 +75,11 @@ Deferred (DSP exists, panes not built): Octave spectrum, Pitch tracker, Delay es
 
 ## Consumer gating (CPU)
 
-`AudioAnalysisContentView` calls `controller.setVisiblePane(_:)` on `.onAppear` and
-`.onChange(of: model.selectedPane)`; the controller registers exactly the visible pane's consumer and
-`windowWillClose` calls `deregisterAllConsumers()`. A hidden/closed window must leave the FFT and
-stereo path idle. The spectrogram also pauses its `MTKView` (`isPaused`) on window miniaturize and
-when removed from its window.
+The controller registers the initial pane in `showWindow(_:)`; `AudioAnalysisContentView` updates it
+on `.onChange(of: model.selectedPane)`. The controller registers exactly the visible pane's consumer,
+and both `stopRenderingForHide()` and `windowWillClose` call `deregisterAllConsumers()`. A
+hidden/closed window must leave the FFT and stereo path idle. The spectrogram also pauses its
+`MTKView` (`isPaused`) while hidden or miniaturized.
 
 ## Persistence
 

--- a/skills/audio-analysis-window/SKILL.md
+++ b/skills/audio-analysis-window/SKILL.md
@@ -6,14 +6,34 @@ description: The modern-UI Audio Analysis window — a Friture-style multi-pane 
 # Audio Analysis Window
 
 A modern-UI-only window offering a Friture-style (https://friture.org) real-time view of the
-playing audio. A SwiftUI segmented picker switches between panes; exactly one pane is visible at
-a time. Modeled on the `ModernSpectrum` window pattern and has **zero** dependencies on the
-classic skin system.
+playing audio. Exactly one pane is visible at a time; the pane is selected via the window's
+**right-click context menu** (no in-window controls — matches the Spectrum window). Modeled on the
+`ModernSpectrum` window pattern and has **zero** dependencies on the classic skin system.
 
 ## Accessing
 
 - Window menu / right-click main window → **Audio Analysis** (guarded by `isModernUIEnabled`)
 - Available in **modern UI mode only**.
+
+## Window chrome & sizing
+
+- **Center-stack window.** Registered as `CenterStackWindowKind.audioAnalysis` in `WindowManager`.
+  It opens at the **same width as the main window**, docks/snaps flush in the vertical stack, and is
+  stretchable in height like the spectrum/playlist windows. `showAudioAnalysis` applies
+  `applyCenterStackSizingConstraints` / `applyDefaultCenterStackFrameForCurrentHT` /
+  `normalizedCenterStackRestoredFrame` exactly like `showSpectrum`. The controller's default size is
+  `ModernSkinElements.spectrumWindowSize`.
+- **Double Size (Large UI).** `WindowManager.applyDoubleSize()` has an explicit audio-analysis block
+  (after the waveform block) that rescales the frame by `classicScaleMultiplier`. Without it the
+  window is the one stack window that doesn't follow Large UI when toggled.
+- **Hide Title Bars.** Included in `effectiveHideTitleBars(for:)` (sub-window list), so it auto-hides
+  when docked and follows the global HT toggle. The view reads `effectiveHideTitleBars` for its
+  title-bar height, drawing, and hit-testing.
+- **Chrome rendering.** `ModernAudioAnalysisView` draws the skin title bar + close button (`spectrum_`
+  prefix) and insets the SwiftUI hosting view into the content area (inside `borderWidth`, below
+  `titleBarHeight`) via `contentAreaRect()` / `layoutHostingView()`. The hosting view's `appearance`
+  is set from skin brightness (aqua/darkAqua) and the content gets `skinTextColor` — do **not** cover
+  the chrome with an opaque background.
 
 ## Panes (MVP)
 
@@ -31,11 +51,19 @@ Deferred (DSP exists, panes not built): Octave spectrum, Pitch tracker, Delay es
 ## Architecture
 
 - **Window**: `Windows/ModernAudioAnalysis/ModernAudioAnalysisWindowController.swift` (conforms to
-  `App/AudioAnalysisWindowProviding.swift`) + `ModernAudioAnalysisView.swift` (SwiftUI host + picker).
-- **Panes**: `ScopePaneView.swift`, `LevelsPaneView.swift`, `SpectrogramPaneView.swift`.
+  `App/AudioAnalysisWindowProviding.swift`) + `ModernAudioAnalysisView.swift` (SwiftUI host + the
+  `menu(for:)` context menu for pane selection + Close).
+- **Pane selection state**: `AudioAnalysisModel: ObservableObject` (`@Published var selectedPane`),
+  owned by the NSView and observed by `AudioAnalysisContentView`. The right-click `menu(for:)` mutates
+  it (radio items + Close); the content view's `.onChange` persists it and calls
+  `controller.setVisiblePane(_:)`.
+- **Panes**: `ScopePaneView.swift`, `LevelsPaneView.swift` (vertical full-height peak/RMS meters,
+  no title text), `SpectrogramPaneView.swift`.
 - **Shader**: `Visualization/SpectrogramShaders.metal` — fullscreen quad generated from
   `[[vertex_id]]` (no vertex buffer), samples an `r32Float` history texture, Viridis colormap LUT.
-  Low frequencies at the bottom (texCoord.y = 0).
+  Low frequencies at the bottom (texCoord.y = 0). **Loaded via `BundleHelper.url(...)` +
+  `device.makeLibrary(source:)`** — `makeDefaultLibrary()` returns nil in SPM executables (same
+  pattern as `SpectrumAnalyzerView`). The `.metal` file is a `.copy` resource in `Package.swift`.
 - **DSP**: `Sources/NullPlayerCore/Audio/AudioAnalysisDSP.swift` — pure-Swift, unit-tested
   (`Tests/NullPlayerCoreTests/AudioAnalysisDSPTests.swift`): `peakDBFS`, `rmsDBFS`, `octaveBands`,
   `estimatePitchHz` (autocorrelation), `estimateDelaySamples` (L/R cross-correlation).
@@ -46,8 +74,8 @@ Deferred (DSP exists, panes not built): Octave spectrum, Pitch tracker, Delay es
 
 ## Consumer gating (CPU)
 
-`ModernAudioAnalysisView` calls `controller.setVisiblePane(_:)` on `.onAppear` and
-`.onChange(of:selectedPane)`; the controller registers exactly the visible pane's consumer and
+`AudioAnalysisContentView` calls `controller.setVisiblePane(_:)` on `.onAppear` and
+`.onChange(of: model.selectedPane)`; the controller registers exactly the visible pane's consumer and
 `windowWillClose` calls `deregisterAllConsumers()`. A hidden/closed window must leave the FFT and
 stereo path idle. The spectrogram also pauses its `MTKView` (`isPaused`) on window miniaturize and
 when removed from its window.
@@ -63,6 +91,13 @@ Main/EQ/Playlist/Spectrum via `WindowManager`.
 - **Notifications post from the audio thread.** Observers must marshal to main: AppKit observers
   use `addObserver(forName:object:queue:.main)`; the SwiftUI Levels pane uses
   `.publisher(for:).receive(on: DispatchQueue.main)`. Mutating SwiftUI `@State` off-main is a bug.
+- **Spectrogram bands are already 0–1.** `.audioSpectrumDataUpdated`'s `"spectrum"` is **75 bands
+  normalized 0–1** (see `AudioEngine` doc comment), NOT dBFS. Feed them straight to the colormap.
+  Treating them as dBFS (e.g. `(v + 80) / 80`) pushes every band to ≈1.0 → the whole window floods
+  yellow.
+- **Shader load (SPM)**: load the `.metal` source via `BundleHelper.url(...)` and compile with
+  `device.makeLibrary(source:)`. `device.makeDefaultLibrary()` returns nil in SPM executables →
+  "Failed to load shader library" and a blank pane.
 - **Metal**: guard `pipelineState` and `historyTexture` **before** creating the command encoder
   (see [metal-gotchas](../metal-gotchas/SKILL.md)); watch the render-to-texture y-flip. The
   spectrogram uses paced `MTKView` drawing (`preferredFramesPerSecond`), not a manual timer loop.

--- a/skills/visualizations/SKILL.md
+++ b/skills/visualizations/SKILL.md
@@ -15,6 +15,7 @@ The standalone waveform window is **not** a Metal visualization mode. It reuses 
 |-------|-------|
 | [main-window-visualization](../main-window-visualization/SKILL.md) | The 76×16 main-window display area: 11 modes, switching, mode-specific settings |
 | [spectrum-analyzer-window](../spectrum-analyzer-window/SKILL.md) | Dedicated 84-bar spectrum window: docking, geometry, mode list, the cropped analyzer curve, vis_classic waveform demand |
+| [audio-analysis-window](../audio-analysis-window/SKILL.md) | Friture-style multi-pane Audio Analysis window: Scope/Levels/Spectrogram panes, stereo PCM path, per-pane consumer gating, AudioAnalysisDSP module |
 | [gpu-vis-modes](../gpu-vis-modes/SKILL.md) | Per-mode internals shared by both windows: Fire, JWST, Lightning, Matrix, Snow, EKG, Classic/Enhanced/Ultra |
 | [album-art-visualizer](../album-art-visualizer/SKILL.md) | Library Browser ART-mode effects (30 Core Image filters) |
 | [projectm-milkdrop](../projectm-milkdrop/SKILL.md) | ProjectM/MilkDrop preset engine in the visualization window |


### PR DESCRIPTION
## Summary

A new **modern-UI Audio Analysis window** (Window menu / right-click → **Audio Analysis**), a Friture-style real-time analyzer. A segmented picker switches between three live panes:

- **Scope** — oscilloscope of the live mono waveform (CoreGraphics).
- **Levels** — per-channel peak + RMS in dBFS with color-coded headroom (SwiftUI).
- **Spectrogram** — scrolling Metal waterfall mapping per-frame FFT magnitudes through a Viridis color ramp (low freq at bottom, time scrolls right→left).

This is the plan's **MVP scope** (Phase 0 + Phase 1 + Phase 2a). The Pitch, Delay, and Octave DSP routines are implemented and unit-tested but their panes are deferred.

## What's included

- **Stereo PCM path** — `AudioEngine` and `StreamingAudioPlayer` publish `.audioStereoPCMDataUpdated` (downsampled L/R) alongside the existing mono mix, gated by a new `addStereoConsumer`/`removeStereoConsumer`/`stereoNeeded` set. Wired on **both** the local engine and the streaming delegate route.
- **`AudioAnalysisDSP`** (`NullPlayerCore`, pure Swift) — `peakDBFS`, `rmsDBFS`, `octaveBands`, `estimatePitchHz` (autocorrelation), `estimateDelaySamples` (L/R cross-correlation). **39 unit tests**, all passing.
- **Per-pane consumer gating** — the visible pane registers exactly the consumer it needs (on appear / pane change); `windowWillClose` deregisters all, so a closed/hidden window leaves the FFT and stereo path idle. The spectrogram also pauses its `MTKView` on minimize.
- **Persistence + docking** — window frame (session state, modern-mode gated) and selected pane persisted; docks/snaps with Main/EQ/Playlist/Spectrum.
- **Docs** — CHANGELOG `0.26.0`; README feature bullet + Viridis license acknowledgment; Viridis third-party notice + regenerated `ThirdPartyNotices.txt`; new `audio-analysis-window` skill (indexed in `visualizations` + `CLAUDE.md`).

## Notes

- **Modern UI only** (guarded at menu, property, and action layers); zero coupling to the classic skin system.
- App version (`Info.plist`) left at `0.25.0` — changelog filed under `0.26.0` per request; bump on request.

## Testing

- `swift build` clean; `swift test --filter NullPlayerCoreTests` → 39/39 pass.
- A Checker pass caught and fixed runtime-wiring bugs (consumer registration never invoked, off-main SwiftUI state mutation, spectrogram texture never uploaded, leaked render loop, and a `stage_in`-without-`vertexDescriptor` black-spectrogram bug).
- **Manual QA still needed:** open the window and verify each pane with local playback **and an HTTP stream**, plus silence; confirm docking and Remember-State-on-Quit.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Introduced an **Audio Analysis** window (modern UI mode only) with **Scope**, **Stereo Levels** (L/R peak & RMS), and a scrolling **Spectrogram** using a **Viridis** colormap; toggle it from the **Windows** menu. Window visibility/position and the selected pane now persist across sessions.
  * Enhanced audio analysis with a **stereo PCM** path to improve stereo visualization accuracy.
* **Documentation & Notices**
  * Added/updated attribution for the **Viridis colormap**.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->