### PR TITLE
Fix ART mode after clearing playlist

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,10 @@
 
 - **Classic utility-window titles** — the classic Spectrum Analyzer, Waveform, Library, and ProjectM windows now draw explicit bitmap-font titles into their skinned title bars, matching the Audio Analysis window. ProjectM is labeled **VISUALIZATIONS**.
 
+### Bug Fixes
+
+- **Library Browser ART mode no longer traps you after clearing the playlist (#283)** — clearing the playlist while ART mode is open now exits ART mode and restores the normal browser controls in both classic and modern UI. Artwork loading is also guarded against stale asynchronous results, while transient track replacement after removing the currently playing playlist row keeps ART mode active.
+
 ## 0.25.0
 
 ### New Features

--- a/Sources/NullPlayer/Windows/ModernLibraryBrowser/ModernLibraryBrowserView.swift
+++ b/Sources/NullPlayer/Windows/ModernLibraryBrowser/ModernLibraryBrowserView.swift
@@ -484,11 +484,19 @@ class ModernLibraryBrowserView: NSView {
     // Art-only mode
     private var isArtOnlyMode: Bool = false {
         didSet {
+            artModeLifecycleGeneration &+= 1
             needsDisplay = true
             if isArtOnlyMode { fetchCurrentTrackRating(); loadAllArtworkForCurrentTrack() }
-            else { isVisualizingArt = false; artworkImages = []; artworkIndex = 0 }
+            else {
+                isVisualizingArt = false
+                artworkCyclingTask?.cancel()
+                artworkCyclingTask = nil
+                artworkImages = []
+                artworkIndex = 0
+            }
         }
     }
+    private var artModeLifecycleGeneration = 0
     private var isVisualizingArt: Bool = false {
         didSet {
             if isVisualizingArt { startVisualizerTimer() } else { stopVisualizerTimer() }
@@ -7161,7 +7169,22 @@ class ModernLibraryBrowserView: NSView {
     }
 
     @objc private func trackDidChange(_ notification: Notification) {
+        artModeLifecycleGeneration &+= 1
+        let generation = artModeLifecycleGeneration
+        let track = notification.userInfo?["track"] as? Track
+
         if isArtOnlyMode {
+            guard track != nil else {
+                DispatchQueue.main.async { [weak self] in
+                    guard let self = self,
+                          self.artModeLifecycleGeneration == generation,
+                          self.isArtOnlyMode,
+                          WindowManager.shared.audioEngine.currentTrack == nil else { return }
+                    self.exitArtOnlyModeForMissingArtwork()
+                }
+                return
+            }
+
             // Art-only mode uses loadAllArtworkForCurrentTrack exclusively.
             // Don't also call loadArtwork(for:) to avoid a race where loadArtwork
             // finishes last with nil and overwrites valid artwork.
@@ -7172,7 +7195,6 @@ class ModernLibraryBrowserView: NSView {
         guard WindowManager.shared.showBrowserArtworkBackground else {
             if currentArtwork != nil { currentArtwork = nil; artworkTrackId = nil; needsDisplay = true }; return
         }
-        let track = notification.userInfo?["track"] as? Track
         loadArtwork(for: track)
     }
     
@@ -8067,7 +8089,12 @@ class ModernLibraryBrowserView: NSView {
                 image = await self.loadRemoteArtwork(urlString: thumb, cacheNamespace: "generic")
             }
             guard !Task.isCancelled else { return }
-            await MainActor.run { self.currentArtwork = image; self.artworkTrackId = track.id; self.needsDisplay = true }
+            await MainActor.run {
+                guard WindowManager.shared.audioEngine.currentTrack?.id == track.id else { return }
+                self.currentArtwork = image
+                self.artworkTrackId = track.id
+                self.needsDisplay = true
+            }
         }
     }
 
@@ -8201,8 +8228,12 @@ class ModernLibraryBrowserView: NSView {
     }
     
     private func loadAllArtworkForCurrentTrack() {
+        artworkLoadTask?.cancel(); artworkLoadTask = nil
         artworkCyclingTask?.cancel(); artworkCyclingTask = nil
-        guard let currentTrack = WindowManager.shared.audioEngine.currentTrack else { artworkImages = []; artworkIndex = 0; currentArtwork = nil; needsDisplay = true; return }
+        guard let currentTrack = WindowManager.shared.audioEngine.currentTrack else {
+            exitArtOnlyModeForMissingArtwork()
+            return
+        }
         artworkImages = []; artworkIndex = 0
         artworkCyclingTask = Task { [weak self] in
             guard let self = self else { return }
@@ -8224,11 +8255,32 @@ class ModernLibraryBrowserView: NSView {
             }
             guard !Task.isCancelled else { return }
             await MainActor.run {
+                guard self.isArtOnlyMode,
+                      WindowManager.shared.audioEngine.currentTrack?.id == currentTrack.id else { return }
+                guard !images.isEmpty else {
+                    self.exitArtOnlyModeForMissingArtwork()
+                    return
+                }
+
                 self.artworkImages = images; self.artworkIndex = 0
                 self.currentArtwork = images.first
+                self.artworkTrackId = currentTrack.id
                 self.needsDisplay = true
             }
         }
+    }
+
+    private func exitArtOnlyModeForMissingArtwork() {
+        artworkLoadTask?.cancel()
+        artworkLoadTask = nil
+        artworkCyclingTask?.cancel()
+        artworkCyclingTask = nil
+        artworkImages = []
+        artworkIndex = 0
+        currentArtwork = nil
+        artworkTrackId = nil
+        isArtOnlyMode = false
+        needsDisplay = true
     }
     
     private func cycleToNextArtwork() {

--- a/Sources/NullPlayer/Windows/PlexBrowser/PlexBrowserView.swift
+++ b/Sources/NullPlayer/Windows/PlexBrowser/PlexBrowserView.swift
@@ -1145,6 +1145,7 @@ class PlexBrowserView: NSView {
     /// Art-only mode - hides tabs and list, shows just album art (session only, not persisted)
     private var isArtOnlyMode: Bool = false {
         didSet {
+            artModeLifecycleGeneration &+= 1
             updateHistoryHostingVisibility()
             needsDisplay = true
             if isArtOnlyMode {
@@ -1155,12 +1156,15 @@ class PlexBrowserView: NSView {
             } else {
                 // Stop visualization when exiting art-only mode
                 isVisualizingArt = false
+                artworkCyclingTask?.cancel()
+                artworkCyclingTask = nil
                 // Clear cycling state
                 artworkImages = []
                 artworkIndex = 0
             }
         }
     }
+    private var artModeLifecycleGeneration = 0
     
     /// Visualization mode - applies audio-reactive effects to album art
     private var isVisualizingArt: Bool = false {
@@ -5981,7 +5985,22 @@ class PlexBrowserView: NSView {
     // MARK: - Artwork Background
     
     @objc private func trackDidChange(_ notification: Notification) {
+        artModeLifecycleGeneration &+= 1
+        let generation = artModeLifecycleGeneration
+        let track = notification.userInfo?["track"] as? Track
+
         if isArtOnlyMode {
+            guard track != nil else {
+                DispatchQueue.main.async { [weak self] in
+                    guard let self = self,
+                          self.artModeLifecycleGeneration == generation,
+                          self.isArtOnlyMode,
+                          WindowManager.shared.audioEngine.currentTrack == nil else { return }
+                    self.exitArtOnlyModeForMissingArtwork()
+                }
+                return
+            }
+
             // Art-only mode uses loadAllArtworkForCurrentTrack exclusively.
             // Don't also call loadArtwork(for:) to avoid a race where loadArtwork
             // finishes last with nil and overwrites valid artwork.
@@ -6000,7 +6019,6 @@ class PlexBrowserView: NSView {
             return
         }
         
-        let track = notification.userInfo?["track"] as? Track
         loadArtwork(for: track)
     }
     
@@ -6090,6 +6108,7 @@ class PlexBrowserView: NSView {
             guard !Task.isCancelled else { return }
             
             await MainActor.run {
+                guard WindowManager.shared.audioEngine.currentTrack?.id == track.id else { return }
                 self.currentArtwork = image
                 self.artworkTrackId = track.id
                 self.needsDisplay = true
@@ -6513,15 +6532,16 @@ class PlexBrowserView: NSView {
     
     /// Load all available artwork for the currently playing track
     private func loadAllArtworkForCurrentTrack() {
+        // ART mode owns the displayed artwork while active.
+        artworkLoadTask?.cancel()
+        artworkLoadTask = nil
+
         // Cancel any pending artwork cycling task
         artworkCyclingTask?.cancel()
         artworkCyclingTask = nil
         
         guard let currentTrack = WindowManager.shared.audioEngine.currentTrack else {
-            artworkImages = []
-            artworkIndex = 0
-            currentArtwork = nil
-            needsDisplay = true
+            exitArtOnlyModeForMissingArtwork()
             return
         }
         
@@ -6568,12 +6588,33 @@ class PlexBrowserView: NSView {
             guard !Task.isCancelled else { return }
             
             await MainActor.run {
+                guard self.isArtOnlyMode,
+                      WindowManager.shared.audioEngine.currentTrack?.id == currentTrack.id else { return }
+                guard !images.isEmpty else {
+                    self.exitArtOnlyModeForMissingArtwork()
+                    return
+                }
+
                 self.artworkImages = images
                 self.artworkIndex = 0
                 self.currentArtwork = images.first
+                self.artworkTrackId = currentTrack.id
                 self.needsDisplay = true
             }
         }
+    }
+
+    private func exitArtOnlyModeForMissingArtwork() {
+        artworkLoadTask?.cancel()
+        artworkLoadTask = nil
+        artworkCyclingTask?.cancel()
+        artworkCyclingTask = nil
+        artworkImages = []
+        artworkIndex = 0
+        currentArtwork = nil
+        artworkTrackId = nil
+        isArtOnlyMode = false
+        needsDisplay = true
     }
     
     /// Load artwork based on the currently selected item in the browser


### PR DESCRIPTION
## Summary
- exit Library Browser ART mode when clearing the playlist removes the current track or artwork
- preserve ART mode during transient current-track replacement when removing a playing playlist row
- cancel and guard asynchronous artwork loads to prevent stale results in both classic and modern UIs

## Testing
- `swift build`
- `DYLD_LIBRARY_PATH="$PWD/Frameworks:/opt/homebrew/lib" swift test` — 239 tests passed
- `git diff --check`

Closes #283

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed Library Browser ART mode becoming unresponsive after clearing the playlist. Clearing the playlist while in ART mode now properly exits the mode and restores normal browser controls.
  * Improved artwork loading reliability to prevent stale or outdated images from appearing during rapid track changes.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->