### PR TITLE
Modern toolbar: rename pM→VZ, add Audio Analyzer (AA) button

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,8 @@
 
 ### Improvements
 
+- **Modern main-window toolbar updated** — the visualizer toggle is now labeled **VZ**, and the former **SK** skin-menu button is now an **AA** toggle for opening and closing the Audio Analyzer. The toolbar order is now **SH RP CA VZ EQ PL SP AA WV LB**; modern skins remain available from the menu bar.
+
 - **Live Modern ↔ Classic UI switching — no restart** — switching UI mode (Skins menu → **Switch to Modern/Classic**, or picking a modern/classic skin while in the other mode) now happens instantly in-process instead of prompting for an app restart. Only the mode-dependent window layer is torn down and rebuilt in the target mode; audio and video playback, casting sessions, the open playlist, current track, seek position, and play/pause state all continue uninterrupted across the switch. The shared 21-band equalizer node is reprogrammed live to the target layout (preserving each layout's own gains), the menu bar and any open sub-windows (EQ, Playlist, Spectrum, Waveform, ProjectM, Library, Audio Analysis) are recreated at their previous positions, and Compact Mode is preserved. Only classic **Large UI** (Double Size) still uses the restart dialog, as it's a size change rather than a mode switch.
 
 - **Classic utility-window titles** — the classic Spectrum Analyzer, Waveform, Library, and ProjectM windows now draw explicit bitmap-font titles into their skinned title bars, matching the Audio Analysis window. ProjectM is labeled **VISUALIZATIONS**.

--- a/Sources/NullPlayer/ModernSkin/ModernSkinRenderer.swift
+++ b/Sources/NullPlayer/ModernSkin/ModernSkinRenderer.swift
@@ -937,7 +937,8 @@ class ModernSkinRenderer {
                              id == "btn_library" ||
                              id == "btn_projectm" ||
                              id == "btn_spectrum" ||
-                             id == "btn_waveform")
+                             id == "btn_waveform" ||
+                             id == "btn_audioanalysis")
         if isBoxedButton {
             let boxColor = isOn ? onColor : offColor
             context.saveGState()

--- a/Sources/NullPlayer/Windows/ModernMainWindow/ModernMainWindowView.swift
+++ b/Sources/NullPlayer/Windows/ModernMainWindow/ModernMainWindowView.swift
@@ -778,11 +778,11 @@ class ModernMainWindowView: NSView {
             ("btn_shuffle", "SH", audioEngine.shuffleEnabled),
             ("btn_repeat", "RP", audioEngine.repeatEnabled),
             ("btn_cast", "CA", CastManager.shared.isCasting),
-            ("btn_sk", "SK", false),
-            ("btn_projectm", "pM", WindowManager.shared.isProjectMVisible),
+            ("btn_projectm", "VZ", WindowManager.shared.isProjectMVisible),
             ("btn_eq", "EQ", WindowManager.shared.isEqualizerVisible),
             ("btn_playlist", "PL", WindowManager.shared.isPlaylistVisible),
             ("btn_spectrum", "SP", WindowManager.shared.isSpectrumVisible),
+            ("btn_audioanalysis", "AA", WindowManager.shared.isAudioAnalysisVisible),
             ("btn_waveform", "WV", WindowManager.shared.isWaveformVisible),
             ("btn_library", "LB", WindowManager.shared.isPlexBrowserVisible),
         ]
@@ -1478,8 +1478,9 @@ class ModernMainWindowView: NSView {
             let rightEdge: CGFloat = 269
             let bw: CGFloat = 16
             let bs = (rightEdge - leftEdge - 10 * bw) / 9
-            let ids = ["btn_shuffle", "btn_repeat", "btn_cast", "btn_sk",
-                       "btn_projectm", "btn_eq", "btn_playlist", "btn_spectrum", "btn_waveform", "btn_library"]
+            let ids = ["btn_shuffle", "btn_repeat", "btn_cast", "btn_projectm",
+                       "btn_eq", "btn_playlist", "btn_spectrum", "btn_audioanalysis",
+                       "btn_waveform", "btn_library"]
             for (i, id) in ids.enumerated() {
                 hitTargets.append((id, NSRect(x: leftEdge + CGFloat(i) * (bw + bs), y: 42, width: bw, height: 14)))
             }
@@ -1722,9 +1723,9 @@ class ModernMainWindowView: NSView {
                 audioEngine.next()
             }
             
-        case "btn_sk":
-            showModernSkinsMenu()
-            
+        case "btn_audioanalysis":
+            WindowManager.shared.toggleAudioAnalysis()
+
         case "btn_shuffle":
             audioEngine.shuffleEnabled.toggle()
             
@@ -1778,13 +1779,6 @@ class ModernMainWindowView: NSView {
         menu.popUp(positioning: nil, at: menuPoint, in: self)
     }
 
-    private func showModernSkinsMenu() {
-        let menu = ContextMenuBuilder.buildModernSkinsMenu()
-        let btnRect = scaledRect(NSRect(x: 163, y: 42, width: 18, height: 14))
-        let menuPoint = NSPoint(x: btnRect.minX, y: btnRect.maxY)
-        menu.popUp(positioning: nil, at: menuPoint, in: self)
-    }
-    
     // MARK: - Keyboard Events
     
     override var acceptsFirstResponder: Bool { true }

--- a/skills/modern-skin-guide/element-reference.md
+++ b/skills/modern-skin-guide/element-reference.md
@@ -86,18 +86,25 @@ If a timer character has no matching sprite, the modern renderer falls back to d
 }
 ```
 
-## Window Toggle Buttons
+## Main Window Toggle Row
 
-These buttons appear between the seek bar and transport row, toggling window visibility.
+These 16×14 buttons appear between the seek bar and transport row. They are
+dynamically spaced from x=93 through x=269 at y=42.
 
-| Element ID | Default Rect | States | Description |
-|-----------|-------------|--------|-------------|
-| `btn_2x` | 140,42,20,14 | off, on, off_pressed, on_pressed | Large UI (1.5x) toggle |
-| `btn_eq` | 152,42,20,14 | off, on, off_pressed, on_pressed | EQ window toggle |
-| `btn_playlist` | 174,42,20,14 | off, on, off_pressed, on_pressed | Playlist window toggle |
-| `btn_library` | 196,42,20,14 | off, on, off_pressed, on_pressed | Library browser toggle |
-| `btn_projectm` | 218,42,22,14 | off, on, off_pressed, on_pressed | ProjectM window toggle |
-| `btn_spectrum` | 242,42,22,14 | off, on, off_pressed, on_pressed | Spectrum window toggle |
+| Order | Element ID | Label | Description |
+|------:|------------|-------|-------------|
+| 1 | `btn_shuffle` | SH | Shuffle toggle |
+| 2 | `btn_repeat` | RP | Repeat toggle |
+| 3 | `btn_cast` | CA | Output devices menu and casting status |
+| 4 | `btn_projectm` | VZ | Visualizer window toggle |
+| 5 | `btn_eq` | EQ | Equalizer window toggle |
+| 6 | `btn_playlist` | PL | Playlist window toggle |
+| 7 | `btn_spectrum` | SP | Spectrum Analyzer window toggle |
+| 8 | `btn_audioanalysis` | AA | Audio Analyzer window toggle |
+| 9 | `btn_waveform` | WV | Waveform window toggle |
+| 10 | `btn_library` | LB | Library Browser window toggle |
+
+All buttons support `off`, `on`, `off_pressed`, and `on_pressed` image states.
 
 **Color:** Use `minicontrol_buttons` in `elements` to control the ON state color for all main window toggle buttons. Falls back to `palette.accent`.
 


### PR DESCRIPTION
## Summary
Repurposes the modern main window's row of toggle buttons:
- Relabel the visualizer button **pM → VZ** (same ProjectM toggle action).
- Replace the **SK** button (modern-skins menu) with an **Audio Analyzer** toggle labeled **AA**, wired to `WindowManager.toggleAudioAnalysis()`, with the same rounded outline box as the other window-toggle buttons.
- New row order: `SH RP CA VZ EQ PL SP AA WV LB`.
- Removed the now-dead `showModernSkinsMenu()` helper (its only caller was the SK button). `ContextMenuBuilder.buildModernSkinsMenu()` is untouched and still used by the menu bar.

Note: removing SK removes the only button entry point to the modern-skins menu; this is intended.

## Changes
- `ModernMainWindowView.swift`: button defs, hit-target ids, click handler, removed dead helper.
- `ModernSkinRenderer.swift`: added `btn_audioanalysis` to the boxed-button set.

## Testing
- `swift build` clean (no errors, no unused-method warnings).
- Manual QA: in modern UI mode, confirm row reads `SH RP CA VZ EQ PL SP AA WV LB`; `VZ` toggles the visualizer; `AA` opens/closes the Audio Analyzer window and shows the outline box + highlight while visible; existing toggles render correctly at default and Double Size.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added audio analysis toggle button to the main window

* **Documentation**
  * Updated the UI element reference guide for main window toggle buttons, including new dynamic button spacing (x=93–269), updated button ordering, and confirmed image state support

<!-- end of auto-generated comment: release notes by coderabbit.ai -->