### PR TITLE
Fix kHz display for streamed tracks without a visualization (#285)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,10 @@
 
 - **Classic utility-window titles** — the classic Spectrum Analyzer, Waveform, Library, and ProjectM windows now draw explicit bitmap-font titles into their skinned title bars, matching the Audio Analysis window. ProjectM is labeled **VISUALIZATIONS**.
 
+### Bug Fixes
+
+- **kHz display now shows for streamed tracks without a visualization open (#285)** — the classic skin's sample-rate (kHz) readout stayed blank for streaming tracks (e.g. a Plex MP3) whose server metadata omits the sample rate. The streaming player only reported the decoded format — which fills in the missing sample rate — while a spectrum/oscilloscope/waveform consumer was active, so with no visualization showing the kHz never appeared. Format detection now runs as soon as the first audio buffer arrives, independent of visualization demand.
+
 ## 0.25.0
 
 ### New Features

--- a/Sources/NullPlayer/Audio/StreamingAudioPlayer.swift
+++ b/Sources/NullPlayer/Audio/StreamingAudioPlayer.swift
@@ -417,14 +417,13 @@ class StreamingAudioPlayer {
     // MARK: - Spectrum Analysis
     
     private func processAudioBuffer(_ buffer: AVAudioPCMBuffer) {
-        // Skip FFT processing when paused or stopped to save CPU
-        // The frame filter still receives buffers but we don't need to process them
         guard state == .playing else { return }
-        guard spectrumNeeded || waveformNeeded || stereoNeeded || magnitudesNeeded else { return }
 
-        guard let channelData = buffer.floatChannelData else { return }
-        
-        // Report format info once per track
+        // Report format info once per track. This must run regardless of whether any
+        // visualization/waveform consumer is active: it fills in the sample rate (and
+        // channels) for streaming tracks — e.g. Plex MP3s — whose server metadata omits
+        // it, so the classic skin's kHz display works even with no visualization showing.
+        // It only needs buffer.format, so report it before the consumer-demand guard below.
         if !hasReportedFormat {
             hasReportedFormat = true
             let sampleRate = Int(buffer.format.sampleRate)
@@ -433,7 +432,13 @@ class StreamingAudioPlayer {
                 self?.delegate?.streamingPlayerDidDetectFormat(sampleRate: sampleRate, channels: channels)
             }
         }
-        
+
+        // Skip FFT/waveform processing when no consumer needs the data to save CPU.
+        // The frame filter still receives buffers but we don't need to process them.
+        guard spectrumNeeded || waveformNeeded || stereoNeeded || magnitudesNeeded else { return }
+
+        guard let channelData = buffer.floatChannelData else { return }
+
         let frameCount = Int(buffer.frameLength)
         guard frameCount > 0 else { return }
         


### PR DESCRIPTION
## Summary

Fixes #285 — the classic skin's sample-rate (**kHz**) readout stayed blank for streaming tracks (e.g. a **Plex** MP3) whose server metadata doesn't include the sample rate.

## Root cause

Plex (and other servers) sometimes omit `samplingRate` on the audio stream, so `Track.sampleRate` is `nil`. There's a fallback for this: `StreamingAudioPlayer` reports the actual decoded format via `streamingPlayerDidDetectFormat(...)`, and `AudioEngine` uses it to fill in the missing sample rate. But that one-shot format report lived inside `processAudioBuffer` **below** the consumer-demand guard:

```swift
guard spectrumNeeded || waveformNeeded || stereoNeeded || magnitudesNeeded else { return }
// ... format report happened here
```

The `frameFiltering` tap always runs, but with the classic skin showing no spectrum/oscilloscope/waveform visualization, none of those flags are set, so the function bailed early and the format was never reported → nil sample rate never filled in → no kHz.

## Fix

Move the one-shot format report **above** the consumer-demand guard so it fires on the first audio buffer regardless of visualization demand. It only reads `buffer.format`, so it doesn't need the channel data the heavier FFT/waveform path requires.

## Notes / testing

- Local files are unaffected (their sample rate is extracted at `Track` init).
- `swift build` passes.
- The kHz fills in shortly after playback starts (once the first decoded buffer arrives), matching existing behavior for channels and other stream-derived format info.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed kHz display appearing blank for streamed tracks when no visualization is open in the classic skin.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->