### PR TITLE
Reimplement Compact Mode with anchored status-item window

### DIFF
--- a/Sources/NullPlayer/App/AppDelegate.swift
+++ b/Sources/NullPlayer/App/AppDelegate.swift
@@ -278,6 +278,7 @@ class AppDelegate: NSObject, NSApplicationDelegate {
     }
 
     private func setupMainMenu() {
+        dynamicMenuBuilders.removeAll(keepingCapacity: true)
         let mainMenu = NSMenu()
         
         // Application menu (NullPlayer menu)

--- a/Sources/NullPlayer/App/AppDelegate.swift
+++ b/Sources/NullPlayer/App/AppDelegate.swift
@@ -65,26 +65,34 @@ class AppDelegate: NSObject, NSApplicationDelegate {
             ModernSkinEngine.shared.loadPreferredSkin()
         }
         
-        // Show the main player window
-        windowManager.showMainWindow()
-        
-        // Bring app to foreground after windows are created
-        NSApp.activate(ignoringOtherApps: true)
-        windowManager.mainWindowController?.window?.makeKeyAndOrderFront(nil)
-        
+        // Restore settings state (skin, volume, EQ, windows). Compact Mode must be
+        // entered only after the asynchronous window restoration has completed, so it
+        // can capture and hide the actual restored window set.
+        let shouldRestoreCompactMode = UserDefaults.standard.bool(forKey: "compactModeEnabled")
+
+        // Create the main window, but only reveal it when we are NOT launching straight into
+        // the menu-bar Compact Mode — otherwise the regular window flashes onscreen before
+        // compact mode hides it (~0.1s later, after async restore completes).
+        windowManager.showMainWindow(reveal: !shouldRestoreCompactMode)
+
+        // Bring app to foreground after windows are created (skip when starting in Compact
+        // Mode, where the app is a menu-bar accessory and the main window stays hidden).
+        if !shouldRestoreCompactMode {
+            NSApp.activate(ignoringOtherApps: true)
+            windowManager.mainWindowController?.window?.makeKeyAndOrderFront(nil)
+        }
+
         // Set up the application menu
         setupMainMenu()
 
         // Start cast discovery from app lifecycle, not from menu construction.
         CastManager.shared.startDiscovery()
-        
-        // Restore settings state (skin, volume, EQ, windows). Compact Mode must be
-        // entered only after the asynchronous window restoration has completed, so it
-        // can capture and hide the actual restored window set.
-        let shouldRestoreCompactMode = UserDefaults.standard.bool(forKey: "compactModeEnabled")
+
         AppStateManager.shared.restoreSettingsState { [weak self] in
             guard shouldRestoreCompactMode else { return }
-            self?.windowManager.enterCompactMode(revealWindow: false)
+            // The main window was created but never revealed, so force its snapshot to
+            // "visible" — exiting Compact Mode must restore it onscreen.
+            self?.windowManager.enterCompactMode(revealWindow: false, treatMainAsVisible: true)
         }
         
         // Mark app as ready for file opens

--- a/Sources/NullPlayer/App/LibraryBrowserWindowProviding.swift
+++ b/Sources/NullPlayer/App/LibraryBrowserWindowProviding.swift
@@ -33,21 +33,4 @@ protocol LibraryBrowserWindowProviding: ModeDependentWindow {
     /// Used by AppStateManager to save/restore the active tab
     var browseModeRawValue: Int { get set }
 
-    // MARK: - Compact Mode
-
-    /// Smallest content width that keeps the window usable when launched in Compact Mode.
-    var minimumCompactContentWidth: CGFloat { get }
-
-    /// Enable/disable Compact Mode: embed a stripped-down player bar across the top of the
-    /// browser window so it can act as the app's sole window in menu-bar (Compact) mode.
-    func setCompactMode(_ enabled: Bool)
-
-    /// Forward the engine's playback time to the embedded compact player bar.
-    func updateCompactBarTime(current: TimeInterval, duration: TimeInterval)
-
-    /// Forward the current track to the embedded compact player bar.
-    func updateCompactBarTrack(_ track: Track?)
-
-    /// Tell the embedded compact player bar that the playback state changed.
-    func updateCompactBarPlaybackState()
 }

--- a/Sources/NullPlayer/App/WindowManager.swift
+++ b/Sources/NullPlayer/App/WindowManager.swift
@@ -220,6 +220,15 @@ class WindowManager {
     /// Library Browser frame before Compact Mode repositioned it under the status item.
     private var savedPlexBrowserFrameForCompactMode: NSRect?
 
+    /// Visible app-owned windows outside WindowManager's controller set. Compact Mode hides
+    /// these temporarily and restores them on exit; orphaned mode-dependent windows are excluded.
+    private var savedAdditionalWindowsForCompactMode: [NSWindow] = []
+
+    /// Marks mode-dependent player windows so stale instances can be distinguished from
+    /// legitimate standalone dialogs when sweeping NSApp.windows.
+    private static let modeDependentWindowIdentifier =
+        NSUserInterfaceItemIdentifier("nullPlayer.modeDependentWindow")
+
     /// Ensure modern main window keeps full-height geometry in HT mode at startup/restore.
     /// Keeps the top edge fixed so legacy compact HT frames are expanded.
     @discardableResult
@@ -563,6 +572,7 @@ class WindowManager {
                 mainWindowController = MainWindowController()
             }
         }
+        markModeDependentWindow(mainWindowController?.window)
         // Enforce HT compact height on both first show and subsequent re-shows.
         if isRunningModernUI {
             normalizeModernMainWindowForHTIfNeeded()
@@ -588,6 +598,7 @@ class WindowManager {
                 playlistWindowController = PlaylistWindowController()
             }
         }
+        markModeDependentWindow(playlistWindowController?.window)
         
         // Position BEFORE showing (unless restoring from saved state)
         if let playlistWindow = playlistWindowController?.window {
@@ -645,6 +656,7 @@ class WindowManager {
                 equalizerWindowController = EQWindowController()
             }
         }
+        markModeDependentWindow(equalizerWindowController?.window)
         
         // Position BEFORE showing (unless restoring from saved state)
         if let eqWindow = equalizerWindowController?.window {
@@ -827,6 +839,7 @@ class WindowManager {
                 plexBrowserWindowController = PlexBrowserWindowController()
             }
         }
+        markModeDependentWindow(plexBrowserWindowController?.window)
         plexBrowserWindowController?.showWindow(nil)
         applyAlwaysOnTopToWindow(plexBrowserWindowController?.window)
         // Position window to match the vertical stack
@@ -1020,6 +1033,7 @@ class WindowManager {
     }
 
     private func saveWindowVisibilityForCompactMode() {
+        savedAdditionalWindowsForCompactMode.removeAll()
         savedPlexBrowserFrameForCompactMode = plexBrowserWindowController?.window?.frame
         savedWindowVisibility = [
             "main": mainWindowController?.window?.isVisible ?? false,
@@ -1060,16 +1074,23 @@ class WindowManager {
         for window in NSApp.windows where window.isVisible {
             if window === compactWindow { continue }
             if isSystemOrTransientWindow(window) { continue }
-            NSLog("WindowManager: compact mode hiding orphaned window class=%@",
+            let isOrphanedPlayerWindow =
+                window.identifier == Self.modeDependentWindowIdentifier
+            if !isOrphanedPlayerWindow {
+                savedAdditionalWindowsForCompactMode.append(window)
+            }
+            NSLog("WindowManager: compact mode hiding %@ window class=%@",
+                  isOrphanedPlayerWindow ? "orphaned" : "additional",
                   NSStringFromClass(type(of: window)))
             window.orderOut(nil)
         }
     }
 
     /// Windows the compact-mode sweep must never touch: the status-bar item window,
-    /// popovers/tooltips, floating palettes (NSPanel), and attached modal sheets.
+    /// system popovers/tooltips/palettes, and attached modal sheets. App-owned NSPanel
+    /// instances (such as About) are not exempt.
     private func isSystemOrTransientWindow(_ window: NSWindow) -> Bool {
-        if window is NSPanel { return true }            // color/font panels, popovers, tooltips
+        if window is NSColorPanel || window is NSFontPanel { return true }
         if window.sheetParent != nil { return true }    // attached modal sheet
         let className = NSStringFromClass(type(of: window))
         let systemClasses = ["NSStatusBarWindow", "_NSPopoverWindow",
@@ -1119,8 +1140,16 @@ class WindowManager {
         if savedWindowVisibility["plexBrowserShade"] == true {
             plexBrowserWindowController?.setShadeMode(true)
         }
+        for window in savedAdditionalWindowsForCompactMode {
+            window.orderFront(nil)
+        }
+        savedAdditionalWindowsForCompactMode.removeAll()
         savedPlexBrowserFrameForCompactMode = nil
         savedWindowVisibility.removeAll()
+    }
+
+    private func markModeDependentWindow(_ window: NSWindow?) {
+        window?.identifier = Self.modeDependentWindowIdentifier
     }
 
     /// While Compact Mode is active, state persistence must record the windows that were
@@ -1881,6 +1910,7 @@ class WindowManager {
                 projectMWindowController = ProjectMWindowController()
             }
         }
+        markModeDependentWindow(projectMWindowController?.window)
         projectMWindowController?.showWindow(nil)
         applyAlwaysOnTopToWindow(projectMWindowController?.window)
         // Position window to match the vertical stack
@@ -1968,6 +1998,7 @@ class WindowManager {
                 spectrumWindowController = SpectrumWindowController()
             }
         }
+        markModeDependentWindow(spectrumWindowController?.window)
         
         // Position BEFORE showing (unless restoring from saved state)
         if let window = spectrumWindowController?.window {
@@ -2035,6 +2066,7 @@ class WindowManager {
                 audioAnalysisWindowController = AudioAnalysisWindowController()
             }
         }
+        markModeDependentWindow(audioAnalysisWindowController?.window)
 
         if let window = audioAnalysisWindowController?.window {
             applyCenterStackSizingConstraints(window, kind: .audioAnalysis)
@@ -2097,6 +2129,7 @@ class WindowManager {
                 waveformWindowController = WaveformWindowController()
             }
         }
+        markModeDependentWindow(waveformWindowController?.window)
 
         if let window = waveformWindowController?.window {
             let classicController = waveformWindowController as? WaveformWindowController
@@ -4315,8 +4348,7 @@ class WindowManager {
 
         for window in NSApp.windows where window.isVisible {
             guard !trackedWindows.contains(ObjectIdentifier(window)) else { continue }
-            guard window !== plexBrowserWindowController?.window else { continue }
-            guard !isSystemOrTransientWindow(window) else { continue }
+            guard window.identifier == Self.modeDependentWindowIdentifier else { continue }
             NSLog("WindowManager: DEBUG orphan survived rebuild class=%@",
                   NSStringFromClass(type(of: window)))
         }

--- a/Sources/NullPlayer/App/WindowManager.swift
+++ b/Sources/NullPlayer/App/WindowManager.swift
@@ -585,7 +585,10 @@ class WindowManager {
     
     // MARK: - Window Management
     
-    func showMainWindow() {
+    /// - Parameter reveal: When `false`, the controller (and its window) are created and
+    ///   configured but the window is never ordered onscreen. Used at launch when starting
+    ///   straight into Compact Mode, so the regular window doesn't flash before it is hidden.
+    func showMainWindow(reveal: Bool = true) {
         let isNew = mainWindowController == nil
         if isNew {
             if isModernUIEnabled {
@@ -600,7 +603,9 @@ class WindowManager {
         if isRunningModernUI {
             normalizeModernMainWindowForHTIfNeeded()
         }
-        mainWindowController?.showWindow(nil)
+        if reveal {
+            mainWindowController?.showWindow(nil)
+        }
         applyAlwaysOnTopToWindow(mainWindowController?.window)
     }
     
@@ -970,13 +975,21 @@ class WindowManager {
     ///   shown and positioned under the status item. When `false` (restore on launch) the window
     ///   is left hidden behind the status item so the *first* click reveals it — otherwise the
     ///   status item starts in a "visible" state and the first click would just hide it.
-    func enterCompactMode(revealWindow: Bool = true) {
+    /// - Parameter treatMainAsVisible: When `true` (launch-into-compact path), the captured
+    ///   snapshot records the main window as visible even though it was never revealed, so
+    ///   exiting Compact Mode later restores it onscreen. The main window is always part of the
+    ///   regular layout, so this matches the live-toggle behavior. Defaults to `false` so the
+    ///   live menu toggle keeps recording the main window's actual visibility.
+    func enterCompactMode(revealWindow: Bool = true, treatMainAsVisible: Bool = false) {
         guard compactModeState == .regular else { return }
         compactModeState = .entering
         compactModeEnabled = true
         UserDefaults.standard.set(true, forKey: "compactModeEnabled")
 
         regularWindowSnapshot = captureRegularWindowSnapshot()
+        if treatMainAsVisible {
+            regularWindowSnapshot?.main?.wasVisible = true
+        }
         detachManagedChildWindowsForCompactMode()
         orderOutRegularWindows()
 

--- a/Sources/NullPlayer/App/WindowManager.swift
+++ b/Sources/NullPlayer/App/WindowManager.swift
@@ -1050,6 +1050,31 @@ class WindowManager {
                        debugWindowController?.window].compactMap({ $0 }) {
             window.orderOut(nil)
         }
+
+        // Phase 2: defensive sweep for orphaned windows from prior UI mode toggles
+        orderOutOrphanedAppWindows()
+    }
+
+    private func orderOutOrphanedAppWindows() {
+        let compactWindow = plexBrowserWindowController?.window
+        for window in NSApp.windows where window.isVisible {
+            if window === compactWindow { continue }
+            if isSystemOrTransientWindow(window) { continue }
+            NSLog("WindowManager: compact mode hiding orphaned window class=%@",
+                  NSStringFromClass(type(of: window)))
+            window.orderOut(nil)
+        }
+    }
+
+    /// Windows the compact-mode sweep must never touch: the status-bar item window,
+    /// popovers/tooltips, floating palettes (NSPanel), and attached modal sheets.
+    private func isSystemOrTransientWindow(_ window: NSWindow) -> Bool {
+        if window is NSPanel { return true }            // color/font panels, popovers, tooltips
+        if window.sheetParent != nil { return true }    // attached modal sheet
+        let className = NSStringFromClass(type(of: window))
+        let systemClasses = ["NSStatusBarWindow", "_NSPopoverWindow",
+                             "NSToolTipPanel", "NSCarbonMenuWindow", "NSMenuWindowManagerWindow"]
+        return systemClasses.contains(className)
     }
 
     private func restoreWindowVisibilityAfterCompactMode() {
@@ -4271,6 +4296,31 @@ class WindowManager {
         mainWindowController?.window?.makeKeyAndOrderFront(nil)
         postWindowLayoutDidChange()
         updateDockedChildWindows()
+
+        #if DEBUG
+        // Log any visible orphaned windows that survived the rebuild
+        var trackedWindows = Set<ObjectIdentifier>()
+        for window in [mainWindowController?.window,
+                       playlistWindowController?.window,
+                       equalizerWindowController?.window,
+                       plexBrowserWindowController?.window,
+                       projectMWindowController?.window,
+                       spectrumWindowController?.window,
+                       audioAnalysisWindowController?.window,
+                       waveformWindowController?.window,
+                       videoPlayerWindowController?.window,
+                       debugWindowController?.window].compactMap({ $0 }) {
+            trackedWindows.insert(ObjectIdentifier(window))
+        }
+
+        for window in NSApp.windows where window.isVisible {
+            guard !trackedWindows.contains(ObjectIdentifier(window)) else { continue }
+            guard window !== plexBrowserWindowController?.window else { continue }
+            guard !isSystemOrTransientWindow(window) else { continue }
+            NSLog("WindowManager: DEBUG orphan survived rebuild class=%@",
+                  NSStringFromClass(type(of: window)))
+        }
+        #endif
     }
 
     /// Re-seed freshly created windows with the current audio/video presentation state.

--- a/Sources/NullPlayer/App/WindowManager.swift
+++ b/Sources/NullPlayer/App/WindowManager.swift
@@ -972,9 +972,12 @@ class WindowManager {
         createCompactStatusItem()
 
         if revealWindow {
-            plexBrowserWindowController?.window?.makeKeyAndOrderFront(nil)
-            positionCompactWindowUnderStatusItem()
-            NSApp.activate(ignoringOtherApps: true)
+            // Changing activation policy is asynchronous. Present on the next main-loop turn
+            // so AppKit cannot order the modern borderless window back out as the transition
+            // completes.
+            DispatchQueue.main.async { [weak self] in
+                self?.showCompactWindow()
+            }
         } else {
             // showPlexBrowser() ordered the window front; tuck it away until the first click.
             plexBrowserWindowController?.window?.orderOut(nil)
@@ -1030,6 +1033,7 @@ class WindowManager {
         UserDefaults.standard.set(false, forKey: "compactModeEnabled")
 
         plexBrowserWindowController?.setCompactMode(false)
+        applyAlwaysOnTopToWindow(plexBrowserWindowController?.window)
 
         // Restore the Dock icon and remove the status-bar item.
         NSApp.setActivationPolicy(.regular)
@@ -1269,10 +1273,16 @@ class WindowManager {
         if window.isVisible {
             window.orderOut(nil)
         } else {
-            window.makeKeyAndOrderFront(nil)
-            positionCompactWindowUnderStatusItem()
-            NSApp.activate(ignoringOtherApps: true)
+            showCompactWindow()
         }
+    }
+
+    private func showCompactWindow() {
+        guard compactModeEnabled, let window = plexBrowserWindowController?.window else { return }
+        window.level = .statusBar
+        positionCompactWindowUnderStatusItem()
+        window.makeKeyAndOrderFront(nil)
+        NSApp.activate(ignoringOtherApps: true)
     }
 
     @objc private func exitCompactModeMenuAction() {

--- a/Sources/NullPlayer/App/WindowManager.swift
+++ b/Sources/NullPlayer/App/WindowManager.swift
@@ -214,6 +214,10 @@ class WindowManager {
     /// Status-bar item shown while Compact Mode is active.
     private var compactStatusItem: NSStatusItem?
 
+    /// The first reveal after entering Compact Mode opens at the minimum usable dimensions.
+    /// Subsequent status-item hide/show cycles preserve any user resize.
+    private var compactWindowNeedsInitialSizing = false
+
     /// Window visibility captured when entering Compact Mode, restored on exit.
     private var savedWindowVisibility: [String: Bool] = [:]
 
@@ -946,6 +950,7 @@ class WindowManager {
         guard !compactModeEnabled else { return }
         compactModeEnabled = true
         UserDefaults.standard.set(true, forKey: "compactModeEnabled")
+        compactWindowNeedsInitialSizing = true
 
         // Remember which windows are visible so we can restore them on exit.
         saveWindowVisibilityForCompactMode()
@@ -999,12 +1004,19 @@ class WindowManager {
 
             // Available vertical space below the status item (top stays anchored to the item).
             let available = topY - visible.minY - 8
-            // Ensure a usable width and a tall, dropdown-style height. Don't shrink a window the
-            // user has already grown; only grow a too-small one. Always clamp to fit the screen.
-            // Floor at the width needed to keep all tab labels inside their outlines.
             let tabFloor = plexBrowserWindowController?.minimumCompactContentWidth ?? (360 * m)
-            frame.size.width = max(frame.width, max(360 * m, tabFloor))
-            frame.size.height = max(frame.height, min(available, 620 * m))
+            let minimumWidth = max(window.minSize.width, max(360 * m, tabFloor))
+            let minimumHeight = window.minSize.height
+
+            if compactWindowNeedsInitialSizing {
+                // Enter Compact Mode at the smallest usable frame. Do this only on the first
+                // reveal so resizing is preserved when the status item hides and shows it.
+                frame.size.width = min(minimumWidth, visible.width - 16)
+                frame.size.height = min(minimumHeight, available)
+                compactWindowNeedsInitialSizing = false
+            } else {
+                frame.size.width = max(frame.width, minimumWidth)
+            }
             frame.size.height = min(frame.height, available)
             originX = min(max(originX, visible.minX + 8), visible.maxX - frame.width - 8)
         }

--- a/Sources/NullPlayer/App/WindowManager.swift
+++ b/Sources/NullPlayer/App/WindowManager.swift
@@ -80,6 +80,34 @@ enum DragMode {
     case group     // holdThreshold elapsed before drag — connected windows move together
 }
 
+private enum CompactModeState {
+    case regular
+    case entering
+    case compactHidden
+    case compactVisible
+    case exiting
+}
+
+private struct WindowSnapshot {
+    var wasVisible: Bool
+    var frame: NSRect
+    var wasShadeMode: Bool
+}
+
+private struct CompactWindowSnapshot {
+    var main: WindowSnapshot?
+    var equalizer: WindowSnapshot?
+    var playlist: WindowSnapshot?
+    var spectrum: WindowSnapshot?
+    var audioAnalysis: WindowSnapshot?
+    var waveform: WindowSnapshot?
+    var projectM: WindowSnapshot?
+    var library: WindowSnapshot?
+    var video: WindowSnapshot?
+    var debug: WindowSnapshot?
+    var additionalWindows: [NSWindow] = []
+}
+
 /// Joined edge intervals for seamless modern window border suppression.
 /// Top/bottom ranges are in local X coordinates; left/right ranges are in local Y coordinates.
 struct EdgeOcclusionSegments: Equatable {
@@ -205,28 +233,19 @@ class WindowManager {
         set { UserDefaults.standard.set(newValue, forKey: "hideTitleBars") }
     }
 
-    /// Whether Compact Mode (menu-bar app: one window = library browser + embedded player) is
-    /// currently active. Works in both classic and modern UI; toggled live at runtime. The
-    /// persisted preference key `compactModeEnabled` mirrors this so the mode can be restored
-    /// on the next launch.
+    /// Whether Compact Mode (menu-bar mini-player) is currently active. Works in both
+    /// classic and modern UI; toggled live at runtime. The persisted preference key
+    /// `compactModeEnabled` mirrors this so the mode can be restored on the next launch.
     private(set) var compactModeEnabled = false
+
+    private var compactModeState: CompactModeState = .regular
+
+    private var regularWindowSnapshot: CompactWindowSnapshot?
 
     /// Status-bar item shown while Compact Mode is active.
     private var compactStatusItem: NSStatusItem?
 
-    /// The first reveal after entering Compact Mode opens at the minimum usable dimensions.
-    /// Subsequent status-item hide/show cycles preserve any user resize.
-    private var compactWindowNeedsInitialSizing = false
-
-    /// Window visibility captured when entering Compact Mode, restored on exit.
-    private var savedWindowVisibility: [String: Bool] = [:]
-
-    /// Library Browser frame before Compact Mode repositioned it under the status item.
-    private var savedPlexBrowserFrameForCompactMode: NSRect?
-
-    /// Visible app-owned windows outside WindowManager's controller set. Compact Mode hides
-    /// these temporarily and restores them on exit; orphaned mode-dependent windows are excluded.
-    private var savedAdditionalWindowsForCompactMode: [NSWindow] = []
+    private var compactWindowController: CompactModeWindowController?
 
     /// Marks mode-dependent player windows so stale instances can be distinguished from
     /// legitimate standalone dialogs when sweeping NSApp.windows.
@@ -837,11 +856,7 @@ class WindowManager {
     func showPlexBrowser(at restoredFrame: NSRect? = nil) {
         let isNewWindow = plexBrowserWindowController == nil
         if isNewWindow {
-            if isModernUIEnabled {
-                plexBrowserWindowController = ModernLibraryBrowserWindowController()
-            } else {
-                plexBrowserWindowController = PlexBrowserWindowController()
-            }
+            createPlexBrowserWindowController()
         }
         markModeDependentWindow(plexBrowserWindowController?.window)
         plexBrowserWindowController?.showWindow(nil)
@@ -890,7 +905,16 @@ class WindowManager {
         }
         postLayoutChangeNotification()
     }
-    
+
+    private func createPlexBrowserWindowController() {
+        if isModernUIEnabled {
+            plexBrowserWindowController = ModernLibraryBrowserWindowController()
+        } else {
+            plexBrowserWindowController = PlexBrowserWindowController()
+        }
+        markModeDependentWindow(plexBrowserWindowController?.window)
+    }
+
     var isPlexBrowserVisible: Bool {
         plexBrowserWindowController?.window?.isVisible == true
     }
@@ -947,128 +971,90 @@ class WindowManager {
     ///   is left hidden behind the status item so the *first* click reveals it — otherwise the
     ///   status item starts in a "visible" state and the first click would just hide it.
     func enterCompactMode(revealWindow: Bool = true) {
-        guard !compactModeEnabled else { return }
+        guard compactModeState == .regular else { return }
+        compactModeState = .entering
         compactModeEnabled = true
         UserDefaults.standard.set(true, forKey: "compactModeEnabled")
-        compactWindowNeedsInitialSizing = true
 
-        // Remember which windows are visible so we can restore them on exit.
-        saveWindowVisibilityForCompactMode()
-        // Hide everything except the library browser, which becomes the sole window.
-        hideAllWindowsForCompactMode()
+        regularWindowSnapshot = captureRegularWindowSnapshot()
+        detachManagedChildWindowsForCompactMode()
+        orderOutRegularWindows()
 
-        // Ensure the library browser exists and shows the embedded player bar.
-        showPlexBrowser()
-        if savedWindowVisibility["plexBrowserShade"] == true {
-            // Capture the normal frame restored by leaving shade mode. Restoring this before
-            // re-entering shade mode on exit preserves both the shade frame and its normal frame.
-            plexBrowserWindowController?.setShadeMode(false)
-            savedPlexBrowserFrameForCompactMode = plexBrowserWindowController?.window?.frame
-        }
-        plexBrowserWindowController?.setCompactMode(true)
-
-        // Menu-bar app behaviour: hide the Dock icon, add a status-bar item.
         NSApp.setActivationPolicy(.accessory)
         createCompactStatusItem()
+        createCompactWindowControllerIfNeeded()
 
-        if revealWindow {
-            // Changing activation policy is asynchronous. Present on the next main-loop turn
-            // so AppKit cannot order the modern borderless window back out as the transition
-            // completes.
-            DispatchQueue.main.async { [weak self] in
-                self?.showCompactWindow()
+        DispatchQueue.main.async { [weak self] in
+            guard let self, self.compactModeState == .entering else { return }
+            if revealWindow {
+                // showCompactWindow() self-defers its reveal until the status-item anchor is
+                // ready, so a single call is enough — no second show needed.
+                self.showCompactWindow()
+                self.compactModeState = .compactVisible
+            } else {
+                self.hideCompactWindow()
+                self.compactModeState = .compactHidden
             }
-        } else {
-            // showPlexBrowser() ordered the window front; tuck it away until the first click.
-            plexBrowserWindowController?.window?.orderOut(nil)
         }
         postLayoutChangeNotification()
-    }
-
-    /// Anchor the compact window so its top edge hangs just below the status-bar item,
-    /// horizontally centred under the item (clamped to the screen) — like a menu-bar dropdown.
-    private func positionCompactWindowUnderStatusItem() {
-        guard let window = plexBrowserWindowController?.window,
-              let button = compactStatusItem?.button,
-              let buttonWindow = button.window else { return }
-
-        let buttonRectInWindow = button.convert(button.bounds, to: nil)
-        let buttonScreenRect = buttonWindow.convertToScreen(buttonRectInWindow)
-        let gap: CGFloat = 4
-
-        var frame = window.frame
-        var originX = buttonScreenRect.midX - frame.width / 2
-        let topY = buttonScreenRect.minY - gap
-
-        let screen = buttonWindow.screen ?? NSScreen.screens.first { $0.frame.contains(buttonScreenRect.origin) } ?? NSScreen.main
-        if let visible = screen?.visibleFrame {
-            let m = isRunningModernUI ? ModernSkinElements.sizeMultiplier : 1.0
-            originX = min(max(originX, visible.minX + 8), visible.maxX - frame.width - 8)
-
-            // Available vertical space below the status item (top stays anchored to the item).
-            let available = topY - visible.minY - 8
-            let tabFloor = plexBrowserWindowController?.minimumCompactContentWidth ?? (360 * m)
-            let minimumWidth = max(window.minSize.width, max(360 * m, tabFloor))
-            let minimumHeight = window.minSize.height
-
-            if compactWindowNeedsInitialSizing {
-                // Enter Compact Mode at the smallest usable frame. Do this only on the first
-                // reveal so resizing is preserved when the status item hides and shows it.
-                frame.size.width = min(minimumWidth, visible.width - 16)
-                frame.size.height = min(minimumHeight, available)
-                compactWindowNeedsInitialSizing = false
-            } else {
-                frame.size.width = max(frame.width, minimumWidth)
-            }
-            frame.size.height = min(frame.height, available)
-            originX = min(max(originX, visible.minX + 8), visible.maxX - frame.width - 8)
-        }
-        frame.origin = NSPoint(x: originX, y: topY - frame.height)
-        window.setFrame(frame, display: true)
     }
 
     func exitCompactMode() {
-        guard compactModeEnabled else { return }
+        guard compactModeState == .compactVisible ||
+              compactModeState == .compactHidden ||
+              compactModeState == .entering else { return }
+        compactModeState = .exiting
         compactModeEnabled = false
         UserDefaults.standard.set(false, forKey: "compactModeEnabled")
 
-        plexBrowserWindowController?.setCompactMode(false)
-        applyAlwaysOnTopToWindow(plexBrowserWindowController?.window)
-
-        // Restore the Dock icon and remove the status-bar item.
-        NSApp.setActivationPolicy(.regular)
-        restoreDockIconImage()
+        hideCompactWindow()
+        compactWindowController = nil
         removeCompactStatusItem()
 
-        // Switching `.accessory` → `.regular` makes macOS drop the main menu bar, so rebuild it.
-        (NSApp.delegate as? AppDelegate)?.rebuildMainMenu()
+        NSApp.setActivationPolicy(.regular)
+        restoreDockIconImage()
 
-        restoreWindowVisibilityAfterCompactMode()
-        NSApp.activate(ignoringOtherApps: true)
-        postLayoutChangeNotification()
+        DispatchQueue.main.async { [weak self] in
+            guard let self else { return }
+            (NSApp.delegate as? AppDelegate)?.rebuildMainMenu()
+            self.restoreRegularWindowSnapshot()
+            self.updateDockedChildWindows()
+            NSApp.activate(ignoringOtherApps: true)
+            self.compactModeState = .regular
+            self.postLayoutChangeNotification()
+        }
     }
 
-    private func saveWindowVisibilityForCompactMode() {
-        savedAdditionalWindowsForCompactMode.removeAll()
-        savedPlexBrowserFrameForCompactMode = plexBrowserWindowController?.window?.frame
-        savedWindowVisibility = [
-            "main": mainWindowController?.window?.isVisible ?? false,
-            "equalizer": equalizerWindowController?.window?.isVisible ?? false,
-            "playlist": playlistWindowController?.window?.isVisible ?? false,
-            "spectrum": spectrumWindowController?.window?.isVisible ?? false,
-            "audioAnalysis": audioAnalysisWindowController?.window?.isVisible ?? false,
-            "waveform": waveformWindowController?.window?.isVisible ?? false,
-            "projectM": projectMWindowController?.window?.isVisible ?? false,
-            "video": videoPlayerWindowController?.window?.isVisible ?? false,
-            "debug": debugWindowController?.window?.isVisible ?? false,
-            "plexBrowserShade": plexBrowserWindowController?.isShadeMode ?? false,
-            // The library browser becomes the sole compact window, so remember whether it
-            // was open beforehand — otherwise it lingers on screen after exiting Compact Mode.
-            "plexBrowser": plexBrowserWindowController?.window?.isVisible ?? false
-        ]
+    private func captureRegularWindowSnapshot() -> CompactWindowSnapshot {
+        func snap(_ controller: ModeDependentWindow?) -> WindowSnapshot? {
+            guard let window = controller?.window else { return nil }
+            return WindowSnapshot(
+                wasVisible: window.isVisible,
+                frame: window.frame,
+                wasShadeMode: controller?.isShadeMode ?? false
+            )
+        }
+
+        func snapWindow(_ window: NSWindow?) -> WindowSnapshot? {
+            guard let window else { return nil }
+            return WindowSnapshot(wasVisible: window.isVisible, frame: window.frame, wasShadeMode: false)
+        }
+
+        return CompactWindowSnapshot(
+            main: snap(mainWindowController),
+            equalizer: snap(equalizerWindowController),
+            playlist: snap(playlistWindowController),
+            spectrum: snap(spectrumWindowController),
+            audioAnalysis: snap(audioAnalysisWindowController),
+            waveform: snap(waveformWindowController),
+            projectM: snap(projectMWindowController),
+            library: snap(plexBrowserWindowController),
+            video: snapWindow(videoPlayerWindowController?.window),
+            debug: snapWindow(debugWindowController?.window)
+        )
     }
 
-    private func hideAllWindowsForCompactMode() {
+    private func orderOutRegularWindows() {
         for window in [mainWindowController?.window,
                        equalizerWindowController?.window,
                        playlistWindowController?.window,
@@ -1076,24 +1062,44 @@ class WindowManager {
                        audioAnalysisWindowController?.window,
                        waveformWindowController?.window,
                        projectMWindowController?.window,
+                       plexBrowserWindowController?.window,
                        videoPlayerWindowController?.window,
                        debugWindowController?.window].compactMap({ $0 }) {
             window.orderOut(nil)
         }
 
-        // Phase 2: defensive sweep for orphaned windows from prior UI mode toggles
         orderOutOrphanedAppWindows()
     }
 
+    /// Break persistent AppKit parent/child relationships before hiding the normal window set.
+    /// Docking is recomputed on Compact Mode exit after all prior windows are visible again.
+    private func detachManagedChildWindowsForCompactMode() {
+        guard let mainWindow = mainWindowController?.window else { return }
+        let managedWindows = [
+            equalizerWindowController?.window,
+            playlistWindowController?.window,
+            spectrumWindowController?.window,
+            audioAnalysisWindowController?.window,
+            waveformWindowController?.window,
+            projectMWindowController?.window,
+            plexBrowserWindowController?.window
+        ].compactMap { $0 }
+
+        for child in mainWindow.childWindows ?? []
+        where managedWindows.contains(where: { $0 === child }) {
+            mainWindow.removeChildWindow(child)
+        }
+    }
+
     private func orderOutOrphanedAppWindows() {
-        let compactWindow = plexBrowserWindowController?.window
+        let compactWindow = compactWindowController?.window
         for window in NSApp.windows where window.isVisible {
             if window === compactWindow { continue }
             if isSystemOrTransientWindow(window) { continue }
             let isOrphanedPlayerWindow =
                 window.identifier == Self.modeDependentWindowIdentifier
             if !isOrphanedPlayerWindow {
-                savedAdditionalWindowsForCompactMode.append(window)
+                regularWindowSnapshot?.additionalWindows.append(window)
             }
             NSLog("WindowManager: compact mode hiding %@ window class=%@",
                   isOrphanedPlayerWindow ? "orphaned" : "additional",
@@ -1114,54 +1120,47 @@ class WindowManager {
         return systemClasses.contains(className)
     }
 
-    private func restoreWindowVisibilityAfterCompactMode() {
-        if let frame = savedPlexBrowserFrameForCompactMode {
-            plexBrowserWindowController?.window?.setFrame(frame, display: true)
+    private func restoreRegularWindowSnapshot() {
+        guard let snapshot = regularWindowSnapshot else { return }
+
+        func restore(_ snapshot: WindowSnapshot?, controller: ModeDependentWindow?) {
+            guard let snapshot, let window = controller?.window else { return }
+            if snapshot.frame != .zero {
+                window.setFrame(snapshot.frame, display: true)
+            }
+            if controller?.isShadeMode != snapshot.wasShadeMode {
+                controller?.setShadeMode(snapshot.wasShadeMode)
+            }
+            if snapshot.wasVisible {
+                window.orderFront(nil)
+            } else {
+                window.orderOut(nil)
+            }
         }
 
-        // The library browser hosted the compact UI. Restore its prior visibility even if
-        // the user hid the compact window before choosing Exit Compact Mode.
-        if savedWindowVisibility["plexBrowser"] == true {
-            plexBrowserWindowController?.window?.makeKeyAndOrderFront(nil)
-        } else {
-            plexBrowserWindowController?.window?.orderOut(nil)
+        func restoreWindow(_ snapshot: WindowSnapshot?, window: NSWindow?) {
+            guard let snapshot, let window else { return }
+            if snapshot.frame != .zero {
+                window.setFrame(snapshot.frame, display: true)
+            }
+            snapshot.wasVisible ? window.orderFront(nil) : window.orderOut(nil)
         }
-        if savedWindowVisibility["main"] == true {
-            mainWindowController?.window?.orderFront(nil)
-        }
-        if savedWindowVisibility["equalizer"] == true {
-            equalizerWindowController?.window?.orderFront(nil)
-        }
-        if savedWindowVisibility["playlist"] == true {
-            playlistWindowController?.window?.orderFront(nil)
-        }
-        if savedWindowVisibility["spectrum"] == true {
-            spectrumWindowController?.window?.orderFront(nil)
-        }
-        if savedWindowVisibility["audioAnalysis"] == true {
-            audioAnalysisWindowController?.window?.orderFront(nil)
-        }
-        if savedWindowVisibility["waveform"] == true {
-            waveformWindowController?.window?.orderFront(nil)
-        }
-        if savedWindowVisibility["projectM"] == true {
-            projectMWindowController?.window?.orderFront(nil)
-        }
-        if savedWindowVisibility["video"] == true {
-            videoPlayerWindowController?.window?.orderFront(nil)
-        }
-        if savedWindowVisibility["debug"] == true {
-            debugWindowController?.window?.orderFront(nil)
-        }
-        if savedWindowVisibility["plexBrowserShade"] == true {
-            plexBrowserWindowController?.setShadeMode(true)
-        }
-        for window in savedAdditionalWindowsForCompactMode {
+
+        restore(snapshot.main, controller: mainWindowController)
+        restore(snapshot.equalizer, controller: equalizerWindowController)
+        restore(snapshot.playlist, controller: playlistWindowController)
+        restore(snapshot.spectrum, controller: spectrumWindowController)
+        restore(snapshot.audioAnalysis, controller: audioAnalysisWindowController)
+        restore(snapshot.waveform, controller: waveformWindowController)
+        restore(snapshot.projectM, controller: projectMWindowController)
+        restore(snapshot.library, controller: plexBrowserWindowController)
+        restoreWindow(snapshot.video, window: videoPlayerWindowController?.window)
+        restoreWindow(snapshot.debug, window: debugWindowController?.window)
+
+        for window in snapshot.additionalWindows {
             window.orderFront(nil)
         }
-        savedAdditionalWindowsForCompactMode.removeAll()
-        savedPlexBrowserFrameForCompactMode = nil
-        savedWindowVisibility.removeAll()
+        regularWindowSnapshot = nil
     }
 
     private func markModeDependentWindow(_ window: NSWindow?) {
@@ -1171,8 +1170,20 @@ class WindowManager {
     /// While Compact Mode is active, state persistence must record the windows that were
     /// visible before entry rather than the intentionally hidden compact-mode window set.
     func visibilityForStateSaving(_ key: String, current: Bool) -> Bool {
-        guard compactModeEnabled else { return current }
-        return savedWindowVisibility[key] ?? current
+        guard compactModeState != .regular, let snapshot = regularWindowSnapshot else { return current }
+        switch key {
+        case "main": return snapshot.main?.wasVisible ?? current
+        case "equalizer": return snapshot.equalizer?.wasVisible ?? current
+        case "playlist": return snapshot.playlist?.wasVisible ?? current
+        case "spectrum": return snapshot.spectrum?.wasVisible ?? current
+        case "audioAnalysis": return snapshot.audioAnalysis?.wasVisible ?? current
+        case "waveform": return snapshot.waveform?.wasVisible ?? current
+        case "projectM": return snapshot.projectM?.wasVisible ?? current
+        case "plexBrowser": return snapshot.library?.wasVisible ?? current
+        case "video": return snapshot.video?.wasVisible ?? current
+        case "debug": return snapshot.debug?.wasVisible ?? current
+        default: return current
+        }
     }
 
     /// Switching activation policy `.accessory` → `.regular` makes macOS forget the bundle's
@@ -1254,7 +1265,8 @@ class WindowManager {
     private func presentCompactStatusMenu() {
         guard let item = compactStatusItem else { return }
         let menu = NSMenu()
-        let toggle = NSMenuItem(title: "Show/Hide Window", action: #selector(toggleCompactWindowVisibility), keyEquivalent: "")
+        let title = compactModeState == .compactVisible ? "Hide Compact Window" : "Show Compact Window"
+        let toggle = NSMenuItem(title: title, action: #selector(toggleCompactWindowVisibility), keyEquivalent: "")
         toggle.target = self
         menu.addItem(toggle)
         menu.addItem(.separator())
@@ -1269,20 +1281,38 @@ class WindowManager {
     }
 
     @objc private func toggleCompactWindowVisibility() {
-        guard let window = plexBrowserWindowController?.window else { return }
-        if window.isVisible {
-            window.orderOut(nil)
-        } else {
+        switch compactModeState {
+        case .compactVisible:
+            hideCompactWindow()
+            compactModeState = .compactHidden
+        case .compactHidden:
             showCompactWindow()
+            compactModeState = .compactVisible
+        default:
+            break
         }
     }
 
+    private func createCompactWindowControllerIfNeeded() {
+        if compactWindowController == nil {
+            compactWindowController = CompactModeWindowController(modernUI: isRunningModernUI)
+        }
+        compactWindowController?.seedFromAudioEngine()
+    }
+
+    private func hideCompactWindow() {
+        compactWindowController?.hide()
+    }
+
     private func showCompactWindow() {
-        guard compactModeEnabled, let window = plexBrowserWindowController?.window else { return }
-        window.level = .statusBar
-        positionCompactWindowUnderStatusItem()
-        window.makeKeyAndOrderFront(nil)
-        NSApp.activate(ignoringOtherApps: true)
+        guard compactModeEnabled else { return }
+        createCompactWindowControllerIfNeeded()
+        compactWindowController?.show(anchoredTo: compactStatusItem?.button)
+    }
+
+    func compactSurfaceDidHide() {
+        guard compactModeState == .compactVisible || compactModeState == .entering else { return }
+        compactModeState = .compactHidden
     }
 
     @objc private func exitCompactModeMenuAction() {
@@ -1292,17 +1322,17 @@ class WindowManager {
     // Forwarders from the AudioEngine broadcast hub to the embedded compact player bar.
     func compactBarUpdateTime(current: TimeInterval, duration: TimeInterval) {
         guard compactModeEnabled else { return }
-        plexBrowserWindowController?.updateCompactBarTime(current: current, duration: duration)
+        compactWindowController?.updateTime(current: current, duration: duration)
     }
 
     func compactBarUpdateTrack(_ track: Track?) {
         guard compactModeEnabled else { return }
-        plexBrowserWindowController?.updateCompactBarTrack(track)
+        compactWindowController?.updateTrack(track)
     }
 
     func compactBarUpdatePlaybackState() {
         guard compactModeEnabled else { return }
-        plexBrowserWindowController?.updateCompactBarPlaybackState()
+        compactWindowController?.updatePlaybackState()
     }
 
     // MARK: - Library History

--- a/Sources/NullPlayer/Skin/SkinRenderer.swift
+++ b/Sources/NullPlayer/Skin/SkinRenderer.swift
@@ -2764,6 +2764,35 @@ class SkinRenderer {
         }
     }
 
+    /// Continue the classic Library/playlist side rails through an embedded compact player row.
+    func drawCompactPlayerSideBorders(in context: CGContext, bounds: NSRect,
+                                      titleHeight: CGFloat, viewScale: CGFloat) {
+        let displaySideWidth = SkinElements.PlexBrowser.Layout.leftBorder
+        let sideWidth = displaySideWidth / max(viewScale, 1)
+        let contentTop = titleHeight
+        let contentHeight = max(0, bounds.height - contentTop)
+        let leftDest = NSRect(x: 0, y: contentTop, width: sideWidth, height: contentHeight)
+        let rightDest = NSRect(x: bounds.width - sideWidth, y: contentTop,
+                               width: sideWidth, height: contentHeight)
+
+        guard let pleditImage = skin.pledit else {
+            NSColor(calibratedRed: 0.08, green: 0.08, blue: 0.10, alpha: 1.0).setFill()
+            context.fill(leftDest)
+            context.fill(rightDest)
+            return
+        }
+
+        let source = SkinElements.Playlist.leftSideTile
+        drawSprite(from: pleditImage, sourceRect: source, to: leftDest, in: context)
+
+        context.saveGState()
+        context.translateBy(x: rightDest.midX, y: 0)
+        context.scaleBy(x: -1, y: 1)
+        context.translateBy(x: -rightDest.midX, y: 0)
+        drawSprite(from: pleditImage, sourceRect: source, to: rightDest, in: context)
+        context.restoreGState()
+    }
+
     /// Draw playlist side borders
     private func drawPlaylistSideBorders(in context: CGContext, bounds: NSRect) {
         drawPlaylistStyleSideBorders(in: context, bounds: bounds,

--- a/Sources/NullPlayer/Windows/CompactMode/CompactModeWindowController.swift
+++ b/Sources/NullPlayer/Windows/CompactMode/CompactModeWindowController.swift
@@ -65,6 +65,7 @@ final class CompactModeWindowController: NSWindowController {
     }
 
     deinit {
+        NotificationCenter.default.removeObserver(self)
         browserController.prepareForUITeardown()
     }
 
@@ -83,6 +84,22 @@ final class CompactModeWindowController: NSWindowController {
         window.alphaValue = 0
         position(anchoredTo: nil, display: false)
         window.orderOut(nil)
+
+        // The compact window floats at `.statusBar` level (above `.modalPanel`), so dialogs
+        // such as the Add Folder / Add YouTube Channel panels would open *behind* it. Drop
+        // below modal level whenever one of our own windows takes key focus, and restore the
+        // floating level when the compact window itself regains key. Keyed-by-our-windows
+        // only, so switching to another app doesn't sink the window.
+        NotificationCenter.default.addObserver(
+            self, selector: #selector(handleWindowDidBecomeKey(_:)),
+            name: NSWindow.didBecomeKeyNotification, object: nil)
+    }
+
+    @objc private func handleWindowDidBecomeKey(_ note: Notification) {
+        guard let window, window.isVisible else { return }
+        guard let keyWindow = note.object as? NSWindow else { return }
+        // A dialog/panel from our app took key — let it sit above the floating compact window.
+        window.level = (keyWindow === window) ? .statusBar : .normal
     }
 
     func seedFromAudioEngine() {

--- a/Sources/NullPlayer/Windows/CompactMode/CompactModeWindowController.swift
+++ b/Sources/NullPlayer/Windows/CompactMode/CompactModeWindowController.swift
@@ -1,0 +1,220 @@
+import AppKit
+
+private protocol CompactModeBrowserSurface: AnyObject {
+    var window: NSWindow? { get }
+    var isShadeMode: Bool { get }
+    var minimumCompactContentWidth: CGFloat { get }
+
+    func setCompactMode(_ enabled: Bool)
+    func updateCompactBarTime(current: TimeInterval, duration: TimeInterval)
+    func updateCompactBarTrack(_ track: Track?)
+    func updateCompactBarPlaybackState()
+    func prepareForUITeardown()
+}
+
+extension PlexBrowserWindowController: CompactModeBrowserSurface {}
+extension ModernLibraryBrowserWindowController: CompactModeBrowserSurface {}
+
+final class CompactModeWindowController: NSWindowController {
+
+    private let browserController: CompactModeBrowserSurface
+    private let modernUI: Bool
+    private var needsInitialSizing = true
+    private var revealWorkItem: DispatchWorkItem?
+
+    private let retryInterval: TimeInterval = 0.02       // ~1–2 AppKit layout passes per tick
+    private let maxRetryAttempts = 15                    // ~0.3s budget for status-item layout
+    private let statusAnchorReadyThreshold: CGFloat = 40 // menu bar ≈ 24–28pt + jitter
+
+    private var compactBaseWidth: CGFloat {
+        browserController.minimumCompactContentWidth
+    }
+
+    init(modernUI: Bool) {
+        self.modernUI = modernUI
+        if modernUI {
+            browserController = ModernLibraryBrowserWindowController()
+        } else {
+            browserController = PlexBrowserWindowController()
+        }
+        super.init(window: browserController.window)
+        setupWindow()
+        browserController.setCompactMode(true)
+        seedFromAudioEngine()
+    }
+
+    required init?(coder: NSCoder) {
+        modernUI = WindowManager.shared.isRunningModernUI
+        if modernUI {
+            browserController = ModernLibraryBrowserWindowController()
+        } else {
+            browserController = PlexBrowserWindowController()
+        }
+        super.init(coder: coder)
+        window = browserController.window
+        setupWindow()
+        browserController.setCompactMode(true)
+        seedFromAudioEngine()
+    }
+
+    deinit {
+        browserController.prepareForUITeardown()
+    }
+
+    private func setupWindow() {
+        guard let window else { return }
+        window.level = .statusBar
+        window.collectionBehavior = [.moveToActiveSpace, .transient, .ignoresCycle]
+        window.hidesOnDeactivate = false
+        window.isReleasedWhenClosed = false
+        window.animationBehavior = .none
+        window.hasShadow = true
+        window.title = "Compact Mode"
+        window.setAccessibilityIdentifier("CompactModeWindow")
+        window.setAccessibilityLabel("Compact Mode")
+        window.minSize = NSSize(width: compactBaseWidth, height: window.minSize.height)
+        window.alphaValue = 0
+        position(anchoredTo: nil, display: false)
+        window.orderOut(nil)
+    }
+
+    func seedFromAudioEngine() {
+        let engine = WindowManager.shared.audioEngine
+        browserController.updateCompactBarTrack(engine.currentTrack)
+        browserController.updateCompactBarTime(current: engine.currentTime, duration: engine.duration)
+        browserController.updateCompactBarPlaybackState()
+    }
+
+    func show(anchoredTo button: NSStatusBarButton?) {
+        guard let window else { return }
+        revealWorkItem?.cancel()
+
+        window.level = .statusBar
+        window.collectionBehavior = [.moveToActiveSpace, .transient, .ignoresCycle]
+
+        let wasVisible = window.isVisible && window.alphaValue > 0
+        if wasVisible {
+            // Already on screen: reposition immediately and stay visible — no flash possible.
+            position(anchoredTo: button, display: true)
+            window.orderFrontRegardless()
+            window.makeKey()
+            window.hasShadow = true
+            window.alphaValue = 1
+            return
+        }
+
+        // Not yet visible: keep the window invisible (alpha 0) at the best-known position
+        // until the status-item anchor has laid out, then position and reveal exactly once
+        // at the correct top-right corner. Ordering front at alpha 0 keeps it invisible while
+        // letting the retry closure detect a mid-flight hide() via window.isVisible.
+        window.alphaValue = 0
+        window.hasShadow = false
+        position(anchoredTo: button, display: false)
+        window.orderFrontRegardless()
+        scheduleReveal(anchoredTo: button, attempt: 0)
+    }
+
+    private func scheduleReveal(anchoredTo button: NSStatusBarButton?, attempt: Int) {
+        let reveal = DispatchWorkItem { [weak self, weak button] in
+            guard let self, let window = self.window, window.isVisible else { return }
+            guard self.isStatusAnchorReady(button) || attempt >= self.maxRetryAttempts else {
+                self.scheduleReveal(anchoredTo: button, attempt: attempt + 1)
+                return
+            }
+            // Reveal unconditionally once the anchor is ready or the cap is hit. On cap
+            // exhaustion position() degrades to the top-right fallback; never leave the
+            // window stuck at alpha 0 — an invisible compact window is worse than a flash.
+            self.position(anchoredTo: button, display: false)
+            window.displayIfNeeded()
+            window.hasShadow = true
+            window.alphaValue = 1
+            window.makeKey()
+        }
+        revealWorkItem = reveal
+        DispatchQueue.main.asyncAfter(deadline: .now() + retryInterval, execute: reveal)
+    }
+
+    private func isStatusAnchorReady(_ button: NSStatusBarButton?) -> Bool {
+        guard let button, let buttonWindow = button.window else { return false }
+        let buttonRectInWindow = button.convert(button.bounds, to: nil)
+        let buttonScreenRect = buttonWindow.convertToScreen(buttonRectInWindow)
+        let screen = buttonWindow.screen
+            ?? NSScreen.screens.first { $0.frame.contains(buttonScreenRect.origin) }
+            ?? NSScreen.main
+        guard let screen else { return false }
+        // The only reliable readiness signal is menu-bar proximity: NSStatusBar creates the
+        // button's window eagerly (so button.window/.screen are non-nil before layout), but a
+        // not-yet-laid-out item sits near the origin. Compare against screen.frame.maxY (the
+        // menu-bar edge), not visibleFrame.maxY which excludes the menu bar.
+        return abs(buttonScreenRect.maxY - screen.frame.maxY) < statusAnchorReadyThreshold
+    }
+
+    func hide() {
+        revealWorkItem?.cancel()
+        window?.alphaValue = 0
+        window?.orderOut(nil)
+    }
+
+    func updateTime(current: TimeInterval, duration: TimeInterval) {
+        browserController.updateCompactBarTime(current: current, duration: duration)
+    }
+
+    func updateTrack(_ track: Track?) {
+        browserController.updateCompactBarTrack(track)
+    }
+
+    func updatePlaybackState() {
+        browserController.updateCompactBarPlaybackState()
+    }
+
+    private func position(anchoredTo button: NSStatusBarButton?, display: Bool = true) {
+        guard let window else { return }
+
+        let gap: CGFloat = 0
+        let margin: CGFloat = 8
+        let visibleFrame: NSRect
+        let topY: CGFloat
+        let centerX: CGFloat
+        let hasStatusAnchor: Bool
+
+        if let button, isStatusAnchorReady(button), let buttonWindow = button.window {
+            let buttonRectInWindow = button.convert(button.bounds, to: nil)
+            let buttonScreenRect = buttonWindow.convertToScreen(buttonRectInWindow)
+            let screen = buttonWindow.screen
+                ?? NSScreen.screens.first { $0.frame.contains(buttonScreenRect.origin) }
+                ?? NSScreen.main
+            visibleFrame = screen?.visibleFrame ?? NSScreen.main?.visibleFrame ?? .zero
+            topY = visibleFrame.maxY - gap
+            centerX = buttonScreenRect.midX
+            hasStatusAnchor = true
+        } else {
+            let screen = NSScreen.main
+            visibleFrame = screen?.visibleFrame ?? .zero
+            topY = visibleFrame.maxY - gap
+            centerX = visibleFrame.midX
+            hasStatusAnchor = false
+        }
+        guard visibleFrame != .zero else { return }
+
+        let minimumWidth = compactBaseWidth
+        let minimumHeight = window.minSize.height
+        let availableHeight = max(minimumHeight, topY - visibleFrame.minY - margin)
+
+        var frame = window.frame
+        if needsInitialSizing {
+            frame.size.width = min(minimumWidth, visibleFrame.width - margin * 2)
+            frame.size.height = min(minimumHeight, availableHeight)
+            needsInitialSizing = false
+        } else {
+            frame.size.width = max(frame.width, minimumWidth)
+            frame.size.height = min(frame.height, availableHeight)
+        }
+
+        frame.origin.x = hasStatusAnchor ? centerX - frame.width / 2 : visibleFrame.maxX - frame.width - margin
+        frame.origin.x = min(max(frame.origin.x, visibleFrame.minX + margin), visibleFrame.maxX - frame.width - margin)
+        frame.origin.y = topY - frame.height
+        frame.origin.y = min(max(frame.origin.y, visibleFrame.minY + margin), visibleFrame.maxY - frame.height)
+
+        window.setFrame(frame, display: display, animate: false)
+    }
+}

--- a/Sources/NullPlayer/Windows/CompactMode/CompactModeWindowController.swift
+++ b/Sources/NullPlayer/Windows/CompactMode/CompactModeWindowController.swift
@@ -21,6 +21,10 @@ final class CompactModeWindowController: NSWindowController {
     private let modernUI: Bool
     private var needsInitialSizing = true
     private var revealWorkItem: DispatchWorkItem?
+    /// Screen-space center X of the status-item icon from the last time it resolved.
+    /// Reused to keep the window middle-aligned when the live anchor is momentarily
+    /// unavailable, instead of snapping to the screen edge.
+    private var lastAnchorCenterX: CGFloat?
 
     private let retryInterval: TimeInterval = 0.02       // ~1–2 AppKit layout passes per tick
     private let maxRetryAttempts = 15                    // ~0.3s budget for status-item layout
@@ -189,6 +193,15 @@ final class CompactModeWindowController: NSWindowController {
             visibleFrame = screen?.visibleFrame ?? NSScreen.main?.visibleFrame ?? .zero
             topY = visibleFrame.maxY - gap
             centerX = buttonScreenRect.midX
+            lastAnchorCenterX = centerX
+            hasStatusAnchor = true
+        } else if let cachedCenterX = lastAnchorCenterX {
+            // Anchor briefly unavailable (e.g. a relayout): reuse the last known icon
+            // center so the window stays middle-aligned rather than jumping to the edge.
+            let screen = NSScreen.main
+            visibleFrame = screen?.visibleFrame ?? .zero
+            topY = visibleFrame.maxY - gap
+            centerX = cachedCenterX
             hasStatusAnchor = true
         } else {
             let screen = NSScreen.main

--- a/Sources/NullPlayer/Windows/CompactMode/CompactModeWindowController.swift
+++ b/Sources/NullPlayer/Windows/CompactMode/CompactModeWindowController.swift
@@ -26,8 +26,11 @@ final class CompactModeWindowController: NSWindowController {
     private let maxRetryAttempts = 15                    // ~0.3s budget for status-item layout
     private let statusAnchorReadyThreshold: CGFloat = 40 // menu bar ≈ 24–28pt + jitter
 
+    // Render the compact window ~1/5 narrower than the browser's label-fit minimum.
+    private let compactWidthFactor: CGFloat = 0.8
+
     private var compactBaseWidth: CGFloat {
-        browserController.minimumCompactContentWidth
+        browserController.minimumCompactContentWidth * compactWidthFactor
     }
 
     init(modernUI: Bool) {

--- a/Sources/NullPlayer/Windows/ModernLibraryBrowser/ModernLibraryBrowserView.swift
+++ b/Sources/NullPlayer/Windows/ModernLibraryBrowser/ModernLibraryBrowserView.swift
@@ -191,7 +191,7 @@ class ModernLibraryBrowserView: NSView {
 
     /// Compact Mode: when true, a stripped-down player bar is embedded across the top
     /// (just below the title bar) and all content below shifts down to make room.
-    /// The window itself is never resized — only the list/content region shrinks.
+    /// The window itself is never resized -- only the list/content region shrinks.
     var compactMode: Bool = false {
         didSet {
             guard compactMode != oldValue else { return }

--- a/Sources/NullPlayer/Windows/ModernLibraryBrowser/ModernLibraryBrowserWindowController.swift
+++ b/Sources/NullPlayer/Windows/ModernLibraryBrowser/ModernLibraryBrowserWindowController.swift
@@ -239,6 +239,7 @@ extension ModernLibraryBrowserWindowController: NSWindowDelegate {
     func windowShouldClose(_ sender: NSWindow) -> Bool {
         if isCompactMode {
             sender.orderOut(nil)
+            WindowManager.shared.compactSurfaceDidHide()
             WindowManager.shared.notifyMainWindowVisibilityChanged()
             return false
         }

--- a/Sources/NullPlayer/Windows/PlexBrowser/ClassicCompactPlayerBarView.swift
+++ b/Sources/NullPlayer/Windows/PlexBrowser/ClassicCompactPlayerBarView.swift
@@ -239,7 +239,13 @@ final class ClassicCompactPlayerBarView: NSView {
 
     private func drawResizableMainTitleBar(renderer: SkinRenderer, skin: Skin,
                                            context: CGContext, isActive: Bool) {
-        guard let image = skin.titlebar else { return }
+        guard let image = skin.titlebar else {
+            // Skins missing TITLEBAR.BMP (or the empty fallback skin) would otherwise leave the
+            // top strip transparent. Fill it with the same surface color as the control row.
+            context.setFillColor(NSColor(calibratedWhite: 0.07, alpha: 1.0).cgColor)
+            context.fill(NSRect(x: 0, y: 0, width: designWidth, height: titleBarHeight))
+            return
+        }
         let source = isActive ? SkinElements.TitleBar.active : SkinElements.TitleBar.inactive
         let destination = NSRect(x: 0, y: 0, width: designWidth, height: titleBarHeight)
 

--- a/Sources/NullPlayer/Windows/PlexBrowser/ClassicCompactPlayerBarView.swift
+++ b/Sources/NullPlayer/Windows/PlexBrowser/ClassicCompactPlayerBarView.swift
@@ -446,6 +446,7 @@ final class ClassicCompactPlayerBarView: NSView {
             case .minimize:
                 if minimizeHitRect.contains(nativePoint(event)) {
                     window?.orderOut(nil)
+                    WindowManager.shared.compactSurfaceDidHide()
                     WindowManager.shared.notifyMainWindowVisibilityChanged()
                 }
             case .close:

--- a/Sources/NullPlayer/Windows/PlexBrowser/ClassicCompactPlayerBarView.swift
+++ b/Sources/NullPlayer/Windows/PlexBrowser/ClassicCompactPlayerBarView.swift
@@ -26,7 +26,10 @@ final class ClassicCompactPlayerBarView: NSView {
     private var designHeight: CGFloat { titleBarHeight + controlRowHeight }
     private let controlRowTopPad: CGFloat = 3
     private var rowHeight: CGFloat { controlRowHeight - controlRowTopPad }
-    private let pad: CGFloat = 5
+    /// Match the Library side rails in display points, accounting for this view's scale.
+    private var pad: CGFloat {
+        SkinElements.PlexBrowser.Layout.leftBorder / nativeScale + 3
+    }
     private let buttonHeight: CGFloat = 18
     /// Native widths of the CBUTTONS transport sprites: prev, play/pause, stop, next.
     private let buttonWidths: [CGFloat] = [23, 23, 23, 22]
@@ -222,6 +225,14 @@ final class ClassicCompactPlayerBarView: NSView {
         // Volume slider (classic volume sprite + thumb).
         let volume = CGFloat(WindowManager.shared.audioEngine.volume)
         drawVolumeBar(fraction: volume, renderer: renderer, skin: skin, context: context)
+
+        // Continue the Library Browser's decorative side rails through the player row.
+        renderer.drawCompactPlayerSideBorders(
+            in: context,
+            bounds: NSRect(x: 0, y: 0, width: designWidth, height: designHeight),
+            titleHeight: titleBarHeight,
+            viewScale: scale
+        )
 
         context.restoreGState()
     }

--- a/Sources/NullPlayer/Windows/PlexBrowser/ClassicCompactPlayerBarView.swift
+++ b/Sources/NullPlayer/Windows/PlexBrowser/ClassicCompactPlayerBarView.swift
@@ -19,14 +19,13 @@ final class ClassicCompactPlayerBarView: NSView {
 
     // MARK: - Layout constants (classic native pixels)
 
-    /// Design height in native units. Tall enough for transport buttons (18) plus a two-row
-    /// title/seek middle column, with `topPad` of breathing room above so the controls don't
-    /// sit jammed against the macOS menu bar.
-    private let designHeight: CGFloat = 24
-    /// Empty space (native units) reserved above the control row.
-    private let topPad: CGFloat = 4
-    /// Height of the interactive control row, below `topPad`.
-    private var rowHeight: CGFloat { designHeight - topPad }
+    /// Main-window titlebar followed by a dedicated player-control row. Keeping these as
+    /// separate vertical regions prevents the titlebar from covering transport controls.
+    private let titleBarHeight: CGFloat = SkinElements.titleBarHeight
+    private let controlRowHeight: CGFloat = 24
+    private var designHeight: CGFloat { titleBarHeight + controlRowHeight }
+    private let controlRowTopPad: CGFloat = 3
+    private var rowHeight: CGFloat { controlRowHeight - controlRowTopPad }
     private let pad: CGFloat = 5
     private let buttonHeight: CGFloat = 18
     /// Native widths of the CBUTTONS transport sprites: prev, play/pause, stop, next.
@@ -36,8 +35,11 @@ final class ClassicCompactPlayerBarView: NSView {
     private let posThumbSize = NSSize(width: 29, height: 10)
     private let volThumbSize = NSSize(width: 14, height: 11)
 
-    /// Suggested on-screen bar height.
-    static func preferredHeight() -> CGFloat { 33 }
+    /// Suggested on-screen bar height. Match the rest of the classic UI's scaling exactly so
+    /// bitmap sprites are not resampled at an arbitrary compact-bar-only scale.
+    static func preferredHeight() -> CGFloat {
+        (SkinElements.titleBarHeight + 24) * Skin.scaleFactor
+    }
 
     // MARK: - State
 
@@ -96,7 +98,7 @@ final class ClassicCompactPlayerBarView: NSView {
 
     /// Transport button rects keyed prev/play/stop/next.
     private var transportRects: [NSRect] {
-        let y = topPad + (rowHeight - buttonHeight) / 2
+        let y = titleBarHeight + controlRowTopPad + (rowHeight - buttonHeight) / 2
         var rects: [NSRect] = []
         var x = pad
         for w in buttonWidths {
@@ -112,7 +114,7 @@ final class ClassicCompactPlayerBarView: NSView {
 
     private var volumeRect: NSRect {
         NSRect(x: designWidth - pad - volumeSize.width,
-               y: topPad + (rowHeight - volumeSize.height) / 2,
+               y: titleBarHeight + controlRowTopPad + (rowHeight - volumeSize.height) / 2,
                width: volumeSize.width, height: volumeSize.height)
     }
 
@@ -120,7 +122,8 @@ final class ClassicCompactPlayerBarView: NSView {
         // "00:00 / 00:00" = 13 chars × 5px native.
         let w = 13 * SkinElements.TextFont.charWidth
         return NSRect(x: volumeRect.minX - 6 - w,
-                      y: topPad + (rowHeight - SkinElements.TextFont.charHeight) / 2,
+                      y: titleBarHeight + controlRowTopPad
+                        + (rowHeight - SkinElements.TextFont.charHeight) / 2,
                       width: w, height: SkinElements.TextFont.charHeight)
     }
 
@@ -128,16 +131,34 @@ final class ClassicCompactPlayerBarView: NSView {
     private var middleRect: NSRect {
         let left = transportEndX
         let right = timeRect.minX - 4
-        return NSRect(x: left, y: 0, width: max(0, right - left), height: designHeight)
+        return NSRect(x: left, y: titleBarHeight,
+                      width: max(0, right - left), height: controlRowHeight)
     }
 
     private var titleRect: NSRect {
-        NSRect(x: middleRect.minX, y: topPad + 1, width: middleRect.width, height: SkinElements.TextFont.charHeight)
+        NSRect(x: middleRect.minX, y: titleBarHeight + controlRowTopPad + 1,
+               width: middleRect.width, height: SkinElements.TextFont.charHeight)
     }
 
     private var seekRect: NSRect {
         NSRect(x: middleRect.minX, y: designHeight - seekHeight - 1,
                width: middleRect.width, height: seekHeight)
+    }
+
+    private var minimizeRect: NSRect {
+        NSRect(x: designWidth - 31, y: 3, width: 9, height: 9)
+    }
+
+    private var closeRect: NSRect {
+        NSRect(x: designWidth - 11, y: 3, width: 9, height: 9)
+    }
+
+    private var minimizeHitRect: NSRect {
+        NSRect(x: designWidth - 33, y: 0, width: 14, height: titleBarHeight)
+    }
+
+    private var closeHitRect: NSRect {
+        NSRect(x: designWidth - 15, y: 0, width: 15, height: titleBarHeight)
     }
 
     // MARK: - Drawing
@@ -154,16 +175,26 @@ final class ClassicCompactPlayerBarView: NSView {
         context.scaleBy(x: 1, y: -1)
         context.scaleBy(x: scale, y: scale)
 
-        let designRect = NSRect(x: 0, y: 0, width: designWidth, height: designHeight)
-
-        // Background strip + faint bottom separator so the bar reads as its own surface.
+        // Player surface below the titlebar.
         context.setFillColor(NSColor(calibratedWhite: 0.07, alpha: 1.0).cgColor)
-        context.fill(designRect)
+        context.fill(NSRect(x: 0, y: titleBarHeight,
+                            width: designWidth, height: controlRowHeight))
         context.setStrokeColor(NSColor(calibratedWhite: 0.0, alpha: 0.6).cgColor)
         context.setLineWidth(1)
         context.move(to: CGPoint(x: 0, y: designHeight - 0.5))
         context.addLine(to: CGPoint(x: designWidth, y: designHeight - 0.5))
         context.strokePath()
+
+        // Use the active classic main-window titlebar as the menu-bar-facing top border.
+        // Preserve its end caps instead of stretching the 275px bitmap across the browser.
+        drawResizableMainTitleBar(renderer: renderer, skin: skin, context: context,
+                                  isActive: window?.isKeyWindow ?? true)
+        renderer.drawButton(.minimize,
+                            state: pressedButton == .minimize ? .pressed : .normal,
+                            at: minimizeRect, in: context)
+        renderer.drawButton(.close,
+                            state: pressedButton == .close ? .pressed : .normal,
+                            at: closeRect, in: context)
 
         // Transport buttons (prev, play/pause, stop, next).
         let rects = transportRects
@@ -193,6 +224,61 @@ final class ClassicCompactPlayerBarView: NSView {
         drawVolumeBar(fraction: volume, renderer: renderer, skin: skin, context: context)
 
         context.restoreGState()
+    }
+
+    private func drawResizableMainTitleBar(renderer: SkinRenderer, skin: Skin,
+                                           context: CGContext, isActive: Bool) {
+        guard let image = skin.titlebar else { return }
+        let source = isActive ? SkinElements.TitleBar.active : SkinElements.TitleBar.inactive
+        let destination = NSRect(x: 0, y: 0, width: designWidth, height: titleBarHeight)
+
+        guard destination.width > source.width else {
+            renderer.drawSprite(from: image, sourceRect: source, to: destination, in: context)
+            return
+        }
+
+        // A skin may bake its title anywhere in the bitmap (centered, left-aligned, or custom
+        // artwork). Keep the entire section before the controls intact so that artwork is never
+        // sliced. Extend only the neutral rail immediately before the right-side controls.
+        let rightWidth: CGFloat = 37
+        let intactWidth = source.width - rightWidth
+        let extensionWidth = destination.width - source.width
+        let railWidth: CGFloat = 8
+        let railSource = NSRect(x: source.maxX - rightWidth - railWidth,
+                                y: source.minY, width: railWidth, height: source.height)
+
+        renderer.drawSprite(
+            from: image,
+            sourceRect: NSRect(x: source.minX, y: source.minY,
+                               width: intactWidth, height: source.height),
+            to: NSRect(x: destination.minX, y: destination.minY,
+                       width: intactWidth, height: destination.height),
+            in: context
+        )
+
+        var railX = intactWidth
+        let railEnd = railX + extensionWidth
+        while railX < railEnd {
+            let width = min(railWidth, railEnd - railX)
+            renderer.drawSprite(
+                from: image,
+                sourceRect: NSRect(x: railSource.minX, y: railSource.minY,
+                                   width: width, height: railSource.height),
+                to: NSRect(x: railX, y: destination.minY,
+                           width: width, height: destination.height),
+                in: context
+            )
+            railX += width
+        }
+
+        renderer.drawSprite(
+            from: image,
+            sourceRect: NSRect(x: source.maxX - rightWidth, y: source.minY,
+                               width: rightWidth, height: source.height),
+            to: NSRect(x: destination.maxX - rightWidth, y: destination.minY,
+                       width: rightWidth, height: destination.height),
+            in: context
+        )
     }
 
     private func drawTitle(renderer: SkinRenderer, context: CGContext) {
@@ -279,6 +365,22 @@ final class ClassicCompactPlayerBarView: NSView {
     override func mouseDown(with event: NSEvent) {
         let p = nativePoint(event)
 
+        if closeHitRect.contains(p) {
+            pressedButton = .close
+            needsDisplay = true
+            return
+        }
+        if minimizeHitRect.contains(p) {
+            pressedButton = .minimize
+            needsDisplay = true
+            return
+        }
+        if p.y < titleBarHeight {
+            // Compact Mode is anchored beneath the status item. Consume titlebar clicks
+            // without initiating a window drag so it cannot be detached from the menu bar.
+            return
+        }
+
         if seekRect.insetBy(dx: 0, dy: -6).contains(p) {
             isDraggingSeek = true
             updateSeekPosition(from: p)
@@ -330,6 +432,15 @@ final class ClassicCompactPlayerBarView: NSView {
             case .pause: engine.pause()
             case .stop: engine.stop()
             case .next: engine.next()
+            case .minimize:
+                if minimizeHitRect.contains(nativePoint(event)) {
+                    window?.orderOut(nil)
+                    WindowManager.shared.notifyMainWindowVisibilityChanged()
+                }
+            case .close:
+                if closeHitRect.contains(nativePoint(event)) {
+                    window?.performClose(nil)
+                }
             default: break
             }
         }
@@ -391,5 +502,9 @@ final class ClassicCompactPlayerBarView: NSView {
 
     func skinDidChange() {
         needsDisplay = true
+    }
+
+    override func menu(for event: NSEvent) -> NSMenu? {
+        ContextMenuBuilder.buildMenu(includeOutputDevices: false, includeRepeatShuffle: false)
     }
 }

--- a/Sources/NullPlayer/Windows/PlexBrowser/PlexBrowserWindowController.swift
+++ b/Sources/NullPlayer/Windows/PlexBrowser/PlexBrowserWindowController.swift
@@ -198,9 +198,8 @@ class PlexBrowserWindowController: NSWindowController, LibraryBrowserWindowProvi
 
         if enabled {
             let size = browserView.frame.size
-            // Tuck the browser's own "LIBRARY" title bar up behind the (opaque) player bar so it
-            // disappears in this view — the player bar becomes the window's top chrome. The
-            // container lays both children out deterministically on every resize.
+            // Tuck the browser's own "LIBRARY" title bar up behind the opaque player bar so it
+            // disappears in this view; the player bar becomes the compact window's top chrome.
             let container = ClassicCompactContainerView(frame: NSRect(origin: .zero, size: size))
             container.autoresizingMask = [.width, .height]
             container.barHeight = ClassicCompactPlayerBarView.preferredHeight()
@@ -210,8 +209,8 @@ class PlexBrowserWindowController: NSWindowController, LibraryBrowserWindowProvi
             let bar = ClassicCompactPlayerBarView(frame: .zero)
             bar.autoresizingMask = []
 
-            container.addSubview(browserView)   // below
-            container.addSubview(bar)           // on top (opaque, covers the title bar)
+            container.addSubview(browserView)
+            container.addSubview(bar)
             container.browser = browserView
             container.playerBar = bar
             window.contentView = container
@@ -300,6 +299,7 @@ extension PlexBrowserWindowController: NSWindowDelegate {
     func windowShouldClose(_ sender: NSWindow) -> Bool {
         if isCompactMode {
             sender.orderOut(nil)
+            WindowManager.shared.compactSurfaceDidHide()
             WindowManager.shared.notifyMainWindowVisibilityChanged()
             return false
         }

--- a/docs/compact-mode-reimplementation-plan.md
+++ b/docs/compact-mode-reimplementation-plan.md
@@ -1,0 +1,342 @@
+# Compact Mode Reimplementation Plan
+
+## Summary
+
+Compact Mode should be reimplemented as a dedicated menu-bar mini-player surface.
+
+The current implementation is structurally fragile because it repurposes the Library Browser window as the compact window. That couples Compact Mode to normal browser behavior: side docking, browser layout, shade mode, state restoration, resizing, modern/classic browser variants, and AppKit child-window relationships.
+
+The replacement design should introduce a dedicated Compact Mode controller and dedicated compact window. Compact Mode should no longer use `plexBrowserWindowController` or `ModernLibraryBrowserWindowController` as its surface.
+
+## Current problems
+
+Compact Mode currently mutates too many unrelated systems at once:
+
+- application activation policy (`.regular` ↔ `.accessory`)
+- status-bar item lifecycle
+- main menu lifecycle
+- normal window visibility snapshots
+- docked child-window relationships
+- Library Browser normal/compact rendering
+- persistent `compactModeEnabled` restore behavior
+- live modern/classic UI switching behavior
+
+This creates ambiguous states:
+
+- Library Browser visible as a normal window vs visible as compact window
+- Library Browser hidden because the user closed it vs hidden because Compact Mode owns it
+- Library Browser frame as normal restored frame vs compact dropdown frame
+- `window.isVisible` says “visible” while the user cannot see the window because activation policy/window ordering changed
+- exiting compact restores browser/main/menu state in the wrong order
+
+The missing menu-bar items after exiting Compact Mode are a symptom of the same issue. `.accessory → .regular` is asynchronous, but the current implementation rebuilds menus and restores windows as if the app is immediately regular again.
+
+## High-level direction
+
+1. Revert the incremental Compact Mode patches from the current debugging session.
+2. Stop using Library Browser as the Compact Mode surface.
+3. Add a dedicated `CompactModeWindowController` and `CompactModeView`.
+4. Add a small Compact Mode coordinator/state machine.
+5. Make enter/exit transitions explicit and ordered.
+6. Keep normal app-window restoration separate from compact-window ownership.
+
+## Files to add
+
+Suggested new files:
+
+- `Sources/NullPlayer/Windows/CompactMode/CompactModeWindowController.swift`
+- `Sources/NullPlayer/Windows/CompactMode/CompactModeView.swift`
+- optional: `Sources/NullPlayer/App/CompactModeCoordinator.swift`
+
+Alternatively, the coordinator can live in `WindowManager+CompactMode.swift` if the project prefers extensions over another object.
+
+## Files to simplify/remove compact responsibilities from
+
+Remove app-level Compact Mode responsibilities from the Library Browser implementations:
+
+- `Sources/NullPlayer/Windows/PlexBrowser/PlexBrowserWindowController.swift`
+- `Sources/NullPlayer/Windows/ModernLibraryBrowser/ModernLibraryBrowserWindowController.swift`
+- `Sources/NullPlayer/Windows/ModernLibraryBrowser/ModernLibraryBrowserView.swift`
+- `Sources/NullPlayer/App/LibraryBrowserWindowProviding.swift`
+
+Specifically, Compact Mode should no longer call:
+
+- `showPlexBrowser()`
+- `plexBrowserWindowController?.setCompactMode(true)`
+- `plexBrowserWindowController?.window` as the compact surface
+
+If the embedded Library Browser mini-player is wanted later, treat it as a separate browser feature, not app-level Compact Mode.
+
+## State machine
+
+Compact Mode should not infer state from `window.isVisible`.
+
+Use explicit state:
+
+```swift
+enum CompactModeState {
+    case regular
+    case entering
+    case compactHidden
+    case compactVisible
+    case exiting
+}
+```
+
+Tracked coordinator state:
+
+```swift
+private var compactModeState: CompactModeState = .regular
+private var regularWindowSnapshot: CompactWindowSnapshot?
+private var compactStatusItem: NSStatusItem?
+private var compactWindowController: CompactModeWindowController?
+```
+
+## Regular-window snapshot
+
+Use a typed snapshot, not a string dictionary.
+
+Example:
+
+```swift
+struct CompactWindowSnapshot {
+    var main: WindowSnapshot?
+    var equalizer: WindowSnapshot?
+    var playlist: WindowSnapshot?
+    var spectrum: WindowSnapshot?
+    var audioAnalysis: WindowSnapshot?
+    var waveform: WindowSnapshot?
+    var projectM: WindowSnapshot?
+    var library: WindowSnapshot?
+    var video: WindowSnapshot?
+    var debug: WindowSnapshot?
+}
+
+struct WindowSnapshot {
+    var wasVisible: Bool
+    var frame: NSRect
+    var wasShadeMode: Bool
+}
+```
+
+The compact window must never be included in this snapshot.
+
+## Enter Compact Mode sequence
+
+`enterCompactMode(revealWindow:)` should follow this order:
+
+```swift
+guard compactModeState == .regular else { return }
+
+compactModeState = .entering
+UserDefaults.standard.set(true, forKey: "compactModeEnabled")
+
+regularWindowSnapshot = captureRegularWindowSnapshot()
+
+detachDockedChildWindows()
+orderOutRegularWindows()
+
+NSApp.setActivationPolicy(.accessory)
+createCompactStatusItem()
+createCompactWindowControllerIfNeeded()
+
+DispatchQueue.main.async {
+    if revealWindow {
+        showCompactWindow()
+        compactModeState = .compactVisible
+    } else {
+        hideCompactWindow()
+        compactModeState = .compactHidden
+    }
+}
+```
+
+Important requirements:
+
+- Do not call `showPlexBrowser()`.
+- Do not route through normal side-docked window positioning.
+- Do not reuse `plexBrowserWindowController?.window`.
+- Detach AppKit child windows before hiding normal windows.
+- Compact window ownership belongs only to the Compact Mode controller.
+
+## Exit Compact Mode sequence
+
+`exitCompactMode()` should follow this order:
+
+```swift
+guard compactModeState == .compactVisible || compactModeState == .compactHidden else { return }
+
+compactModeState = .exiting
+UserDefaults.standard.set(false, forKey: "compactModeEnabled")
+
+hideCompactWindow()
+destroyOrRetainCompactWindowController()
+removeCompactStatusItem()
+
+NSApp.setActivationPolicy(.regular)
+restoreDockIconImage()
+
+DispatchQueue.main.async {
+    rebuildMainMenu()
+    restoreRegularWindowSnapshot()
+    updateDockedChildWindows()
+    NSApp.activate(ignoringOtherApps: true)
+    compactModeState = .regular
+}
+```
+
+Main menu restoration must happen after returning to `.regular`. Do not rebuild the menu synchronously immediately after `NSApp.setActivationPolicy(.regular)`.
+
+## Compact window design
+
+Use a dedicated `NSPanel` or borderless `NSWindow`.
+
+Recommended panel setup:
+
+```swift
+let panel = NSPanel(
+    contentRect: initialFrame,
+    styleMask: [.borderless, .nonactivatingPanel],
+    backing: .buffered,
+    defer: false
+)
+
+panel.level = .statusBar
+panel.collectionBehavior = [.canJoinAllSpaces, .transient, .ignoresCycle]
+panel.hidesOnDeactivate = false
+panel.isReleasedWhenClosed = false
+```
+
+Show using:
+
+```swift
+panel.orderFrontRegardless()
+```
+
+Positioning:
+
+- Prefer anchoring below the status-bar item.
+- If the status item window is not available yet, fall back to a visible top-area position on the active/main screen.
+- Clamp to the screen’s visible frame.
+
+## Status item behavior
+
+The status item should own only compact visibility and exit commands.
+
+Left click:
+
+```swift
+toggleCompactWindowVisibility()
+```
+
+Right-click menu:
+
+- Show/Hide Compact Window
+- Exit Compact Mode
+
+Do not use `window.isVisible` as source of truth. Use `compactModeState`.
+
+## Playback updates
+
+Current forwarding methods in `WindowManager` can stay, but their target should change.
+
+Instead of forwarding to the Library Browser:
+
+```swift
+plexBrowserWindowController?.updateCompactBarTime(...)
+plexBrowserWindowController?.updateCompactBarTrack(...)
+plexBrowserWindowController?.updateCompactBarPlaybackState()
+```
+
+forward to:
+
+```swift
+compactModeWindowController?.updateTime(...)
+compactModeWindowController?.updateTrack(...)
+compactModeWindowController?.updatePlaybackState()
+```
+
+The compact controller/view should read from `WindowManager.shared.audioEngine` only for initial seeding. Ongoing updates should come through the existing broadcast/forwarding path.
+
+## Launch restore behavior
+
+Existing launch behavior:
+
+```swift
+let shouldRestoreCompactMode = UserDefaults.standard.bool(forKey: "compactModeEnabled")
+AppStateManager.shared.restoreSettingsState {
+    if shouldRestoreCompactMode {
+        enterCompactMode(revealWindow: false)
+    }
+}
+```
+
+This is acceptable only if restoration is safe.
+
+Add defensive behavior:
+
+- If Compact Mode restore cannot create a status item or compact window, clear `compactModeEnabled`.
+- Restore regular main window.
+- Rebuild main menu.
+- Never leave the app in accessory mode without a status item.
+
+## Live UI mode switching
+
+If the user switches modern/classic while Compact Mode is active, prefer a simple policy:
+
+1. Exit Compact Mode.
+2. Perform UI mode switch.
+3. Do not automatically re-enter Compact Mode unless there is a deliberate product decision to do so.
+
+This is safer because Compact Mode should be mode-independent and should not depend on the mode-dependent window teardown/rebuild path.
+
+## Testing matrix
+
+Manual QA:
+
+- Launch regular → enter Compact Mode → compact window appears.
+- Exit Compact Mode → main menu and main window restored.
+- Enter Compact Mode again → compact window appears.
+- Hide compact window via status item → show via status item.
+- Right-click status item → Exit Compact Mode.
+- Relaunch while `compactModeEnabled` is persisted → app starts as menu-bar app with status item.
+- Relaunch compact → status item click shows compact window.
+- Modern UI: main only.
+- Modern UI: main + EQ + playlist + spectrum + library.
+- Classic UI: main only.
+- Classic UI: main + EQ + playlist + spectrum + library.
+- Library Browser open before compact → restored correctly on exit.
+- Library Browser closed before compact → stays closed on exit.
+- Docked windows before compact → docking restored after exit.
+- Switch modern/classic after exiting compact.
+- Switch modern/classic while compact is active → should exit compact first, then switch.
+
+Automated/pure-logic tests:
+
+- valid state transitions
+- invalid transition no-ops
+- snapshot capture/restore data shape
+- compact show/hide state changes
+- persisted `compactModeEnabled` handling
+- restore failure clears persisted compact flag
+
+Most AppKit ordering and activation-policy behavior still requires manual QA.
+
+## Non-goals
+
+- Do not make Library Browser the compact surface.
+- Do not infer Compact Mode state from normal window visibility.
+- Do not synchronously restore menu/windows immediately after activation policy changes.
+- Do not include the compact window in regular window state snapshots.
+- Do not rely on docked child-window behavior while in Compact Mode.
+
+## Success criteria
+
+Compact Mode is successful when:
+
+- the app can enter and exit Compact Mode repeatedly in both modern and classic UI;
+- the compact window always appears when requested;
+- the menu bar always returns after exit;
+- normal windows restore exactly to their pre-compact visibility and frames;
+- Library Browser behavior is unchanged outside Compact Mode;
+- launch restore cannot trap the app in an invisible accessory-mode state.

--- a/skills/ui-guide/SKILL.md
+++ b/skills/ui-guide/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: ui-guide
-description: Coordinate systems, scaling architecture, hit testing, and skin sprite rendering for NullPlayer's UI. Use when working on window scaling, skin rendering, coordinate transforms, visual layout, or playlist/marquee text rendering.
+description: Coordinate systems, scaling architecture, hit testing, skin sprite rendering, window layout, and Compact Mode for NullPlayer's UI. Use when working on window scaling, skin rendering, coordinate transforms, visual layout, compact/status-item windows, or playlist/marquee text rendering.
 ---
 
 # UI & Skin Rendering Guide
@@ -603,6 +603,26 @@ view's deferred `deinit` cannot wipe a same-id registration the replacement alre
 **DEBUG-only** `debugRecreateModeDependentWindows()` (Window menu → "Recreate Windows
 (Debug)") runs the same teardown/rebuild in the *same* mode — the leak/lifecycle test that
 de-risks the live switch. Requires a debug build: `./scripts/kill_build_run.sh --debug`.
+
+## Compact Mode
+
+Compact Mode is a WindowManager state transition, not a second main window style.
+
+Key implementation details:
+- `WindowManager.enterCompactMode(revealWindow:)` snapshots regular windows, detaches docked child windows, orders regular windows out, switches the app to `.accessory`, creates the status item, and owns the Compact Mode state (`regular`, `compactVisible`, `compactHidden`).
+- `Windows/CompactMode/CompactModeWindowController.swift` owns a private browser controller (`PlexBrowserWindowController` or `ModernLibraryBrowserWindowController`) and calls `setCompactMode(true)`. Do not replace this with a custom compact-only view; Compact Mode must keep the same browser compact surface and embedded compact player bar behavior as the old implementation.
+- Compact updates are forwarded through the compact controller (`updateCompactBarTime`, `updateCompactBarTrack`, `updateCompactBarPlaybackState`) so playback state stays live while the regular windows are hidden.
+- The status item left-click toggles compact visibility. Right-click opens the compact menu. Hidden compact mode remains in `.accessory` until explicitly exited.
+- Exiting Compact Mode removes the status item, switches back to `.regular`, rebuilds the main menu asynchronously, restores the regular window snapshot, then reattaches/restores docked windows.
+
+Placement rules:
+- The compact window is positioned by `CompactModeWindowController.position(anchoredTo:)`.
+- On show, align the compact window's top edge to the current screen `visibleFrame.maxY`; do not leave a top margin/gap below the menu bar.
+- Use side/bottom margins only. Do not clamp the top edge with the same edge margin used for the sides.
+- When the status item button is not available yet, fall back to top-right placement on the main screen, then reassert positioning shortly after entry once AppKit has created the status item window.
+- Keep the compact width based on the browser surface's `minimumCompactContentWidth`. Do not force a narrower hard-coded width, and do not abbreviate/truncate browser tab labels just to make the window thinner.
+- Use `.moveToActiveSpace` for the compact window, not `.canJoinAllSpaces`. Showing/hiding from the status item should reveal the compact window on the user's current desktop/Space, not stick to a previous Space or appear everywhere.
+- Avoid transition flashes by giving the compact window a top-right fallback frame during setup, using `display: false` for hidden frame changes, and delaying shadow/key/display until the final frame is applied on reveal.
 
 ## Window Docking
 

--- a/skills/user-guide/SKILL.md
+++ b/skills/user-guide/SKILL.md
@@ -74,6 +74,8 @@ Windows automatically snap together when dragged near each other:
 **Compact Mode** collapses NullPlayer to a single menu-bar app. Toggle it from the main window's right-click context menu (**Compact Mode**) or the `Windows` top menu — available in **both classic and modern UI**. When enabled:
 
 - The Dock icon is hidden (the app switches to an accessory/menu-bar app) and a **NullPlayer status-bar item** appears in the menu bar. Clicking it reveals the single compact window; its menu also has **Exit Compact Mode**.
+- Left-clicking the status-bar item toggles the compact window shown/hidden. Right-clicking opens the Compact Mode menu.
+- The compact window opens at the top-right of the screen, aligned directly below the menu bar with no extra gap.
 - The sole window is the **Library Browser** with a stripped-down player bar embedded across the top (transport, seek + time, a scrolling title marquee, and volume), built from the active UI's own components (classic skin sprites in classic, modern controls in modern).
 - All other windows (Main, EQ, Playlist, Spectrum, etc.) are hidden; their prior visibility is remembered and restored when you exit.
 - Exiting restores the Dock icon, the macOS menu bar, and the previously open windows.


### PR DESCRIPTION
## Summary

Reimplements Compact Mode as a dedicated, menu-bar-anchored window shared across classic and modern UI, and fixes the positioning/reveal glitches in the old implementation.

- **New `CompactMode/` window layer** (`CompactModeWindowController`) anchored under the menu-bar status item, used by both classic (`PlexBrowser`) and modern (`ModernLibraryBrowser`) surfaces via a shared protocol.
- **No more top-left flash on entry.** The window stays invisible (alpha 0) at its best-known position until the status-item anchor has laid out, then positions and reveals exactly once. `position()` validates anchor readiness by menu-bar proximity and the old 0.2s double-show band-aid is gone.
- **Consistent middle alignment.** The icon's center X is cached once it resolves and reused when the live anchor is momentarily unavailable, so the window no longer alternates between centered-under-icon and the screen-edge fallback.
- **~1/5 narrower window** — the compact base width is scaled to 0.8 of the browser's label-fit minimum.
- Supporting changes across `WindowManager`, the browser views/controllers, the player bar, and skin renderers, plus a reimplementation plan doc and skill-guide updates.

## Test plan

- `swift build` / `swift test`
- Toggle Compact Mode (menu + status item) from classic and modern UI: window appears centered under the icon at top-right with no top-left flash and no jump.
- Rapid enter/exit toggling: window never sticks at alpha 0, reveals after a `hide()`, or lands off-position.
- Relaunch with `compactModeEnabled` persisted: first status-item click reveals cleanly.
- Multi-display: window anchors under the status item (cap-exhausted fallback uses `NSScreen.main`, acknowledged limitation).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved Compact Mode window management with better state tracking during enter/exit transitions.
  * Enhanced regular window restoration when exiting Compact Mode.
  * Refined window positioning to align with the menu bar.

* **Documentation**
  * Updated Compact Mode guides with interaction details (left-click toggle, right-click menu) and positioning behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->