### PR TITLE
Add Octave, Pitch, and Delay panes to Audio Analysis window

### DIFF
--- a/Sources/NullPlayer/App/ContextMenuBuilder.swift
+++ b/Sources/NullPlayer/App/ContextMenuBuilder.swift
@@ -85,7 +85,7 @@ class ContextMenuBuilder {
         menu.addItem(buildWindowItem("Equalizer", visible: wm.isEqualizerVisible, action: #selector(MenuActions.toggleEQ)))
         menu.addItem(buildWindowItem("Playlist Editor", visible: wm.isPlaylistVisible, action: #selector(MenuActions.togglePlaylist)))
         menu.addItem(buildWindowItem("Spectrum Analyzer", visible: wm.isSpectrumVisible, action: #selector(MenuActions.toggleSpectrum)))
-        menu.addItem(buildWindowItem("Audio Analysis", visible: wm.isAudioAnalysisVisible, action: #selector(MenuActions.toggleAudioAnalysis)))
+        menu.addItem(buildWindowItem("Audio Analyzer", visible: wm.isAudioAnalysisVisible, action: #selector(MenuActions.toggleAudioAnalysis)))
         menu.addItem(buildWindowItem("Waveform", visible: wm.isWaveformVisible, action: #selector(MenuActions.toggleWaveform)))
         menu.addItem(buildWindowItem("Library Browser", visible: wm.isPlexBrowserVisible, action: #selector(MenuActions.togglePlexBrowser)))
         if wm.isRunningModernUI {

--- a/Sources/NullPlayer/Audio/AudioEngine.swift
+++ b/Sources/NullPlayer/Audio/AudioEngine.swift
@@ -22,6 +22,10 @@ extension Notification.Name {
     /// userInfo contains: "spectrum" ([Float]) - 75 bands normalized 0-1
     static let audioSpectrumDataUpdated = Notification.Name("audioSpectrumDataUpdated")
 
+    /// Posted when raw FFT magnitudes are available for octave band analysis
+    /// userInfo contains: "magnitudes" ([Float]) - linear magnitudes (fftSize/2 elements), "sampleRate" (Double), "fftSize" (Int)
+    static let audioFFTMagnitudesUpdated = Notification.Name("audioFFTMagnitudesUpdated")
+
     /// Posted when playback state changes (playing, paused, stopped)
     /// userInfo contains: "state" (PlaybackState)
     static let audioPlaybackStateChanged = Notification.Name("audioPlaybackStateChanged")
@@ -472,6 +476,9 @@ class AudioEngine {
     /// Stereo PCM consumers — stereo tap is skipped entirely when this set is empty
     private var stereoConsumers = Set<String>()
 
+    /// Magnitudes consumers — raw FFT magnitude posting is skipped entirely when this set is empty
+    private var magnitudesConsumers = Set<String>()
+
     /// Cached value of modernUIEnabled to avoid 60x/sec UserDefaults reads
     private var isModernUIEnabled: Bool
 
@@ -514,6 +521,18 @@ class AudioEngine {
     }
 
     var stereoNeeded: Bool { !stereoConsumers.isEmpty }
+
+    func addMagnitudesConsumer(_ id: String) {
+        magnitudesConsumers.insert(id)
+        streamingPlayer?.magnitudesNeeded = !magnitudesConsumers.isEmpty
+    }
+
+    func removeMagnitudesConsumer(_ id: String) {
+        magnitudesConsumers.remove(id)
+        streamingPlayer?.magnitudesNeeded = !magnitudesConsumers.isEmpty
+    }
+
+    var magnitudesNeeded: Bool { !magnitudesConsumers.isEmpty }
 
     // MARK: - Pre-allocated FFT Buffers (Memory Optimization)
 
@@ -1594,7 +1613,21 @@ class AudioEngine {
         for i in 0..<fftSize / 2 {
             fftMagnitudes[i] = sqrt(fftRealOut[i] * fftRealOut[i] + fftImagOut[i] * fftImagOut[i])
         }
-        
+
+        // Post raw linear magnitudes for octave band analysis (gated by magnitudesNeeded)
+        if magnitudesNeeded {
+            let magnitudesCopy = Array(fftMagnitudes.prefix(fftSize / 2))
+            NotificationCenter.default.post(
+                name: .audioFFTMagnitudesUpdated,
+                object: self,
+                userInfo: [
+                    "magnitudes": magnitudesCopy,
+                    "sampleRate": buffer.format.sampleRate,
+                    "fftSize": fftSize
+                ]
+            )
+        }
+
         // Convert to dB and normalize - use pre-allocated buffer
         var one: Float = 1.0
         vDSP_vdbcon(fftMagnitudes, 1, &one, &fftLogMagnitudes, 1, vDSP_Length(fftSize / 2), 0)
@@ -4334,6 +4367,7 @@ class AudioEngine {
             streamingPlayer?.spectrumNeeded = spectrumNeeded
             streamingPlayer?.waveformNeeded = waveformNeeded
             streamingPlayer?.stereoNeeded = stereoNeeded
+            streamingPlayer?.magnitudesNeeded = magnitudesNeeded
             streamingPlayer?.isModernUIEnabled = isModernUIEnabled
         }
 
@@ -5152,6 +5186,7 @@ class AudioEngine {
         streamingPlayer?.spectrumNeeded = spectrumNeeded
         streamingPlayer?.waveformNeeded = waveformNeeded
         streamingPlayer?.stereoNeeded = stereoNeeded
+        streamingPlayer?.magnitudesNeeded = magnitudesNeeded
         streamingPlayer?.isModernUIEnabled = isModernUIEnabled
         // crossfadeStreamingPlayer (old primary) already has nil delegate from above
         

--- a/Sources/NullPlayer/Audio/AudioEngine.swift
+++ b/Sources/NullPlayer/Audio/AudioEngine.swift
@@ -1491,7 +1491,7 @@ class AudioEngine {
     }
     
     private func processAudioBuffer(_ buffer: AVAudioPCMBuffer) {
-        guard spectrumNeeded || waveformNeeded || stereoNeeded else { return }
+        guard spectrumNeeded || waveformNeeded || stereoNeeded || magnitudesNeeded else { return }
         guard let channelData = buffer.floatChannelData else { return }
 
         let frameCount = Int(buffer.frameLength)
@@ -1542,7 +1542,10 @@ class AudioEngine {
             )
         }
 
-        guard spectrumNeeded, frameCount >= fftSize, let fftSetup = fftSetup else { return }
+        // The FFT runs when spectrum OR raw magnitudes are demanded; the 75-band spectrum
+        // work below is gated separately by `spectrumNeeded` so an octave-only (magnitudes)
+        // consumer does not pay for it.
+        guard spectrumNeeded || magnitudesNeeded, frameCount >= fftSize, let fftSetup = fftSetup else { return }
 
         // Throttle updates to 60Hz max to prevent memory buildup
         let now = CFAbsoluteTimeGetCurrent()
@@ -1627,6 +1630,9 @@ class AudioEngine {
                 ]
             )
         }
+
+        // Everything below is the 75-band spectrum path; skip it for magnitudes-only consumers.
+        guard spectrumNeeded else { return }
 
         // Convert to dB and normalize - use pre-allocated buffer
         var one: Float = 1.0

--- a/Sources/NullPlayer/Audio/StreamingAudioPlayer.swift
+++ b/Sources/NullPlayer/Audio/StreamingAudioPlayer.swift
@@ -420,7 +420,7 @@ class StreamingAudioPlayer {
         // Skip FFT processing when paused or stopped to save CPU
         // The frame filter still receives buffers but we don't need to process them
         guard state == .playing else { return }
-        guard spectrumNeeded || waveformNeeded || stereoNeeded else { return }
+        guard spectrumNeeded || waveformNeeded || stereoNeeded || magnitudesNeeded else { return }
 
         guard let channelData = buffer.floatChannelData else { return }
         
@@ -492,7 +492,9 @@ class StreamingAudioPlayer {
             }
         }
 
-        guard spectrumNeeded, frameCount >= fftSize, let fftSetup = fftSetup else { return }
+        // The FFT runs when spectrum OR raw magnitudes are demanded; the 75-band spectrum
+        // work below is gated separately by `spectrumNeeded`.
+        guard spectrumNeeded || magnitudesNeeded, frameCount >= fftSize, let fftSetup = fftSetup else { return }
 
         // Get audio samples (mono mix if stereo) - use pre-allocated buffer
         if channelCount == 1 {
@@ -572,6 +574,9 @@ class StreamingAudioPlayer {
                 ]
             )
         }
+
+        // Everything below is the 75-band spectrum path; skip it for magnitudes-only consumers.
+        guard spectrumNeeded else { return }
 
         // Map to 75 bands (classic skin-style) using logarithmic frequency mapping
         // Zero out pre-allocated buffer

--- a/Sources/NullPlayer/Audio/StreamingAudioPlayer.swift
+++ b/Sources/NullPlayer/Audio/StreamingAudioPlayer.swift
@@ -49,6 +49,9 @@ class StreamingAudioPlayer {
     /// Whether stereo PCM data should be produced — bridged from AudioEngine.stereoNeeded
     var stereoNeeded: Bool = false
 
+    /// Whether raw FFT magnitudes should be posted — bridged from AudioEngine.magnitudesNeeded
+    var magnitudesNeeded: Bool = false
+
     /// Cached value of modernUIEnabled to avoid 60x/sec UserDefaults reads
     var isModernUIEnabled: Bool = UserDefaults.standard.bool(forKey: "modernUIEnabled")
 
@@ -555,7 +558,21 @@ class StreamingAudioPlayer {
         for i in 0..<fftSize / 2 {
             fftMagnitudes[i] = sqrt(fftRealOut[i] * fftRealOut[i] + fftImagOut[i] * fftImagOut[i])
         }
-        
+
+        // Post raw linear magnitudes for octave band analysis (gated by magnitudesNeeded)
+        if magnitudesNeeded {
+            let magnitudesCopy = Array(fftMagnitudes.prefix(fftSize / 2))
+            NotificationCenter.default.post(
+                name: .audioFFTMagnitudesUpdated,
+                object: self,
+                userInfo: [
+                    "magnitudes": magnitudesCopy,
+                    "sampleRate": buffer.format.sampleRate,
+                    "fftSize": fftSize
+                ]
+            )
+        }
+
         // Map to 75 bands (classic skin-style) using logarithmic frequency mapping
         // Zero out pre-allocated buffer
         let bandCount = 75

--- a/Sources/NullPlayer/Resources/Info.plist
+++ b/Sources/NullPlayer/Resources/Info.plist
@@ -36,7 +36,7 @@
 	<key>CFBundlePackageType</key>
 	<string>APPL</string>
 	<key>CFBundleShortVersionString</key>
-	<string>0.25.0</string>
+	<string>0.26.0</string>
 	<key>CFBundleVersion</key>
 	<string>2</string>
 	<key>ITSAppUsesNonExemptEncryption</key>

--- a/Sources/NullPlayer/Visualization/SpectrogramShaders.metal
+++ b/Sources/NullPlayer/Visualization/SpectrogramShaders.metal
@@ -80,5 +80,9 @@ fragment float4 spectrogramFragmentShader(
     // Apply colormap based on magnitude
     float3 color = viridisColormap(historyValue);
 
+    // Fade the noise floor to black so silence reads as a black background instead of
+    // Viridis' dark-purple zero color, without distorting the rest of the gradient.
+    color *= smoothstep(0.0, 0.05, historyValue);
+
     return float4(color, 1.0);
 }

--- a/Sources/NullPlayer/Visualization/SpectrogramShaders.metal
+++ b/Sources/NullPlayer/Visualization/SpectrogramShaders.metal
@@ -80,9 +80,5 @@ fragment float4 spectrogramFragmentShader(
     // Apply colormap based on magnitude
     float3 color = viridisColormap(historyValue);
 
-    // Fade the noise floor to black so silence reads as a black background instead of
-    // Viridis' dark-purple zero color, without distorting the rest of the gradient.
-    color *= smoothstep(0.0, 0.05, historyValue);
-
     return float4(color, 1.0);
 }

--- a/Sources/NullPlayer/Windows/AudioAnalysis/AudioAnalysisConsumerCoordinator.swift
+++ b/Sources/NullPlayer/Windows/AudioAnalysis/AudioAnalysisConsumerCoordinator.swift
@@ -7,7 +7,6 @@ final class AudioAnalysisConsumerCoordinator {
     private let levelsConsumerId = "audioAnalysis.levels"
     private let spectrogramConsumerId = "audioAnalysis.spectrogram"
     private let pitchConsumerId = "audioAnalysis.pitch"
-    private let octaveSpectrumConsumerId = "audioAnalysis.octave.spectrum"
     private let octaveMagnitudesConsumerId = "audioAnalysis.octave.magnitudes"
     private let delayConsumerId = "audioAnalysis.delay"
 
@@ -42,13 +41,8 @@ final class AudioAnalysisConsumerCoordinator {
             remove: engine.removeSpectrumConsumer
         )
 
-        // Pane 3: Octave — spectrum + magnitudes consumers
-        updateConsumer(
-            octaveSpectrumConsumerId,
-            needed: index == 3,
-            add: engine.addSpectrumConsumer,
-            remove: engine.removeSpectrumConsumer
-        )
+        // Pane 3: Octave — magnitudes consumer only. The magnitudes path runs the FFT on its
+        // own (see AudioEngine/StreamingAudioPlayer), so no spectrum consumer is needed.
         updateConsumer(
             octaveMagnitudesConsumerId,
             needed: index == 3,

--- a/Sources/NullPlayer/Windows/AudioAnalysis/AudioAnalysisConsumerCoordinator.swift
+++ b/Sources/NullPlayer/Windows/AudioAnalysis/AudioAnalysisConsumerCoordinator.swift
@@ -2,56 +2,99 @@ import Foundation
 
 /// Keeps the audio engine work gated to the currently visible analysis pane.
 final class AudioAnalysisConsumerCoordinator {
+    // Consumer IDs for each pane
     private let scopeConsumerId = "audioAnalysis.scope"
     private let levelsConsumerId = "audioAnalysis.levels"
     private let spectrogramConsumerId = "audioAnalysis.spectrogram"
+    private let pitchConsumerId = "audioAnalysis.pitch"
+    private let octaveSpectrumConsumerId = "audioAnalysis.octave.spectrum"
+    private let octaveMagnitudesConsumerId = "audioAnalysis.octave.magnitudes"
+    private let delayConsumerId = "audioAnalysis.delay"
+
+    /// Maps consumer ID to its removal function for proper cleanup
+    private var consumerRemovers: [String: (String) -> Void] = [:]
     private var activeConsumers: Set<String> = []
 
     func setVisiblePane(_ index: Int) {
         let engine = WindowManager.shared.audioEngine
 
+        // Pane 0: Scope — spectrum consumer
         updateConsumer(
             scopeConsumerId,
             needed: index == 0,
             add: engine.addSpectrumConsumer,
             remove: engine.removeSpectrumConsumer
         )
+
+        // Pane 1: Levels — stereo consumer
         updateConsumer(
             levelsConsumerId,
             needed: index == 1,
             add: engine.addStereoConsumer,
             remove: engine.removeStereoConsumer
         )
+
+        // Pane 2: Spectrogram — spectrum consumer
         updateConsumer(
             spectrogramConsumerId,
             needed: index == 2,
             add: engine.addSpectrumConsumer,
             remove: engine.removeSpectrumConsumer
         )
+
+        // Pane 3: Octave — spectrum + magnitudes consumers
+        updateConsumer(
+            octaveSpectrumConsumerId,
+            needed: index == 3,
+            add: engine.addSpectrumConsumer,
+            remove: engine.removeSpectrumConsumer
+        )
+        updateConsumer(
+            octaveMagnitudesConsumerId,
+            needed: index == 3,
+            add: engine.addMagnitudesConsumer,
+            remove: engine.removeMagnitudesConsumer
+        )
+
+        // Pane 4: Pitch — spectrum consumer
+        updateConsumer(
+            pitchConsumerId,
+            needed: index == 4,
+            add: engine.addSpectrumConsumer,
+            remove: engine.removeSpectrumConsumer
+        )
+
+        // Pane 5: Delay — stereo consumer
+        updateConsumer(
+            delayConsumerId,
+            needed: index == 5,
+            add: engine.addStereoConsumer,
+            remove: engine.removeStereoConsumer
+        )
     }
 
     func deregisterAll() {
-        let engine = WindowManager.shared.audioEngine
         for consumerId in activeConsumers {
-            if consumerId == levelsConsumerId {
-                engine.removeStereoConsumer(consumerId)
-            } else {
-                engine.removeSpectrumConsumer(consumerId)
+            if let remover = consumerRemovers[consumerId] {
+                remover(consumerId)
             }
         }
         activeConsumers.removeAll()
+        consumerRemovers.removeAll()
     }
 
     private func updateConsumer(
         _ consumerId: String,
         needed: Bool,
         add: (String) -> Void,
-        remove: (String) -> Void
+        remove: @escaping (String) -> Void
     ) {
         if needed {
             guard activeConsumers.insert(consumerId).inserted else { return }
+            consumerRemovers[consumerId] = remove
             add(consumerId)
         } else if activeConsumers.remove(consumerId) != nil {
+            consumerRemovers.removeValue(forKey: consumerId)
             remove(consumerId)
         }
     }

--- a/Sources/NullPlayer/Windows/AudioAnalysis/AudioAnalysisContentView.swift
+++ b/Sources/NullPlayer/Windows/AudioAnalysis/AudioAnalysisContentView.swift
@@ -4,7 +4,7 @@ import SwiftUI
 final class AudioAnalysisModel: ObservableObject {
     @Published var selectedPane: Int
 
-    static let paneTitles = ["Scope", "Levels", "Spectrogram"]
+    static let paneTitles = ["Scope", "Levels", "Spectrogram", "Octave", "Pitch", "Delay"]
     static let selectedPaneDefaultsKey = "audioAnalysisSelectedPane"
 
     init(selectedPane: Int) {
@@ -22,6 +22,9 @@ struct AudioAnalysisContentView: View {
             switch model.selectedPane {
             case 1: LevelsPaneView()
             case 2: SpectrogramPaneView()
+            case 3: OctavePaneView()
+            case 4: PitchPaneView()
+            case 5: DelayPaneView()
             default: ScopePaneView()
             }
         }

--- a/Sources/NullPlayer/Windows/AudioAnalysis/AudioAnalysisView.swift
+++ b/Sources/NullPlayer/Windows/AudioAnalysis/AudioAnalysisView.swift
@@ -40,7 +40,7 @@ final class AudioAnalysisView: NSView {
         wantsLayer = true
         setAccessibilityIdentifier("audioAnalysisView")
         setAccessibilityRole(.group)
-        setAccessibilityLabel("NullPlayer Audio Analysis")
+        setAccessibilityLabel("NullPlayer Audio Analyzer")
 
         let content = AudioAnalysisContentView(model: model) { [weak self] pane in
             self?.controller?.setVisiblePane(pane)
@@ -96,7 +96,7 @@ final class AudioAnalysisView: NSView {
             pressedButton: pressedButton,
             isShadeMode: false,
             controlScale: WindowManager.shared.playlistChromeScale,
-            title: "AUDIO ANALYSIS",
+            title: "AUDIO ANALYZER",
             showsShade: false
         )
         context.restoreGState()

--- a/Sources/NullPlayer/Windows/AudioAnalysis/AudioAnalysisWindowController.swift
+++ b/Sources/NullPlayer/Windows/AudioAnalysis/AudioAnalysisWindowController.swift
@@ -28,12 +28,12 @@ final class AudioAnalysisWindowController: NSWindowController, AudioAnalysisWind
             width: CGFloat.greatestFiniteMagnitude,
             height: CGFloat.greatestFiniteMagnitude
         )
-        window.title = "NullPlayer Audio Analysis"
+        window.title = "NullPlayer Audio Analyzer"
         window.isReleasedWhenClosed = false
         window.center()
         window.delegate = self
         window.setAccessibilityIdentifier("AudioAnalysisWindow")
-        window.setAccessibilityLabel("NullPlayer Audio Analysis Window")
+        window.setAccessibilityLabel("NullPlayer Audio Analyzer Window")
     }
 
     private func setupView() {

--- a/Sources/NullPlayer/Windows/AudioAnalysis/DelayPaneView.swift
+++ b/Sources/NullPlayer/Windows/AudioAnalysis/DelayPaneView.swift
@@ -1,0 +1,98 @@
+import SwiftUI
+import NullPlayerCore
+
+/// Delay Estimator pane — displays inter-channel phase delay using cross-correlation.
+struct DelayPaneView: View {
+    @State private var delaySamples: Int = 0
+    @State private var delayMS: Double = 0
+    @State private var direction: String = "aligned"
+    @State private var sampleRate: Double = 44100
+
+    private var rangeMS: Double { 256.0 / sampleRate * 1000 }  // ±5.8 ms at 44.1 kHz
+
+    var body: some View {
+        // Compact, fit-in-place layout — the content area is short (~88pt tall at
+        // the default window size). Centered so it scales up cleanly when resized.
+        VStack(spacing: 6) {
+            Spacer(minLength: 0)
+
+            // Primary readouts: delay (ms) + lag (samples)
+            HStack(alignment: .top, spacing: 24) {
+                readout(caption: "DELAY (ms)", value: String(format: "%.2f", delayMS))
+                readout(caption: "SAMPLES", value: String(delaySamples))
+            }
+            .padding(.horizontal, 12)
+
+            Text(direction)
+                .font(.system(size: 11, weight: .semibold, design: .monospaced))
+                .foregroundColor(.cyan)
+
+            // Horizontal needle centered at 0
+            GeometryReader { geo in
+                let normalized = min(1.0, max(-1.0, delayMS / rangeMS))
+                ZStack {
+                    RoundedRectangle(cornerRadius: 2)
+                        .fill(Color(white: 0.12))
+                    Rectangle()
+                        .fill(Color(white: 0.4))
+                        .frame(width: 1)
+                    Rectangle()
+                        .fill(Color.yellow)
+                        .frame(width: 2)
+                        .position(
+                            x: geo.size.width / 2 + normalized * geo.size.width / 2.2,
+                            y: geo.size.height / 2
+                        )
+                }
+            }
+            .frame(height: 12)
+            .padding(.horizontal, 24)
+
+            Text("range ±\(String(format: "%.1f", rangeMS)) ms")
+                .font(.system(size: 8, weight: .regular, design: .monospaced))
+                .foregroundColor(Color(white: 0.5))
+
+            Spacer(minLength: 0)
+        }
+        .frame(maxWidth: .infinity, maxHeight: .infinity)
+        .background(Color.black)
+        .onReceive(NotificationCenter.default.publisher(for: .audioStereoPCMDataUpdated).receive(on: DispatchQueue.main)) { notification in
+            guard let userInfo = notification.userInfo,
+                  let left = userInfo["left"] as? [Float],
+                  let right = userInfo["right"] as? [Float],
+                  let sr = userInfo["sampleRate"] as? Double else { return }
+
+            sampleRate = sr
+
+            // Compute cross-correlation delay
+            let maxLag = left.count / 2
+            let lagSamples = AudioAnalysisDSP.estimateDelaySamples(left: left, right: right, maxLagSamples: maxLag)
+
+            delaySamples = lagSamples
+            delayMS = Double(lagSamples) / sr * 1000
+
+            if lagSamples > 0 {
+                direction = "right lags left"
+            } else if lagSamples < 0 {
+                direction = "left lags right"
+            } else {
+                direction = "aligned"
+            }
+        }
+    }
+
+    /// A captioned numeric readout that shrinks to fit rather than clipping.
+    private func readout(caption: String, value: String) -> some View {
+        VStack(spacing: 2) {
+            Text(caption)
+                .font(.system(size: 8, weight: .semibold, design: .monospaced))
+                .foregroundColor(.gray)
+            Text(value)
+                .font(.system(size: 26, weight: .semibold, design: .monospaced))
+                .foregroundColor(.white)
+                .lineLimit(1)
+                .minimumScaleFactor(0.4)
+        }
+        .frame(maxWidth: .infinity)
+    }
+}

--- a/Sources/NullPlayer/Windows/AudioAnalysis/OctavePaneView.swift
+++ b/Sources/NullPlayer/Windows/AudioAnalysis/OctavePaneView.swift
@@ -1,0 +1,187 @@
+import AppKit
+import SwiftUI
+import NullPlayerCore
+
+/// Octave spectrum pane — displays logarithmic octave band analysis with peak-hold.
+struct OctavePaneView: NSViewRepresentable {
+    func makeNSView(context: Context) -> NSView {
+        return OctaveCanvasView()
+    }
+
+    func updateNSView(_ nsView: NSView, context: Context) {
+        // View handles all updates via notifications
+    }
+}
+
+/// Canvas-based octave spectrum analyzer with peak-hold decay.
+class OctaveCanvasView: NSView {
+    private var magnitudes: [Float] = []
+    private var sampleRate: Double = 44100
+    private var fftSize: Int = 2048
+    private var bands: [(centerHz: Double, level: Float)] = []
+
+    // Peak-hold per band (decays slowly)
+    private var peakHolds: [Float] = Array(repeating: 0, count: 100)
+    private var magnitudesObserver: NSObjectProtocol?
+
+    override init(frame: NSRect) {
+        super.init(frame: frame)
+        commonInit()
+    }
+
+    required init?(coder: NSCoder) {
+        super.init(coder: coder)
+        commonInit()
+    }
+
+    private func commonInit() {
+        wantsLayer = true
+        layer?.backgroundColor = NSColor.black.cgColor
+
+        // Observe magnitudes updates from the audio engine
+        magnitudesObserver = NotificationCenter.default.addObserver(
+            forName: .audioFFTMagnitudesUpdated,
+            object: nil,
+            queue: .main
+        ) { [weak self] notification in
+            guard let userInfo = notification.userInfo,
+                  let magnitudes = userInfo["magnitudes"] as? [Float],
+                  let sampleRate = userInfo["sampleRate"] as? Double,
+                  let fftSize = userInfo["fftSize"] as? Int else { return }
+
+            self?.updateWithMagnitudes(magnitudes, sampleRate: sampleRate, fftSize: fftSize)
+            self?.needsDisplay = true
+        }
+    }
+
+    deinit {
+        if let observer = magnitudesObserver {
+            NotificationCenter.default.removeObserver(observer)
+        }
+    }
+
+    private func updateWithMagnitudes(_ magnitudes: [Float], sampleRate: Double, fftSize: Int) {
+        self.magnitudes = magnitudes
+        self.sampleRate = sampleRate
+        self.fftSize = fftSize
+
+        // Compute octave bands (3 bands per octave, 20 Hz to 20 kHz)
+        self.bands = AudioAnalysisDSP.octaveBands(
+            magnitudes: magnitudes,
+            sampleRate: sampleRate,
+            fftSize: fftSize,
+            bandsPerOctave: 3,
+            minFreq: 20,
+            maxFreq: 20000
+        )
+
+        // Update peak holds (decay slowly, track maxima). Preserve peaks across
+        // frames; resize only when the band count changes.
+        if peakHolds.count != bands.count {
+            peakHolds = Array(repeating: 0, count: bands.count)
+        }
+        for i in 0..<bands.count {
+            let level = bands[i].level
+            let oldPeak = peakHolds[i]
+            peakHolds[i] = max(level, oldPeak * 0.85)  // 85% decay per frame
+        }
+    }
+
+    override func draw(_ dirtyRect: NSRect) {
+        super.draw(dirtyRect)
+
+        guard let context = NSGraphicsContext.current?.cgContext else { return }
+
+        // Background
+        NSColor.black.setFill()
+        bounds.fill()
+
+        guard !bands.isEmpty else { return }
+
+        drawOctaveSpectrum(in: context)
+    }
+
+    private func drawOctaveSpectrum(in context: CGContext) {
+        let width = bounds.width
+        let height = bounds.height
+        // Tight margins: the content area is short (~88pt), so reserve only a title
+        // line at the top and an x-axis label strip at the bottom. The bars get the rest.
+        let topMargin: CGFloat = 15
+        let bottomMargin: CGFloat = 14
+        let leftMargin: CGFloat = 6
+        let rightMargin: CGFloat = 6
+
+        let plotWidth = width - leftMargin - rightMargin
+        let plotHeight = height - topMargin - bottomMargin
+
+        guard plotWidth > 0, plotHeight > 0, !bands.isEmpty else { return }
+
+        // Draw title (top line)
+        let titleAttr: [NSAttributedString.Key: Any] = [
+            .font: NSFont.monospacedSystemFont(ofSize: 10, weight: .semibold),
+            .foregroundColor: NSColor.green
+        ]
+        let titleStr = NSAttributedString(string: "Octave (1/3)", attributes: titleAttr)
+        titleStr.draw(at: CGPoint(x: leftMargin, y: height - 13))
+
+        // Bars grow UP from a bottom baseline (non-flipped NSView: y=0 is the bottom).
+        let baselineY = bottomMargin
+        let barWidth = plotWidth / CGFloat(bands.count)
+
+        for (index, band) in bands.enumerated() {
+            let x = leftMargin + CGFloat(index) * barWidth + barWidth * 0.1
+            let barActualWidth = max(1, barWidth * 0.8)
+            let barHeight = CGFloat(band.level) * plotHeight
+
+            let barRect = CGRect(x: x, y: baselineY, width: barActualWidth, height: barHeight)
+
+            let color: NSColor
+            if band.level > 0.7 {
+                color = NSColor.red
+            } else if band.level > 0.4 {
+                color = NSColor.yellow
+            } else {
+                color = NSColor.green
+            }
+
+            context.setFillColor(color.cgColor)
+            context.fill(barRect)
+
+            // Peak-hold marker
+            if index < peakHolds.count {
+                let peakY = baselineY + CGFloat(peakHolds[index]) * plotHeight
+                context.setStrokeColor(NSColor.white.cgColor)
+                context.setLineWidth(1)
+                context.move(to: CGPoint(x: x, y: peakY))
+                context.addLine(to: CGPoint(x: x + barActualWidth, y: peakY))
+                context.strokePath()
+            }
+        }
+
+        // Frequency labels below the baseline. Use a sparse set so they don't crowd.
+        let labelFreqs: [Double] = [63, 250, 1000, 4000, 16000]
+        let labelAttr: [NSAttributedString.Key: Any] = [
+            .font: NSFont.monospacedSystemFont(ofSize: 8, weight: .regular),
+            .foregroundColor: NSColor.gray
+        ]
+
+        for freq in labelFreqs {
+            if let closestIndex = bands.enumerated().min(by: {
+                abs($0.element.centerHz - freq) < abs($1.element.centerHz - freq)
+            })?.offset {
+                let x = leftMargin + CGFloat(closestIndex) * barWidth + barWidth / 2
+                let labelStr = NSAttributedString(string: formatFrequency(freq), attributes: labelAttr)
+                let labelSize = labelStr.size()
+                labelStr.draw(at: CGPoint(x: x - labelSize.width / 2, y: 2))
+            }
+        }
+    }
+
+    private func formatFrequency(_ hz: Double) -> String {
+        if hz >= 1000 {
+            return String(format: "%.1fk", hz / 1000)
+        } else {
+            return String(format: "%.0f", hz)
+        }
+    }
+}

--- a/Sources/NullPlayer/Windows/AudioAnalysis/PitchPaneView.swift
+++ b/Sources/NullPlayer/Windows/AudioAnalysis/PitchPaneView.swift
@@ -1,0 +1,125 @@
+import SwiftUI
+import NullPlayerCore
+
+/// Pitch Tracker pane — displays fundamental frequency, nearest note, and cents deviation.
+struct PitchPaneView: View {
+    @State private var frequencyHz: Double? = nil
+    @State private var noteString: String = "—"
+    @State private var centsDeviation: Double = 0
+    @State private var sampleRate: Double = 44100
+
+    private var centsColor: Color {
+        abs(centsDeviation) < 5 ? .green : abs(centsDeviation) < 20 ? .yellow : .red
+    }
+
+    var body: some View {
+        // Compact, fit-in-place layout — the Audio Analysis content area is short
+        // (~88pt tall at the default window size). Centered so it scales up cleanly
+        // when the window is resized taller.
+        VStack(spacing: 6) {
+            Spacer(minLength: 0)
+
+            // Primary readouts: note + frequency side by side
+            HStack(alignment: .top, spacing: 24) {
+                readout(caption: "NOTE", value: noteString, color: .cyan)
+                readout(
+                    caption: "FREQ (Hz)",
+                    value: frequencyHz.map { String(format: "%.1f", $0) } ?? "—",
+                    color: .white
+                )
+            }
+            .padding(.horizontal, 12)
+
+            // Cents deviation bar
+            VStack(spacing: 2) {
+                Text(String(format: "%+.0f¢", centsDeviation))
+                    .font(.system(size: 10, weight: .semibold, design: .monospaced))
+                    .foregroundColor(centsColor)
+
+                GeometryReader { geo in
+                    let normalized = min(1.0, max(-1.0, centsDeviation / 50.0))
+                    ZStack {
+                        RoundedRectangle(cornerRadius: 2)
+                            .fill(Color(white: 0.12))
+                        Rectangle()
+                            .fill(Color(white: 0.35))
+                            .frame(width: 1)
+                        Rectangle()
+                            .fill(centsColor)
+                            .frame(width: 2)
+                            .position(
+                                x: geo.size.width / 2 + normalized * geo.size.width / 2.2,
+                                y: geo.size.height / 2
+                            )
+                    }
+                }
+                .frame(height: 10)
+                .padding(.horizontal, 24)
+            }
+
+            Spacer(minLength: 0)
+        }
+        .frame(maxWidth: .infinity, maxHeight: .infinity)
+        .background(Color.black)
+        .onReceive(NotificationCenter.default.publisher(for: .audioPCMDataUpdated).receive(on: DispatchQueue.main)) { notification in
+            guard let userInfo = notification.userInfo,
+                  let pcm = userInfo["pcm"] as? [Float],
+                  let sr = userInfo["sampleRate"] as? Double else { return }
+
+            sampleRate = sr
+
+            // Estimate pitch from mono PCM
+            let hz = AudioAnalysisDSP.estimatePitchHz(samples: pcm, sampleRate: sr, minHz: 50, maxHz: 2000)
+
+            if let hz = hz {
+                frequencyHz = hz
+                let (note, octave, cents) = hzToNote(hz)
+                noteString = "\(note)\(octave)"
+                centsDeviation = cents
+            } else {
+                frequencyHz = nil
+                noteString = "—"
+                centsDeviation = 0
+            }
+        }
+    }
+
+    /// A captioned numeric readout that shrinks to fit rather than clipping.
+    private func readout(caption: String, value: String, color: Color) -> some View {
+        VStack(spacing: 2) {
+            Text(caption)
+                .font(.system(size: 8, weight: .semibold, design: .monospaced))
+                .foregroundColor(.gray)
+            Text(value)
+                .font(.system(size: 28, weight: .semibold, design: .monospaced))
+                .foregroundColor(color)
+                .lineLimit(1)
+                .minimumScaleFactor(0.4)
+        }
+        .frame(maxWidth: .infinity)
+    }
+}
+
+/// Convert frequency in Hz to note name, octave, and cents deviation from equal temperament.
+/// A4 = 440 Hz
+private func hzToNote(_ hz: Double) -> (note: String, octave: Int, cents: Double) {
+    let noteNames = ["C", "C#", "D", "D#", "E", "F", "F#", "G", "G#", "A", "A#", "B"]
+
+    // Semitones from A4 (440 Hz): n = 12 * log2(hz / 440)
+    let semitonesFromA4 = 12.0 * log2(hz / 440.0)
+
+    // Round to nearest semitone
+    let semitoneRounded = round(semitonesFromA4)
+    let cents = (semitonesFromA4 - semitoneRounded) * 100.0
+
+    // MIDI note number (A4 = 69). Map to a note name (C=0) and octave via
+    // floored arithmetic so frequencies below 440 Hz (negative semitone offsets)
+    // never produce a negative array index.
+    let midi = 69 + Int(semitoneRounded)
+    let noteIndex = ((midi % 12) + 12) % 12        // always 0...11
+    let octave = Int(floor(Double(midi) / 12.0)) - 1
+
+    let note = noteNames[noteIndex]
+
+    return (note, octave, cents)
+}

--- a/Sources/NullPlayer/Windows/AudioAnalysis/ScopePaneView.swift
+++ b/Sources/NullPlayer/Windows/AudioAnalysis/ScopePaneView.swift
@@ -23,8 +23,11 @@ class ScopeCanvasView: NSView {
     private var displayBuffer: [Float] = []
     private var pcmObserver: NSObjectProtocol?
 
-    /// Weight of each incoming frame in the temporal blend (1 = no smoothing, lower = smoother).
-    private let frameWeight: Float = 0.6
+    /// Temporal-blend weights (1 = no smoothing, lower = smoother). The blend is asymmetric: a frame
+    /// that is louder than what's on screen (a beat) snaps in quickly so it is never averaged away,
+    /// while quieter frames blend slowly to suppress flicker.
+    private let attackWeight: Float = 0.85
+    private let releaseWeight: Float = 0.45
 
     override init(frame: NSRect) {
         super.init(frame: frame)
@@ -75,11 +78,21 @@ class ScopeCanvasView: NSView {
 
         if displayBuffer.count != windowLength {
             displayBuffer = Array(pcm[trigger..<(trigger + windowLength)])
-        } else {
-            for i in 0..<windowLength {
-                let sample = pcm[trigger + i]
-                displayBuffer[i] += (sample - displayBuffer[i]) * frameWeight
-            }
+            needsDisplay = true
+            return
+        }
+
+        // Asymmetric blend: snap toward a louder frame (a beat), ease toward a quieter one. This stops
+        // the smoothing from averaging away a strong beat whose trigger locked to a different cycle.
+        var framePeak: Float = 0
+        var displayPeak: Float = 0
+        for i in 0..<windowLength {
+            framePeak = max(framePeak, abs(pcm[trigger + i]))
+            displayPeak = max(displayPeak, abs(displayBuffer[i]))
+        }
+        let weight = framePeak > displayPeak ? attackWeight : releaseWeight
+        for i in 0..<windowLength {
+            displayBuffer[i] += (pcm[trigger + i] - displayBuffer[i]) * weight
         }
         needsDisplay = true
     }

--- a/Sources/NullPlayer/Windows/AudioAnalysis/ScopePaneView.swift
+++ b/Sources/NullPlayer/Windows/AudioAnalysis/ScopePaneView.swift
@@ -12,11 +12,19 @@ struct ScopePaneView: NSViewRepresentable {
     }
 }
 
-/// Canvas-based oscilloscope renderer
+/// Canvas-based oscilloscope renderer.
+///
+/// Two things keep the trace readable: a **trigger** that phase-locks each frame to a rising
+/// zero-crossing (so periodic content stays stationary instead of swimming horizontally), and a
+/// gentle **temporal blend** of the now-aligned frames (so the line stops flickering frame to frame
+/// without smearing transients).
 class ScopeCanvasView: NSView {
-    private var pcmData: [Float] = []
-    private var sampleRate: Double = 44100
+    /// Phase-aligned, temporally smoothed window that is actually drawn.
+    private var displayBuffer: [Float] = []
     private var pcmObserver: NSObjectProtocol?
+
+    /// Weight of each incoming frame in the temporal blend (1 = no smoothing, lower = smoother).
+    private let frameWeight: Float = 0.6
 
     override init(frame: NSRect) {
         super.init(frame: frame)
@@ -39,11 +47,8 @@ class ScopeCanvasView: NSView {
             queue: .main
         ) { [weak self] notification in
             guard let userInfo = notification.userInfo,
-                  let pcm = userInfo["pcm"] as? [Float],
-                  let sampleRate = userInfo["sampleRate"] as? Double else { return }
-            self?.pcmData = pcm
-            self?.sampleRate = sampleRate
-            self?.needsDisplay = true
+                  let pcm = userInfo["pcm"] as? [Float] else { return }
+            self?.ingest(pcm)
         }
     }
 
@@ -51,6 +56,32 @@ class ScopeCanvasView: NSView {
         if let observer = pcmObserver {
             NotificationCenter.default.removeObserver(observer)
         }
+    }
+
+    /// Trigger-align an incoming frame and blend it into the display buffer.
+    private func ingest(_ pcm: [Float]) {
+        let count = pcm.count
+        let maxTriggerOffset = count / 4          // search the first quarter for the trigger
+        let windowLength = count - maxTriggerOffset
+        guard windowLength > 1, maxTriggerOffset >= 1 else { return }
+
+        // Trigger: first rising zero-crossing in the search region. Falls back to 0 (no lock) when
+        // none is found (silence / aperiodic noise), which simply leaves the trace where it is.
+        var trigger = 0
+        for i in 1...maxTriggerOffset where pcm[i - 1] <= 0 && pcm[i] > 0 {
+            trigger = i
+            break
+        }
+
+        if displayBuffer.count != windowLength {
+            displayBuffer = Array(pcm[trigger..<(trigger + windowLength)])
+        } else {
+            for i in 0..<windowLength {
+                let sample = pcm[trigger + i]
+                displayBuffer[i] += (sample - displayBuffer[i]) * frameWeight
+            }
+        }
+        needsDisplay = true
     }
 
     override func draw(_ dirtyRect: NSRect) {
@@ -62,9 +93,8 @@ class ScopeCanvasView: NSView {
         NSColor.black.setFill()
         bounds.fill()
 
-        guard !pcmData.isEmpty else { return }
+        guard displayBuffer.count > 1 else { return }
 
-        // Draw waveform
         drawWaveform(in: context)
     }
 
@@ -73,7 +103,7 @@ class ScopeCanvasView: NSView {
         let height = bounds.height
         let centerY = height / 2
 
-        // Grid lines (optional)
+        // Grid lines
         context.setStrokeColor(NSColor.darkGray.cgColor)
         context.setLineWidth(0.5)
         for i in 1..<4 {
@@ -83,31 +113,31 @@ class ScopeCanvasView: NSView {
         }
         context.strokePath()
 
-        // Waveform line
+        // Waveform line — smoothed with quadratic segments through sample midpoints.
         context.setStrokeColor(NSColor.green.cgColor)
         context.setLineWidth(1.5)
+        context.setLineJoin(.round)
+        context.setLineCap(.round)
 
-        let samplesPerPixel = max(1, pcmData.count / Int(width))
-        var isFirstPoint = true
-
-        for x in 0..<Int(width) {
-            let sampleIndex = min(x * samplesPerPixel, pcmData.count - 1)
-            let sample = pcmData[sampleIndex]
-
-            // Clamp sample to [-1, 1] and map to screen coordinates
-            let clampedSample = max(-1.0, min(1.0, sample))
-            let screenY = centerY - CGFloat(clampedSample) * (centerY - 4)
-
-            let point = CGPoint(x: CGFloat(x), y: screenY)
-
-            if isFirstPoint {
-                context.move(to: point)
-                isFirstPoint = false
-            } else {
-                context.addLine(to: point)
-            }
+        let n = displayBuffer.count
+        func point(_ i: Int) -> CGPoint {
+            let x = width * CGFloat(i) / CGFloat(n - 1)
+            let clamped = max(-1.0, min(1.0, CGFloat(displayBuffer[i])))
+            return CGPoint(x: x, y: centerY - clamped * (centerY - 4))
         }
 
+        context.move(to: point(0))
+        if n == 2 {
+            context.addLine(to: point(1))
+        } else {
+            for i in 1..<(n - 1) {
+                let current = point(i)
+                let next = point(i + 1)
+                let mid = CGPoint(x: (current.x + next.x) / 2, y: (current.y + next.y) / 2)
+                context.addQuadCurve(to: mid, control: current)
+            }
+            context.addLine(to: point(n - 1))
+        }
         context.strokePath()
     }
 }

--- a/Sources/NullPlayer/Windows/ModernAudioAnalysis/ModernAudioAnalysisView.swift
+++ b/Sources/NullPlayer/Windows/ModernAudioAnalysis/ModernAudioAnalysisView.swift
@@ -155,7 +155,7 @@ class ModernAudioAnalysisView: NSView {
         if !WindowManager.shared.effectiveHideTitleBars(for: self.window) {
             renderer.drawTitleBar(
                 in: ModernSkinElements.spectrumTitleBar.defaultRect,
-                title: "AUDIO ANALYSIS",
+                title: "AUDIO ANALYZER",
                 prefix: "spectrum_",
                 context: context
             )

--- a/Sources/NullPlayer/Windows/ModernAudioAnalysis/ModernAudioAnalysisWindowController.swift
+++ b/Sources/NullPlayer/Windows/ModernAudioAnalysis/ModernAudioAnalysisWindowController.swift
@@ -49,7 +49,7 @@ class ModernAudioAnalysisWindowController: NSWindowController, AudioAnalysisWind
         window.hasShadow = true
         // Center-stack minimum; WindowManager.applyCenterStackSizingConstraints refines this on show.
         window.minSize = ModernSkinElements.spectrumMinSize
-        window.title = "NullPlayer Audio Analysis"
+        window.title = "NullPlayer Audio Analyzer"
 
         // Prevent window from being released when closed - we reuse the same controller
         window.isReleasedWhenClosed = false
@@ -59,7 +59,7 @@ class ModernAudioAnalysisWindowController: NSWindowController, AudioAnalysisWind
 
         // Set accessibility identifier
         window.setAccessibilityIdentifier("ModernAudioAnalysisWindow")
-        window.setAccessibilityLabel("NullPlayer Audio Analysis Window")
+        window.setAccessibilityLabel("NullPlayer Audio Analyzer Window")
     }
 
     private func setupView() {

--- a/skills/audio-analysis-window/SKILL.md
+++ b/skills/audio-analysis-window/SKILL.md
@@ -1,9 +1,9 @@
 ---
 name: audio-analysis-window
-description: The classic and modern Audio Analysis windows — a Friture-style multi-pane analyzer (Scope, Levels, Spectrogram), the stereo PCM path that feeds them, per-pane consumer gating, and the shared AudioAnalysisDSP module. Use when modifying either analysis window, its panes, the spectrogram shader, or the stereo/DSP plumbing.
+description: The classic and modern Audio Analyzer windows — a Friture-style multi-pane analyzer (Scope, Levels, Spectrogram, Octave, Pitch, Delay), the stereo PCM path that feeds them, per-pane consumer gating, and the shared AudioAnalysisDSP module. Use when modifying either analyzer window, its panes, the spectrogram shader, or the stereo/DSP plumbing.
 ---
 
-# Audio Analysis Window
+# Audio Analyzer Window
 
 A classic and modern UI window offering a Friture-style (https://friture.org) real-time view of the
 playing audio. Exactly one pane is visible at a time; the pane is selected via the window's
@@ -12,7 +12,7 @@ Spectrum windows in each UI mode.
 
 ## Accessing
 
-- Window menu / main window right-click context menu → **Audio Analysis**
+- Window menu / main window right-click context menu → **Audio Analyzer**
 - Available in classic and modern UI modes.
 
 ## Window chrome & sizing
@@ -34,7 +34,7 @@ Spectrum windows in each UI mode.
   `contentAreaRect()` / `layoutHostingView()`. Its hosting view uses an aqua/darkAqua appearance
   selected from the modern skin brightness.
 - **Chrome rendering — classic.** `AudioAnalysisView` uses `SkinRenderer`'s playlist/spectrum-style
-  chrome with the `AUDIO ANALYSIS` bitmap title and no shade button. It hosts the same SwiftUI pane
+  chrome with the `AUDIO ANALYZER` bitmap title and no shade button. It hosts the same SwiftUI pane
   content inside the classic side and bottom borders. Neither mode may cover its chrome with the
   pane's opaque black background.
 

--- a/skills/audio-analysis-window/SKILL.md
+++ b/skills/audio-analysis-window/SKILL.md
@@ -56,6 +56,33 @@ Spectrum windows in each UI mode.
 **magnitudes** (to receive raw linear magnitudes). This is the only pane that gates the magnitudes
 path; all others share existing notification/consumer infrastructure.
 
+## What each pane shows (behavior + accuracy caveats)
+
+- **Scope** — time-domain oscilloscope: a green waveform line of the 512-sample mono PCM frame over
+  a faint grid. Shows instantaneous waveform shape; idles flat on silence.
+- **Levels** — per-channel **Peak** and **RMS** vertical meters (LEFT/RIGHT), in dBFS over a
+  −120…0 dB range. Meter color: green normally, yellow above −12 dB, red above −6 dB. RMS responds
+  more smoothly than peak.
+- **Spectrogram** — scrolling waterfall (Metal). Each new column is one 75-band spectrum frame mapped
+  through a Viridis colormap (dark = quiet, bright = loud); low frequencies at the bottom, time scrolls
+  right-to-left.
+- **Octave** — 1/3-octave bar spectrum, 20 Hz–20 kHz, one bar per band growing up from the baseline.
+  Bar color green → yellow (>0.4) → red (>0.7) by level; a **white peak-hold tick** marks each band's
+  recent maximum and decays 85%/frame. **Caveat:** the 2048-pt FFT is ≈21.5 Hz/bin, so sub-200 Hz
+  bands have sparse bin coverage and look coarse/step-like.
+- **Pitch** — fundamental-frequency tracker (autocorrelation). Shows **NOTE** (nearest note + octave,
+  e.g. `A4`) and **FREQ (Hz)**, or `—` when there is no confident pitch (silence, noise, or polyphonic
+  material). A cents bar shows deviation from equal temperament: green in tune (<5¢), yellow (<20¢),
+  red beyond. **Caveat:** the 512-sample window (~11.6 ms) is reliable for vocals/treble but unreliable
+  below ~100 Hz (octave errors).
+- **Delay** — stereo inter-channel delay (L/R cross-correlation). Shows **DELAY (ms)**, **SAMPLES**, a
+  direction string ("right lags left" / "left lags right" / "aligned"), and a needle centered at 0.
+  **Caveat:** the 512-sample window resolves only **±~5.8 ms** (at 44.1 kHz); larger delays alias.
+
+These caveats are inherent to the existing 2048-pt FFT / 512-sample PCM frames the panes consume — they
+are display limits, not bugs. If a pane needs better low-frequency or long-delay resolution, the fix is a
+larger analysis buffer, not pane code.
+
 ## Architecture
 
 - **Windows**: `Windows/ModernAudioAnalysis/ModernAudioAnalysisWindowController.swift` and

--- a/skills/audio-analysis-window/SKILL.md
+++ b/skills/audio-analysis-window/SKILL.md
@@ -59,7 +59,10 @@ path; all others share existing notification/consumer infrastructure.
 ## What each pane shows (behavior + accuracy caveats)
 
 - **Scope** — time-domain oscilloscope: a green waveform line of the 512-sample mono PCM frame over
-  a faint grid. Shows instantaneous waveform shape; idles flat on silence.
+  a faint grid. Each frame is **trigger-aligned** to a rising zero-crossing in its first quarter so
+  periodic content stays phase-locked (stationary) instead of swimming, then gently blended into the
+  previous frame (`frameWeight`) to reduce flicker, and drawn as a smoothed quadratic curve. Idles flat
+  on silence (no trigger found → no lock).
 - **Levels** — per-channel **Peak** and **RMS** vertical meters (LEFT/RIGHT), in dBFS over a
   −120…0 dB range. Meter color: green normally, yellow above −12 dB, red above −6 dB. RMS responds
   more smoothly than peak.

--- a/skills/audio-analysis-window/SKILL.md
+++ b/skills/audio-analysis-window/SKILL.md
@@ -38,18 +38,23 @@ Spectrum windows in each UI mode.
   content inside the classic side and bottom borders. Neither mode may cover its chrome with the
   pane's opaque black background.
 
-## Panes (MVP)
+## Panes
 
-| Pane | Source notification | Consumer it registers | Render |
+| Pane | Source notification | Consumer(s) it registers | Render |
 |------|--------------------|----------------------|--------|
 | **Scope** (oscilloscope) | `.audioPCMDataUpdated` (`userInfo["pcm"]` 512 mono) | spectrum | CoreGraphics (`NSView`) |
 | **Levels** (peak/RMS) | `.audioStereoPCMDataUpdated` (`left`/`right` 512) | stereo | SwiftUI bars |
 | **Spectrogram** (waterfall) | `.audioSpectrumDataUpdated` (`spectrum` 75 bands) | spectrum | Metal (`MTKView`) |
+| **Octave** (1/3-octave spectrum) | `.audioFFTMagnitudesUpdated` (`magnitudes` raw linear, `sampleRate`, `fftSize`) | spectrum + magnitudes | CoreGraphics (`NSView`) bars + peak-hold |
+| **Pitch** (fundamental frequency) | `.audioPCMDataUpdated` (512 mono) | spectrum | SwiftUI (Hz, note name, cents deviation) |
+| **Delay** (L/R phase delay) | `.audioStereoPCMDataUpdated` (`left`/`right` 512) | stereo | SwiftUI (ms, samples, direction) |
 
-`.audioPCMDataUpdated` is posted *inside* the spectrum block, so the Scope pane registers a
+`.audioPCMDataUpdated` is posted *inside* the spectrum block, so the Scope and Pitch panes register a
 **spectrum** consumer (not a dedicated PCM one) to make mono PCM flow.
 
-Deferred (DSP exists, panes not built): Octave spectrum, Pitch tracker, Delay estimator.
+**Octave requires dual consumers:** it registers both **spectrum** (to trigger the FFT) and
+**magnitudes** (to receive raw linear magnitudes). This is the only pane that gates the magnitudes
+path; all others share existing notification/consumer infrastructure.
 
 ## Architecture
 
@@ -64,8 +69,10 @@ Deferred (DSP exists, panes not built): Octave spectrum, Pitch tracker, Delay es
   invokes its `onPaneChange` callback, which each window's NSView routes to
   `controller.setVisiblePane(_:)` → `AudioAnalysisConsumerCoordinator`.
 - **Panes**: shared files under `Windows/AudioAnalysis/`: `ScopePaneView.swift`,
-  `LevelsPaneView.swift` (vertical full-height peak/RMS meters, no title text), and
-  `SpectrogramPaneView.swift`.
+  `LevelsPaneView.swift` (vertical full-height peak/RMS meters, no title text),
+  `SpectrogramPaneView.swift`, `OctavePaneView.swift` (1/3-octave bands CoreGraphics with peak-hold),
+  `PitchPaneView.swift` (Hz + note + cents SwiftUI), and `DelayPaneView.swift` (stereo delay
+  cross-correlation SwiftUI).
 - **Shader**: `Visualization/SpectrogramShaders.metal` — fullscreen quad generated from
   `[[vertex_id]]` (no vertex buffer), samples an `r32Float` history texture, Viridis colormap LUT.
   Low frequencies at the bottom (texCoord.y = 0). **Loaded via `BundleHelper.url(...)` +
@@ -79,15 +86,30 @@ Deferred (DSP exists, panes not built): Octave spectrum, Pitch tracker, Delay es
   `stereoNeeded`, mirroring the spectrum/waveform consumer pattern. Wired in **both** the local
   engine and the streaming delegate (`streamingPlayerDidUpdateStereoPCM(left:right:sampleRate:)`).
 
+- **Magnitudes path** (new): `Audio/AudioEngine.swift` and `Audio/StreamingAudioPlayer.swift` publish
+  `.audioFFTMagnitudesUpdated` (userInfo: `"magnitudes"` raw linear half-spectrum, `"sampleRate"`,
+  `"fftSize"`) gated by `addMagnitudesConsumer`/`removeMagnitudesConsumer`/`magnitudesNeeded`.
+  Posted inside the spectrum FFT block, *after* magnitudes are computed but *before* dB conversion.
+  Octave pane is the sole consumer; the gating cost is zero when no Octave pane is visible.
+
 ## Consumer gating (CPU)
 
 `AudioAnalysisConsumerCoordinator` owns the gating (shared by both windows): `setVisiblePane(_:)`
-registers exactly the visible pane's consumer (scope/spectrogram → spectrum, levels → stereo) and
-removes the others; `deregisterAll()` removes everything. The controller registers the initial pane
-in `showWindow(_:)`; the shared content view re-invokes it on `.onChange(of: model.selectedPane)`.
-Both `stopRenderingForHide()` and `windowWillClose` call `consumerCoordinator.deregisterAll()` so a
-hidden/closed window leaves the FFT and stereo path idle. The spectrogram also pauses its `MTKView`
-(`isPaused`) while hidden or miniaturized.
+maps each pane to its consumer(s):
+- Scope (pane 0) → spectrum
+- Levels (pane 1) → stereo
+- Spectrogram (pane 2) → spectrum
+- Octave (pane 3) → spectrum + magnitudes (dual consumers)
+- Pitch (pane 4) → spectrum
+- Delay (pane 5) → stereo
+
+Only the visible pane's consumer(s) are registered; others are removed. `deregisterAll()` removes
+everything via a `consumerRemovers` map that tracks which remove function to call per consumer ID.
+The controller registers the initial pane in `showWindow(_:)`; the shared content view re-invokes
+it on `.onChange(of: model.selectedPane)`. Both `stopRenderingForHide()` and `windowWillClose` call
+`consumerCoordinator.deregisterAll()` so a hidden/closed window leaves the FFT, stereo, and
+magnitudes paths idle. The spectrogram also pauses its `MTKView` (`isPaused`) while hidden or
+miniaturized.
 
 ## Persistence
 

--- a/skills/audio-analysis-window/SKILL.md
+++ b/skills/audio-analysis-window/SKILL.md
@@ -45,16 +45,18 @@ Spectrum windows in each UI mode.
 | **Scope** (oscilloscope) | `.audioPCMDataUpdated` (`userInfo["pcm"]` 512 mono) | spectrum | CoreGraphics (`NSView`) |
 | **Levels** (peak/RMS) | `.audioStereoPCMDataUpdated` (`left`/`right` 512) | stereo | SwiftUI bars |
 | **Spectrogram** (waterfall) | `.audioSpectrumDataUpdated` (`spectrum` 75 bands) | spectrum | Metal (`MTKView`) |
-| **Octave** (1/3-octave spectrum) | `.audioFFTMagnitudesUpdated` (`magnitudes` raw linear, `sampleRate`, `fftSize`) | spectrum + magnitudes | CoreGraphics (`NSView`) bars + peak-hold |
+| **Octave** (1/3-octave spectrum) | `.audioFFTMagnitudesUpdated` (`magnitudes` raw linear, `sampleRate`, `fftSize`) | magnitudes | CoreGraphics (`NSView`) bars + peak-hold |
 | **Pitch** (fundamental frequency) | `.audioPCMDataUpdated` (512 mono) | spectrum | SwiftUI (Hz, note name, cents deviation) |
 | **Delay** (L/R phase delay) | `.audioStereoPCMDataUpdated` (`left`/`right` 512) | stereo | SwiftUI (ms, samples, direction) |
 
 `.audioPCMDataUpdated` is posted *inside* the spectrum block, so the Scope and Pitch panes register a
 **spectrum** consumer (not a dedicated PCM one) to make mono PCM flow.
 
-**Octave requires dual consumers:** it registers both **spectrum** (to trigger the FFT) and
-**magnitudes** (to receive raw linear magnitudes). This is the only pane that gates the magnitudes
-path; all others share existing notification/consumer infrastructure.
+**Octave uses the magnitudes consumer alone.** The magnitudes path is independent: the FFT runs when
+`spectrumNeeded || magnitudesNeeded`, and the 75-band spectrum work is gated separately by
+`spectrumNeeded`. So a `magnitudes` consumer triggers the FFT and `.audioFFTMagnitudesUpdated` on its
+own — no spectrum consumer required, and an octave-only window skips the 75-band mapping. Both
+`AudioEngine` and `StreamingAudioPlayer` implement this gating identically.
 
 ## What each pane shows (behavior + accuracy caveats)
 
@@ -129,7 +131,7 @@ maps each pane to its consumer(s):
 - Scope (pane 0) → spectrum
 - Levels (pane 1) → stereo
 - Spectrogram (pane 2) → spectrum
-- Octave (pane 3) → spectrum + magnitudes (dual consumers)
+- Octave (pane 3) → magnitudes
 - Pitch (pane 4) → spectrum
 - Delay (pane 5) → stereo
 

--- a/skills/audio-system/SKILL.md
+++ b/skills/audio-system/SKILL.md
@@ -329,11 +329,11 @@ Do not assume spectrum demand implies waveform demand.
 - `AudioEngine.magnitudesConsumers` controls raw linear FFT magnitudes (`.audioFFTMagnitudesUpdated`)
 - The waveform window registers a waveform consumer only while visible on a non-file audio track
 - `SpectrumAnalyzerView` registers a waveform consumer only while `qualityMode == .visClassicExact` and the analyzer is actively rendering
-- The Audio Analysis window registers per-pane consumers (see audio-analysis-window skill); a closed window deregisters all of them
+- The Audio Analyzer window registers per-pane consumers (see audio-analysis-window skill); a closed window deregisters all of them
 
 This split matters for CPU usage: hidden waveform windows and inactive `vis_classic` views should not keep paying the live waveform callback cost.
 
-### Stereo PCM and FFT-magnitudes paths (Audio Analysis)
+### Stereo PCM and FFT-magnitudes paths (Audio Analyzer)
 
 Two analysis-only paths exist alongside the mono PCM/spectrum/waveform feeds, each gated by its own
 consumer set so it costs nothing when unused:

--- a/skills/audio-system/SKILL.md
+++ b/skills/audio-system/SKILL.md
@@ -325,10 +325,29 @@ Do not assume spectrum demand implies waveform demand.
 
 - `AudioEngine.spectrumConsumers` controls FFT/spectrum work
 - `AudioEngine.waveformConsumers` controls 576-sample waveform chunk generation
+- `AudioEngine.stereoConsumers` controls separate L/R downsampled PCM (`.audioStereoPCMDataUpdated`)
+- `AudioEngine.magnitudesConsumers` controls raw linear FFT magnitudes (`.audioFFTMagnitudesUpdated`)
 - The waveform window registers a waveform consumer only while visible on a non-file audio track
 - `SpectrumAnalyzerView` registers a waveform consumer only while `qualityMode == .visClassicExact` and the analyzer is actively rendering
+- The Audio Analysis window registers per-pane consumers (see audio-analysis-window skill); a closed window deregisters all of them
 
 This split matters for CPU usage: hidden waveform windows and inactive `vis_classic` views should not keep paying the live waveform callback cost.
+
+### Stereo PCM and FFT-magnitudes paths (Audio Analysis)
+
+Two analysis-only paths exist alongside the mono PCM/spectrum/waveform feeds, each gated by its own
+consumer set so it costs nothing when unused:
+
+- **`.audioStereoPCMDataUpdated`** — `["left": [Float](512), "right": [Float](512), "sampleRate": Double]`.
+  Separate downsampled L/R buffers (mono streams are duplicated into both). Gated by `stereoNeeded`.
+- **`.audioFFTMagnitudesUpdated`** — `["magnitudes": [Float](fftSize/2 linear), "sampleRate": Double, "fftSize": Int]`.
+  Raw **linear** FFT magnitudes (not dB, not the 75-band normalized spectrum). Posted inside the
+  `spectrumNeeded` FFT block, additionally gated by `magnitudesNeeded`. Consumers of this path must also
+  hold a spectrum consumer so the FFT actually runs.
+
+**Both paths are wired in `AudioEngine` (local) and `StreamingAudioPlayer` (streaming) and emit the
+identical payload shape.** A consumer listening to only one path silently misses the other engine — the
+`stereoNeeded`/`magnitudesNeeded` mirror flags bridge engine → streaming the same way `spectrumNeeded` does.
 
 ## BPM Detection
 

--- a/skills/audio-system/SKILL.md
+++ b/skills/audio-system/SKILL.md
@@ -341,9 +341,10 @@ consumer set so it costs nothing when unused:
 - **`.audioStereoPCMDataUpdated`** — `["left": [Float](512), "right": [Float](512), "sampleRate": Double]`.
   Separate downsampled L/R buffers (mono streams are duplicated into both). Gated by `stereoNeeded`.
 - **`.audioFFTMagnitudesUpdated`** — `["magnitudes": [Float](fftSize/2 linear), "sampleRate": Double, "fftSize": Int]`.
-  Raw **linear** FFT magnitudes (not dB, not the 75-band normalized spectrum). Posted inside the
-  `spectrumNeeded` FFT block, additionally gated by `magnitudesNeeded`. Consumers of this path must also
-  hold a spectrum consumer so the FFT actually runs.
+  Raw **linear** FFT magnitudes (not dB, not the 75-band normalized spectrum). The FFT runs when
+  `spectrumNeeded || magnitudesNeeded`; this notification is posted right after the magnitudes are
+  computed, gated by `magnitudesNeeded`, and the 75-band spectrum work is gated separately by
+  `spectrumNeeded`. So a magnitudes consumer is independent — it does not require a spectrum consumer.
 
 **Both paths are wired in `AudioEngine` (local) and `StreamingAudioPlayer` (streaming) and emit the
 identical payload shape.** A consumer listening to only one path silently misses the other engine — the

--- a/skills/user-guide/SKILL.md
+++ b/skills/user-guide/SKILL.md
@@ -22,7 +22,7 @@ A faithful recreation of Winamp 2.x for macOS with Plex/Jellyfin/Subsonic integr
 | **Playlist Editor** | Track list and playlist management | PL button or context menu |
 | **Equalizer** | Classic 10-band EQ or modern 21-band EQ with presets | EQ button or context menu |
 | **Spectrum Analyzer** | Large spectrum visualization | Context menu or Window menu |
-| **Audio Analysis** | Friture-style multi-pane analyzer (Scope, Levels, Spectrogram, Octave, Pitch, Delay) | Context menu or Window menu |
+| **Audio Analyzer** | Friture-style multi-pane analyzer (Scope, Levels, Spectrogram, Octave, Pitch, Delay) | Context menu or Window menu |
 | **Library Browser** | Browse Plex/Jellyfin/Subsonic/Emby and local media | Logo button or context menu |
 | **ProjectM** | Visualization engine host for ProjectM, Geiss, Tripex, and Met Museum Art | Menu button or context menu |
 
@@ -265,7 +265,7 @@ Accessible via **Playback > Sleep Timer** (or the right-click context menu).
 
 ## Visualizations
 
-### Audio Analysis Window
+### Audio Analyzer Window
 A multi-pane real-time analyzer (Friture-style), available in both classic and modern UI. Right-click the window to pick a pane:
 - **Scope** — oscilloscope waveform of the live signal.
 - **Levels** — per-channel Peak and RMS meters (green/yellow/red) in dBFS.

--- a/skills/user-guide/SKILL.md
+++ b/skills/user-guide/SKILL.md
@@ -22,6 +22,7 @@ A faithful recreation of Winamp 2.x for macOS with Plex/Jellyfin/Subsonic integr
 | **Playlist Editor** | Track list and playlist management | PL button or context menu |
 | **Equalizer** | Classic 10-band EQ or modern 21-band EQ with presets | EQ button or context menu |
 | **Spectrum Analyzer** | Large spectrum visualization | Context menu or Window menu |
+| **Audio Analysis** | Friture-style multi-pane analyzer (Scope, Levels, Spectrogram, Octave, Pitch, Delay) | Context menu or Window menu |
 | **Library Browser** | Browse Plex/Jellyfin/Subsonic/Emby and local media | Logo button or context menu |
 | **ProjectM** | Visualization engine host for ProjectM, Geiss, Tripex, and Met Museum Art | Menu button or context menu |
 
@@ -263,6 +264,17 @@ Accessible via **Playback > Sleep Timer** (or the right-click context menu).
 - **Dynamic**: Per-region normalization (bass/mid/treble)
 
 ## Visualizations
+
+### Audio Analysis Window
+A multi-pane real-time analyzer (Friture-style), available in both classic and modern UI. Right-click the window to pick a pane:
+- **Scope** — oscilloscope waveform of the live signal.
+- **Levels** — per-channel Peak and RMS meters (green/yellow/red) in dBFS.
+- **Spectrogram** — scrolling waterfall of the spectrum over time.
+- **Octave** — 1/3-octave bar spectrum (20 Hz–20 kHz) with peak-hold markers.
+- **Pitch** — detected note, frequency, and how sharp/flat it is (best for vocals/single notes; unreliable on deep bass).
+- **Delay** — stereo left/right timing offset in ms and samples (resolves up to ±~5.8 ms).
+
+Only the visible pane runs, so the window is light on CPU and idles when closed.
 
 ### Main Window GPU Modes
 Off, Spectrum, vis_classic, Fire, Enhanced, Ultra, JWST, Lightning, Matrix, Snow, EKG. Double-click cycles visual modes; choose Off from Visuals > Spectrum Analyzer > Main Window > Mode.

--- a/skills/visualizations/SKILL.md
+++ b/skills/visualizations/SKILL.md
@@ -15,7 +15,7 @@ The standalone waveform window is **not** a Metal visualization mode. It reuses 
 |-------|-------|
 | [main-window-visualization](../main-window-visualization/SKILL.md) | The 76×16 main-window display area: 11 modes, switching, mode-specific settings |
 | [spectrum-analyzer-window](../spectrum-analyzer-window/SKILL.md) | Dedicated 84-bar spectrum window: docking, geometry, mode list, the cropped analyzer curve, vis_classic waveform demand |
-| [audio-analysis-window](../audio-analysis-window/SKILL.md) | Friture-style multi-pane Audio Analysis window: Scope/Levels/Spectrogram panes, stereo PCM path, per-pane consumer gating, AudioAnalysisDSP module |
+| [audio-analysis-window](../audio-analysis-window/SKILL.md) | Friture-style multi-pane Audio Analysis window: Scope/Levels/Spectrogram/Octave/Pitch/Delay panes, stereo PCM + FFT-magnitudes paths, per-pane consumer gating, AudioAnalysisDSP module |
 | [gpu-vis-modes](../gpu-vis-modes/SKILL.md) | Per-mode internals shared by both windows: Fire, JWST, Lightning, Matrix, Snow, EKG, Classic/Enhanced/Ultra |
 | [album-art-visualizer](../album-art-visualizer/SKILL.md) | Library Browser ART-mode effects (30 Core Image filters) |
 | [projectm-milkdrop](../projectm-milkdrop/SKILL.md) | ProjectM/MilkDrop preset engine in the visualization window |

--- a/skills/visualizations/SKILL.md
+++ b/skills/visualizations/SKILL.md
@@ -15,7 +15,7 @@ The standalone waveform window is **not** a Metal visualization mode. It reuses 
 |-------|-------|
 | [main-window-visualization](../main-window-visualization/SKILL.md) | The 76×16 main-window display area: 11 modes, switching, mode-specific settings |
 | [spectrum-analyzer-window](../spectrum-analyzer-window/SKILL.md) | Dedicated 84-bar spectrum window: docking, geometry, mode list, the cropped analyzer curve, vis_classic waveform demand |
-| [audio-analysis-window](../audio-analysis-window/SKILL.md) | Friture-style multi-pane Audio Analysis window: Scope/Levels/Spectrogram/Octave/Pitch/Delay panes, stereo PCM + FFT-magnitudes paths, per-pane consumer gating, AudioAnalysisDSP module |
+| [audio-analysis-window](../audio-analysis-window/SKILL.md) | Friture-style multi-pane Audio Analyzer window: Scope/Levels/Spectrogram/Octave/Pitch/Delay panes, stereo PCM + FFT-magnitudes paths, per-pane consumer gating, AudioAnalysisDSP module |
 | [gpu-vis-modes](../gpu-vis-modes/SKILL.md) | Per-mode internals shared by both windows: Fire, JWST, Lightning, Matrix, Snow, EKG, Classic/Enhanced/Ultra |
 | [album-art-visualizer](../album-art-visualizer/SKILL.md) | Library Browser ART-mode effects (30 Core Image filters) |
 | [projectm-milkdrop](../projectm-milkdrop/SKILL.md) | ProjectM/MilkDrop preset engine in the visualization window |


### PR DESCRIPTION
Completes the deferred **Phase 2b** panes of the Audio Analysis window — **Octave**, **Pitch**, and **Delay** — available in **both classic and modern UI**. They plug into the existing shared pane core (`AudioAnalysisModel.paneTitles` drives both right-click menus, the content-view switch, and consumer gating), so a single implementation lights up both modes.

## Panes
- **Octave** — 1/3-octave spectrum analyzer (CoreGraphics) with peak-hold decay, 20 Hz–20 kHz. Fed by a new gated `.audioFFTMagnitudesUpdated` notification (raw linear FFT magnitudes), published from **both** the local engine and the streaming-audio path. Registers spectrum + magnitudes consumers.
- **Pitch** — autocorrelation fundamental tracker: Hz, nearest note + octave, cents-from-equal-temperament. Spectrum consumer.
- **Delay** — stereo L/R cross-correlation delay in ms + samples with direction and resolvable-range note. Stereo consumer.

The DSP (`octaveBands` / `estimatePitchHz` / `estimateDelaySamples`) was already implemented and unit-tested in `NullPlayerCore`.

## CPU gating
The new `magnitudesNeeded` flag + `add/removeMagnitudesConsumer` mirror the existing stereo-consumer pattern in both `AudioEngine` and `StreamingAudioPlayer`. Magnitude publishing is gated so a closed Octave pane (and a closed window) costs nothing. The consumer coordinator was refactored to map each consumer id to its correct removal function so `deregisterAll()` on `windowWillClose` leaves the FFT, stereo, and magnitudes paths idle.

## Fixes during bring-up
- **Crash:** `hzToNote` indexed out of range for pitches below 440 Hz (Swift `%` keeps the dividend's sign → negative note-name index, e.g. ~247 Hz). Reworked using MIDI note number with a positive modulo.
- **Layout:** all three panes were laid out for a tall window and clipped the top of the short (~88pt) content area. Rebuilt as compact, fit-in-place, centered layouts that scale up on resize. Octave bars were also drawing upside-down (hanging from a top baseline) with oversized margins leaving ~8pt for bars — corrected to grow up from a bottom baseline with trimmed margins and sparse frequency labels.

## Testing
- `swift build` clean.
- `swift test --filter NullPlayerCoreTests` — 55/55 pass (existing DSP coverage; no new DSP added).
- Manual: open each pane at default size and resized; confirm CPU idle with the window closed.

No CHANGELOG change in this PR (per request). Includes the `0.26.0` `CFBundleShortVersionString` bump.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Expanded the Audio Analyzer to 6 panes: Octave (1/3-octave), Pitch tracking, and inter-channel Delay estimation.
* **Improvements / Performance**
  * Added a gated FFT magnitudes data path for the Octave pane, reducing CPU when specific panes are inactive.
  * Updated scope waveform rendering for more stable, trigger-aligned visualization.
  * Ensured streaming analyzer behavior propagates magnitudes needs during playback transitions.
* **Bug Fixes**
  * Improved analyzer consumer start/stop lifecycle so panes idle cleanly when hidden or closed.
* **Documentation**
  * Updated skills and the user guide for the full Audio Analyzer lineup and pane CPU gating behavior.
* **Chores**
  * Bumped app version to **0.26.0** and renamed UI text to **Audio Analyzer** throughout.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->