### PR TITLE
Show a download spinner on downloading YouTube video rows

### DIFF
--- a/Sources/NullPlayer/Windows/ModernLibraryBrowser/ModernLibraryBrowserView.swift
+++ b/Sources/NullPlayer/Windows/ModernLibraryBrowser/ModernLibraryBrowserView.swift
@@ -426,7 +426,9 @@ class ModernLibraryBrowserView: NSView {
     private var youtubeChannelVideos: [String: [YouTubeVideo]] = [:]
     private var youtubeExpandTask: Task<Void, Never>?
     private var youtubeDownloadTask: Task<Void, Never>?
-    
+    /// Video IDs currently downloading — drives a per-row spinner on the video entry.
+    private var downloadingVideoIds: Set<String> = []
+
     // Cached data - Video (Plex)
     private var cachedMovies: [PlexMovie] = []
     private var cachedShows: [PlexShow] = []
@@ -2140,10 +2142,20 @@ class ModernLibraryBrowserView: NSView {
                 .font: useFont,
                 .foregroundColor: skin.applyTextOpacity(to: color)
             ]
+            // Per-row download spinner on the title column of a downloading YouTube video.
+            var titleSpinnerInset: CGFloat = 0
+            if column.id == "title", case .youtubeVideo(let video) = item.type,
+               downloadingVideoIds.contains(video.videoId) {
+                let spinnerRadius = min(rect.height * 0.3, 6)
+                let cx = x + 4 + spinnerRadius
+                drawRowSpinner(in: context, center: CGPoint(x: cx, y: rect.midY), radius: spinnerRadius, skin: skin)
+                titleSpinnerInset = spinnerRadius * 2 + 4
+            }
+
             let textSize = value.size(withAttributes: attrs)
             let textY = rect.minY + (rect.height - textSize.height) / 2
-            let textX = isCenteredRadioColumn ? (x + (width - textSize.width) / 2) : (x + 4)
-            let maxTextWidth = width - 8
+            let textX = isCenteredRadioColumn ? (x + (width - textSize.width) / 2) : (x + 4 + titleSpinnerInset)
+            let maxTextWidth = width - 8 - titleSpinnerInset
 
             let drawRect = NSRect(x: textX, y: textY, width: maxTextWidth, height: textSize.height)
             if column.id == "rating" && !isSelected && value.contains("★") {
@@ -2220,7 +2232,26 @@ class ModernLibraryBrowserView: NSView {
         
         startLoadingAnimation()
     }
-    
+
+    /// Small inline spinner used on a downloading YouTube video row.
+    private func drawRowSpinner(in context: CGContext, center: CGPoint, radius: CGFloat, skin: ModernSkin) {
+        let innerRadius = radius * 0.45
+        let outerRadius = radius
+        let numSegments = 8
+        let segmentAngle = CGFloat.pi * 2 / CGFloat(numSegments)
+        context.saveGState()
+        for i in 0..<numSegments {
+            let angle = CGFloat(i) * segmentAngle - CGFloat.pi / 2 + CGFloat(loadingAnimationFrame) * segmentAngle
+            let alpha = CGFloat(i + 1) / CGFloat(numSegments)
+            skin.applyTextOpacity(to: skin.textColor).withAlphaComponent(alpha).setStroke()
+            context.setLineWidth(1.5)
+            context.move(to: CGPoint(x: center.x + cos(angle) * innerRadius, y: center.y + sin(angle) * innerRadius))
+            context.addLine(to: CGPoint(x: center.x + cos(angle) * outerRadius, y: center.y + sin(angle) * outerRadius))
+            context.strokePath()
+        }
+        context.restoreGState()
+    }
+
     private func drawErrorState(in context: CGContext, message: String, listRect: NSRect, skin: ModernSkin) {
         let attrs: [NSAttributedString.Key: Any] = [
             .foregroundColor: skin.applyTextOpacity(to: skin.textDimColor),
@@ -6108,10 +6139,13 @@ class ModernLibraryBrowserView: NSView {
                 WindowManager.shared.audioEngine.playNow([track])
             }
         } else {
+            downloadingVideoIds.insert(video.videoId)
             startLoadingAnimation()
+            needsDisplay = true
             youtubeDownloadTask?.cancel()
             youtubeDownloadTask = Task.detached { @MainActor [weak self] in
                 guard let self = self else { return }
+                defer { self.downloadingVideoIds.remove(video.videoId); self.stopLoadingAnimation(); self.needsDisplay = true }
                 do {
                     let downloadedURL = try await YouTubeManager.shared.downloadAudio(video: video)
                     let track = Track(url: downloadedURL, isYouTubeOrigin: true)
@@ -6120,7 +6154,6 @@ class ModernLibraryBrowserView: NSView {
                 } catch {
                     NSLog("Failed to download YouTube video: %@", error.localizedDescription)
                 }
-                self.stopLoadingAnimation()
             }
         }
     }
@@ -7472,6 +7505,9 @@ class ModernLibraryBrowserView: NSView {
             self.loadingAnimationFrame += 1
             if self.isLoading {
                 self.needsDisplay = true
+            } else if !self.downloadingVideoIds.isEmpty {
+                // Redraw the list area for the per-row download spinner(s)
+                self.needsDisplay = true
             } else if self.isLibraryScanning {
                 // Redraw server bar only for the scan spinner
                 let serverBarY = self.topChromeBottomY - Layout.serverBarHeight
@@ -7484,7 +7520,7 @@ class ModernLibraryBrowserView: NSView {
     }
 
     private func stopLoadingAnimation(force: Bool = false) {
-        guard force || !isLibraryScanning else { return }
+        guard force || (!isLibraryScanning && downloadingVideoIds.isEmpty) else { return }
         loadingAnimationTimer?.invalidate(); loadingAnimationTimer = nil; loadingAnimationFrame = 0
     }
 
@@ -11520,10 +11556,13 @@ class ModernLibraryBrowserView: NSView {
                     WindowManager.shared.audioEngine.playNow([track])
                 }
             } else {
+                downloadingVideoIds.insert(video.videoId)
                 startLoadingAnimation()
+                needsDisplay = true
                 youtubeDownloadTask?.cancel()
                 youtubeDownloadTask = Task.detached { @MainActor [weak self] in
                     guard let self = self else { return }
+                    defer { self.downloadingVideoIds.remove(video.videoId); self.stopLoadingAnimation(); self.needsDisplay = true }
                     do {
                         let downloadedURL = try await YouTubeManager.shared.downloadAudio(video: video)
                         let track = Track(url: downloadedURL, isYouTubeOrigin: true)
@@ -11532,7 +11571,6 @@ class ModernLibraryBrowserView: NSView {
                     } catch {
                         NSLog("Failed to download YouTube video: %@", error.localizedDescription)
                     }
-                    self.stopLoadingAnimation()
                 }
             }
         case .plexRadioStation(let r): playPlexRadioStation(r)

--- a/Sources/NullPlayer/Windows/ModernLibraryBrowser/ModernLibraryBrowserView.swift
+++ b/Sources/NullPlayer/Windows/ModernLibraryBrowser/ModernLibraryBrowserView.swift
@@ -6148,9 +6148,13 @@ class ModernLibraryBrowserView: NSView {
                 defer { self.downloadingVideoIds.remove(video.videoId); self.stopLoadingAnimation(); self.needsDisplay = true }
                 do {
                     let downloadedURL = try await YouTubeManager.shared.downloadAudio(video: video)
+                    // A newer download may have superseded this one; don't auto-play a stale result.
+                    try Task.checkCancellation()
                     let track = Track(url: downloadedURL, isYouTubeOrigin: true)
                     WindowManager.shared.audioEngine.playNow([track])
                     rebuildCurrentModeItems()
+                } catch is CancellationError {
+                    // Superseded by a newer download request; skip side effects.
                 } catch {
                     NSLog("Failed to download YouTube video: %@", error.localizedDescription)
                 }
@@ -11565,9 +11569,13 @@ class ModernLibraryBrowserView: NSView {
                     defer { self.downloadingVideoIds.remove(video.videoId); self.stopLoadingAnimation(); self.needsDisplay = true }
                     do {
                         let downloadedURL = try await YouTubeManager.shared.downloadAudio(video: video)
+                        // A newer download may have superseded this one; don't auto-play a stale result.
+                        try Task.checkCancellation()
                         let track = Track(url: downloadedURL, isYouTubeOrigin: true)
                         WindowManager.shared.audioEngine.playNow([track])
                         rebuildCurrentModeItems()
+                    } catch is CancellationError {
+                        // Superseded by a newer download request; skip side effects.
                     } catch {
                         NSLog("Failed to download YouTube video: %@", error.localizedDescription)
                     }

--- a/Sources/NullPlayer/Windows/PlexBrowser/PlexBrowserView.swift
+++ b/Sources/NullPlayer/Windows/PlexBrowser/PlexBrowserView.swift
@@ -1076,6 +1076,8 @@ class PlexBrowserView: NSView {
     private var youtubeChannelVideos: [String: [YouTubeVideo]] = [:]
     private var youtubeExpandTask: Task<Void, Never>?
     private var youtubeDownloadTask: Task<Void, Never>?
+    /// Video IDs currently downloading — drives a per-row spinner on the video entry.
+    private var downloadingVideoIds: Set<String> = []
 
     private let historyAgent = PlayHistoryAgent()
     private var historyHostingView: NSHostingView<StatsContentView>?
@@ -3373,7 +3375,26 @@ class PlexBrowserView: NSView {
         // Start animation timer if not running
         startLoadingAnimation()
     }
-    
+
+    /// Small inline spinner used on a downloading YouTube video row.
+    private func drawRowSpinner(in context: CGContext, center: CGPoint, radius: CGFloat, colors: PlaylistColors) {
+        let innerRadius = radius * 0.45
+        let outerRadius = radius
+        let numSegments = 8
+        let segmentAngle = CGFloat.pi * 2 / CGFloat(numSegments)
+        context.saveGState()
+        for i in 0..<numSegments {
+            let angle = CGFloat(i) * segmentAngle - CGFloat.pi / 2 + CGFloat(loadingAnimationFrame) * segmentAngle
+            let alpha = CGFloat(i + 1) / CGFloat(numSegments)
+            colors.normalText.withAlphaComponent(alpha).setStroke()
+            context.setLineWidth(1.5)
+            context.move(to: CGPoint(x: center.x + cos(angle) * innerRadius, y: center.y + sin(angle) * innerRadius))
+            context.addLine(to: CGPoint(x: center.x + cos(angle) * outerRadius, y: center.y + sin(angle) * outerRadius))
+            context.strokePath()
+        }
+        context.restoreGState()
+    }
+
     private func drawErrorState(in context: CGContext, drawBounds: NSRect, message: String, colors: PlaylistColors, renderer: SkinRenderer) {
         var listY = Layout.titleBarHeight + Layout.serverBarHeight + Layout.tabBarHeight
         if browseMode == .search {
@@ -3572,8 +3593,16 @@ class PlexBrowserView: NSView {
             } else {
                 // Original rendering for artists, playlists, headers, etc.
                 let indent = CGFloat(item.indentLevel) * 16
-                let textX = itemRect.minX + indent + 4
-                
+                var textX = itemRect.minX + indent + 4
+
+                // Per-row download spinner for a downloading YouTube video
+                if case .youtubeVideo(let video) = item.type, downloadingVideoIds.contains(video.videoId) {
+                    let spinnerRadius = min(itemHeight * 0.3, 6)
+                    drawRowSpinner(in: context, center: CGPoint(x: textX + spinnerRadius, y: itemRect.midY),
+                                   radius: spinnerRadius, colors: colors)
+                    textX += spinnerRadius * 2 + 4
+                }
+
                 // Expand/collapse indicator for hierarchical items
                 if item.hasChildren {
                     let expanded = isExpanded(item)
@@ -5596,7 +5625,7 @@ class PlexBrowserView: NSView {
         let timer = Timer(timeInterval: 0.1, repeats: true) { [weak self] _ in
             guard let self = self else { return }
             self.loadingAnimationFrame += 1
-            if self.isLoading {
+            if self.isLoading || !self.downloadingVideoIds.isEmpty {
                 // Only redraw the list area where the loading spinner is displayed
                 // This prevents menu items from shimmering on non-Retina displays
                 var listY = self.Layout.titleBarHeight + self.Layout.serverBarHeight + self.Layout.tabBarHeight
@@ -5621,7 +5650,7 @@ class PlexBrowserView: NSView {
     }
 
     private func stopLoadingAnimation() {
-        guard !isLibraryScanning else { return }
+        guard !isLibraryScanning && downloadingVideoIds.isEmpty else { return }
         loadingAnimationTimer?.invalidate()
         loadingAnimationTimer = nil
         loadingAnimationFrame = 0
@@ -11112,10 +11141,13 @@ class PlexBrowserView: NSView {
                 WindowManager.shared.audioEngine.playNow([track])
             }
         } else {
+            downloadingVideoIds.insert(video.videoId)
             startLoadingAnimation()
+            needsDisplay = true
             youtubeDownloadTask?.cancel()
             youtubeDownloadTask = Task.detached { @MainActor [weak self] in
                 guard let self = self else { return }
+                defer { self.downloadingVideoIds.remove(video.videoId); self.stopLoadingAnimation(); self.needsDisplay = true }
                 do {
                     let downloadedURL = try await YouTubeManager.shared.downloadAudio(video: video)
                     let track = Track(url: downloadedURL, isYouTubeOrigin: true)
@@ -11124,7 +11156,6 @@ class PlexBrowserView: NSView {
                 } catch {
                     NSLog("Failed to download YouTube video: %@", error.localizedDescription)
                 }
-                self.stopLoadingAnimation()
             }
         }
     }
@@ -17394,10 +17425,13 @@ class PlexBrowserView: NSView {
                     WindowManager.shared.audioEngine.playNow([track])
                 }
             } else {
+                downloadingVideoIds.insert(video.videoId)
                 startLoadingAnimation()
+                needsDisplay = true
                 youtubeDownloadTask?.cancel()
                 youtubeDownloadTask = Task.detached { @MainActor [weak self] in
                     guard let self = self else { return }
+                    defer { self.downloadingVideoIds.remove(video.videoId); self.stopLoadingAnimation(); self.needsDisplay = true }
                     do {
                         let downloadedURL = try await YouTubeManager.shared.downloadAudio(video: video)
                         let track = Track(url: downloadedURL, isYouTubeOrigin: true)
@@ -17406,7 +17440,6 @@ class PlexBrowserView: NSView {
                     } catch {
                         NSLog("Failed to download YouTube video: %@", error.localizedDescription)
                     }
-                    self.stopLoadingAnimation()
                 }
             }
 

--- a/Sources/NullPlayer/Windows/PlexBrowser/PlexBrowserView.swift
+++ b/Sources/NullPlayer/Windows/PlexBrowser/PlexBrowserView.swift
@@ -11150,9 +11150,13 @@ class PlexBrowserView: NSView {
                 defer { self.downloadingVideoIds.remove(video.videoId); self.stopLoadingAnimation(); self.needsDisplay = true }
                 do {
                     let downloadedURL = try await YouTubeManager.shared.downloadAudio(video: video)
+                    // A newer download may have superseded this one; don't auto-play a stale result.
+                    try Task.checkCancellation()
                     let track = Track(url: downloadedURL, isYouTubeOrigin: true)
                     WindowManager.shared.audioEngine.playNow([track])
                     rebuildCurrentModeItems()
+                } catch is CancellationError {
+                    // Superseded by a newer download request; skip side effects.
                 } catch {
                     NSLog("Failed to download YouTube video: %@", error.localizedDescription)
                 }
@@ -17434,9 +17438,13 @@ class PlexBrowserView: NSView {
                     defer { self.downloadingVideoIds.remove(video.videoId); self.stopLoadingAnimation(); self.needsDisplay = true }
                     do {
                         let downloadedURL = try await YouTubeManager.shared.downloadAudio(video: video)
+                        // A newer download may have superseded this one; don't auto-play a stale result.
+                        try Task.checkCancellation()
                         let track = Track(url: downloadedURL, isYouTubeOrigin: true)
                         WindowManager.shared.audioEngine.playNow([track])
                         rebuildCurrentModeItems()
+                    } catch is CancellationError {
+                        // Superseded by a newer download request; skip side effects.
                     } catch {
                         NSLog("Failed to download YouTube video: %@", error.localizedDescription)
                     }


### PR DESCRIPTION
## Summary

Downloading a YouTube video in the **Channels tab** previously gave no visual feedback. The existing `startLoadingAnimation()` call during a download was effectively a no-op: while the channel list is on screen neither `isLoading` nor `isLibraryScanning` is true, so the animation timer stopped itself on its first tick.

This adds a **per-row spinner** on the video entry that's downloading, in both the modern (`ModernLibraryBrowserView`) and classic (`PlexBrowserView`) UIs.

## What changed

- **Track in-flight downloads** in a `downloadingVideoIds` set (keyed by video id) — handles concurrent/queued downloads cleanly.
- **Keep the animation timer alive** while a download is active and redraw the list area; `stopLoadingAnimation()` no longer tears it down mid-download.
- **Draw a small inline spinner** (`drawRowSpinner`) reusing the existing 8-segment rotating-arc pattern from `drawLoadingState`, sized down and placed at the left of the row, shifting the title text right so nothing overlaps. Modern draws it in the resizable column path (`drawColumnRow`); classic draws it in the simple-list path (YouTube has no resizable column group in classic).
- **Wire both entry points** (right-click "Download & Play" and double-click) to insert the id + start the animation, with a `defer` that removes the id, stops the animation, and refreshes — so the spinner is replaced by the existing "⬇" downloaded marker on success, or cleared on failure.

## Notes

Cancelling `youtubeDownloadTask` when a new download starts does not abort the underlying `yt-dlp`/`StreamRipper` process, so a superseded-but-still-running download keeps its spinner until it genuinely finishes (intended).

## Testing

- `swift build` passes (remaining warnings are pre-existing and unrelated).
- Manual QA: download a YouTube video from the Channels tab in both classic and modern UIs; spinner appears on the row, then is replaced by the downloaded marker.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Improvements**
  * Added visual download indicators for YouTube videos: a small spinner now appears inline next to video titles while they are being downloaded.
  * Enhanced loading animation behavior to remain active and visible while any YouTube downloads are in progress, providing clearer feedback about ongoing operations.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->