### PR TITLE
Fix Compact Mode loss, Space-jump, and left-aligned reveal

### DIFF
--- a/Sources/NullPlayer/App/WindowManager.swift
+++ b/Sources/NullPlayer/App/WindowManager.swift
@@ -4494,8 +4494,11 @@ class WindowManager {
         // swallowed by the `.exiting` guard. Mirrors the production reloadUI path.
         if compactModeEnabled {
             let snapshot = modeDependentLayout(from: regularWindowSnapshot)
+            let preSwitchSnapshot = regularWindowSnapshot
             exitCompactMode(restoreRegularWindows: false) { [weak self] in
-                self?.performDebugRecreateModeDependentWindows(snapshot: snapshot, reenterCompact: true)
+                guard let self else { return }
+                self.performDebugRecreateModeDependentWindows(snapshot: snapshot, reenterCompact: true)
+                self.reapplyModeIndependentWindows(from: preSwitchSnapshot)
             }
         } else {
             performDebugRecreateModeDependentWindows(snapshot: captureModeDependentLayout(), reenterCompact: false)
@@ -4545,12 +4548,32 @@ class WindowManager {
         // `compactModeState == .regular` instead of a no-op `.exiting` guard.
         if compactModeEnabled {
             let snapshot = modeDependentLayout(from: regularWindowSnapshot)
+            // The mode-independent windows (video, debug, app panels) survive teardown but were
+            // hidden on compact entry and are not re-shown here. enterCompactMode() will re-capture
+            // the snapshot from the live (still-hidden) windows, losing their visibility — so carry
+            // their pre-switch state forward afterward. See reapplyModeIndependentWindows(from:).
+            let preSwitchSnapshot = regularWindowSnapshot
             exitCompactMode(restoreRegularWindows: false) { [weak self] in
-                self?.performReloadUI(toModernUI: targetModern, snapshot: snapshot, reenterCompact: true)
+                guard let self else { return }
+                self.performReloadUI(toModernUI: targetModern, snapshot: snapshot, reenterCompact: true)
+                self.reapplyModeIndependentWindows(from: preSwitchSnapshot)
             }
         } else {
             performReloadUI(toModernUI: targetModern, snapshot: captureModeDependentLayout(), reenterCompact: false)
         }
+    }
+
+    /// A Compact-Mode-preserving UI switch leaves the mode-independent windows (video player, debug
+    /// console, app-owned panels) hidden without re-showing them, then `enterCompactMode()`
+    /// re-captures `regularWindowSnapshot` from those still-hidden windows — recording them as not
+    /// visible and dropping `additionalWindows`. Carry the mode-independent fields forward from the
+    /// pre-switch capture so a later Compact-Mode exit restores them. The mode-dependent fields in
+    /// the fresh capture are correct (rebuilt then captured) and are left untouched.
+    private func reapplyModeIndependentWindows(from previous: CompactWindowSnapshot?) {
+        guard let previous, regularWindowSnapshot != nil else { return }
+        regularWindowSnapshot?.video = previous.video
+        regularWindowSnapshot?.debug = previous.debug
+        regularWindowSnapshot?.additionalWindows = previous.additionalWindows
     }
 
     /// Build a mode-dependent layout snapshot from a Compact-Mode capture, so the live UI switch

--- a/Sources/NullPlayer/App/WindowManager.swift
+++ b/Sources/NullPlayer/App/WindowManager.swift
@@ -990,12 +990,24 @@ class WindowManager {
         if treatMainAsVisible {
             regularWindowSnapshot?.main?.wasVisible = true
         }
+
+        // Put an (invisible) compact window on the current Space *before* hiding the regular
+        // windows and dropping to .accessory, so NullPlayer always has a window here for the
+        // re-activation below to focus. See CompactModeWindowController.establishPresenceOnActiveSpace().
+        createCompactWindowControllerIfNeeded()
+        compactWindowController?.establishPresenceOnActiveSpace()
+
         detachManagedChildWindowsForCompactMode()
         orderOutRegularWindows()
 
         NSApp.setActivationPolicy(.accessory)
+        // Going .accessory makes macOS resign NullPlayer and activate the next app in the stack.
+        // If that app is fullscreen on another Space (e.g. Console), the user gets switched to that
+        // Space (and the .moveToActiveSpace compact window follows). Immediately re-activate so
+        // NullPlayer stays frontmost on the *current* Space — the compact window is already ordered
+        // front here. Mirrors the NSApp.activate the exit path uses to reclaim focus.
+        NSApp.activate(ignoringOtherApps: true)
         createCompactStatusItem()
-        createCompactWindowControllerIfNeeded()
 
         DispatchQueue.main.async { [weak self] in
             guard let self, self.compactModeState == .entering else { return }

--- a/Sources/NullPlayer/App/WindowManager.swift
+++ b/Sources/NullPlayer/App/WindowManager.swift
@@ -1012,10 +1012,29 @@ class WindowManager {
         postLayoutChangeNotification()
     }
 
-    func exitCompactMode() {
+    /// Exit Compact Mode and restore the regular window layout.
+    ///
+    /// The restore is deferred to the next runloop tick (after the compact window/status item
+    /// are torn down) so AppKit settles before the regular windows are re-shown — this is what
+    /// keeps the transition artifact-free. Callers that must run work only *after* the layout is
+    /// fully restored and `compactModeState` is back to `.regular` (e.g. live UI-mode switching,
+    /// which re-enters Compact Mode afterward) MUST pass `completion`; it runs at the very end of
+    /// that deferred restore. It also fires if the guard rejects the call, so a completion is
+    /// never silently dropped.
+    ///
+    /// Pass `restoreRegularWindows: false` when the caller is about to tear down and rebuild the
+    /// regular windows anyway (the live UI switch). The pre-compact windows are `.managed` and
+    /// assigned to whatever Space they were created on; re-showing them here would activate the
+    /// app on *that* Space and yank the user away from the Space they're currently viewing. Skip
+    /// the restore and the dock/activation-policy churn so the rebuilt-fresh windows (and the
+    /// re-entered compact window) land on the current Space instead.
+    func exitCompactMode(restoreRegularWindows: Bool = true, completion: (() -> Void)? = nil) {
         guard compactModeState == .compactVisible ||
               compactModeState == .compactHidden ||
-              compactModeState == .entering else { return }
+              compactModeState == .entering else {
+            completion?()
+            return
+        }
         compactModeState = .exiting
         compactModeEnabled = false
         UserDefaults.standard.set(false, forKey: "compactModeEnabled")
@@ -1024,17 +1043,22 @@ class WindowManager {
         compactWindowController = nil
         removeCompactStatusItem()
 
-        NSApp.setActivationPolicy(.regular)
-        restoreDockIconImage()
+        if restoreRegularWindows {
+            NSApp.setActivationPolicy(.regular)
+            restoreDockIconImage()
+        }
 
         DispatchQueue.main.async { [weak self] in
             guard let self else { return }
             (NSApp.delegate as? AppDelegate)?.rebuildMainMenu()
-            self.restoreRegularWindowSnapshot()
-            self.updateDockedChildWindows()
-            NSApp.activate(ignoringOtherApps: true)
+            if restoreRegularWindows {
+                self.restoreRegularWindowSnapshot()
+                self.updateDockedChildWindows()
+                NSApp.activate(ignoringOtherApps: true)
+            }
             self.compactModeState = .regular
             self.postLayoutChangeNotification()
+            completion?()
         }
     }
 
@@ -1067,6 +1091,14 @@ class WindowManager {
         )
     }
 
+    /// A window in native fullscreen occupies its own Space. Calling `orderOut` (or `orderFront`)
+    /// on it forces macOS to switch to that Space to run the transition animation — which, when
+    /// the user is viewing a different Space, yanks them away from the desktop they're on. Compact
+    /// Mode must leave such windows untouched: they simply stay on their own Space, out of view.
+    private func isInNativeFullScreen(_ window: NSWindow?) -> Bool {
+        window?.styleMask.contains(.fullScreen) ?? false
+    }
+
     private func orderOutRegularWindows() {
         for window in [mainWindowController?.window,
                        equalizerWindowController?.window,
@@ -1077,7 +1109,8 @@ class WindowManager {
                        projectMWindowController?.window,
                        plexBrowserWindowController?.window,
                        videoPlayerWindowController?.window,
-                       debugWindowController?.window].compactMap({ $0 }) {
+                       debugWindowController?.window].compactMap({ $0 })
+        where !isInNativeFullScreen(window) {
             window.orderOut(nil)
         }
 
@@ -1109,6 +1142,8 @@ class WindowManager {
         for window in NSApp.windows where window.isVisible {
             if window === compactWindow { continue }
             if isSystemOrTransientWindow(window) { continue }
+            // Leave fullscreen windows on their own Space — hiding them would switch Spaces.
+            if isInNativeFullScreen(window) { continue }
             let isOrphanedPlayerWindow =
                 window.identifier == Self.modeDependentWindowIdentifier
             if !isOrphanedPlayerWindow {
@@ -1138,6 +1173,9 @@ class WindowManager {
 
         func restore(_ snapshot: WindowSnapshot?, controller: ModeDependentWindow?) {
             guard let snapshot, let window = controller?.window else { return }
+            // Never touched on entry (see isInNativeFullScreen); leave it on its own Space so
+            // exiting Compact Mode doesn't switch away from the user's current desktop.
+            if isInNativeFullScreen(window) { return }
             if snapshot.frame != .zero {
                 window.setFrame(snapshot.frame, display: true)
             }
@@ -1153,6 +1191,7 @@ class WindowManager {
 
         func restoreWindow(_ snapshot: WindowSnapshot?, window: NSWindow?) {
             guard let snapshot, let window else { return }
+            if isInNativeFullScreen(window) { return }
             if snapshot.frame != .zero {
                 window.setFrame(snapshot.frame, display: true)
             }
@@ -1170,7 +1209,7 @@ class WindowManager {
         restoreWindow(snapshot.video, window: videoPlayerWindowController?.window)
         restoreWindow(snapshot.debug, window: debugWindowController?.window)
 
-        for window in snapshot.additionalWindows {
+        for window in snapshot.additionalWindows where !isInNativeFullScreen(window) {
             window.orderFront(nil)
         }
         regularWindowSnapshot = nil
@@ -4450,17 +4489,25 @@ class WindowManager {
     /// switch (PR4) layers mode-change semantics on top. Logs teardown/recreate timing.
     func debugRecreateModeDependentWindows() {
         NSLog("WindowManager: debugRecreateModeDependentWindows — start")
-        let wasCompact = compactModeEnabled
-        if wasCompact { exitCompactMode() }
-        // Compact Mode hides the underlying player layout. Capture only after exiting so the
-        // snapshot contains the windows that must be restored behind the rebuilt compact UI.
-        let snapshot = captureModeDependentLayout()
+        // Compact Mode restores the underlying layout asynchronously on exit; defer the rebuild
+        // until that completes so the snapshot captures the real windows and the re-enter is not
+        // swallowed by the `.exiting` guard. Mirrors the production reloadUI path.
+        if compactModeEnabled {
+            let snapshot = modeDependentLayout(from: regularWindowSnapshot)
+            exitCompactMode(restoreRegularWindows: false) { [weak self] in
+                self?.performDebugRecreateModeDependentWindows(snapshot: snapshot, reenterCompact: true)
+            }
+        } else {
+            performDebugRecreateModeDependentWindows(snapshot: captureModeDependentLayout(), reenterCompact: false)
+        }
+    }
 
+    private func performDebugRecreateModeDependentWindows(snapshot: ModeDependentLayoutSnapshot, reenterCompact: Bool) {
         let t0 = CACurrentMediaTime()
         teardownModeDependentWindows()
         let tTorn = CACurrentMediaTime()
         recreateModeDependentLayout(snapshot)
-        if wasCompact { enterCompactMode() }
+        if reenterCompact { enterCompactMode() }
         let tDone = CACurrentMediaTime()
 
         NSLog("WindowManager: debugRecreateModeDependentWindows — teardown %.1fms, recreate %.1fms",
@@ -4490,12 +4537,46 @@ class WindowManager {
         guard targetModern != isRunningModernUI else { return }
         NSLog("WindowManager: reloadUI — switching to %@ UI", targetModern ? "modern" : "classic")
 
-        let wasCompact = compactModeEnabled
-        if wasCompact { exitCompactMode() }
-        // Compact Mode's visible browser is only a temporary presentation of the underlying
-        // layout. Capture after exit so re-entering Compact Mode preserves that real layout.
-        let snapshot = captureModeDependentLayout()
+        // Compact Mode hides the underlying regular window layout and restores it *asynchronously*
+        // on exit. When in Compact Mode, derive the layout to rebuild from the pre-compact capture
+        // (`regularWindowSnapshot`) rather than the live windows — they're still hidden, and
+        // re-showing them would pull the user to whatever Space those `.managed` windows live on.
+        // Defer the swap until the compact teardown completes so the re-enter sees
+        // `compactModeState == .regular` instead of a no-op `.exiting` guard.
+        if compactModeEnabled {
+            let snapshot = modeDependentLayout(from: regularWindowSnapshot)
+            exitCompactMode(restoreRegularWindows: false) { [weak self] in
+                self?.performReloadUI(toModernUI: targetModern, snapshot: snapshot, reenterCompact: true)
+            }
+        } else {
+            performReloadUI(toModernUI: targetModern, snapshot: captureModeDependentLayout(), reenterCompact: false)
+        }
+    }
 
+    /// Build a mode-dependent layout snapshot from a Compact-Mode capture, so the live UI switch
+    /// can rebuild the regular windows without first re-showing them. Falls back to a live capture
+    /// if no Compact snapshot exists.
+    private func modeDependentLayout(from snapshot: CompactWindowSnapshot?) -> ModeDependentLayoutSnapshot {
+        guard let snapshot else { return captureModeDependentLayout() }
+        func conv(_ w: WindowSnapshot?) -> UIWindowSnapshot? {
+            guard let w else { return nil }
+            return UIWindowSnapshot(visible: w.wasVisible, frame: w.frame, isShadeMode: w.wasShadeMode)
+        }
+        return ModeDependentLayoutSnapshot(
+            main: conv(snapshot.main),
+            playlist: conv(snapshot.playlist),
+            equalizer: conv(snapshot.equalizer),
+            library: conv(snapshot.library),
+            projectM: conv(snapshot.projectM),
+            spectrum: conv(snapshot.spectrum),
+            audioAnalysis: conv(snapshot.audioAnalysis),
+            waveform: conv(snapshot.waveform)
+        )
+    }
+
+    /// The actual mode-dependent window swap. Runs synchronously when not in Compact Mode, or as
+    /// the `exitCompactMode` completion when it was — see `reloadUI(toModernUI:)`.
+    private func performReloadUI(toModernUI targetModern: Bool, snapshot: ModeDependentLayoutSnapshot, reenterCompact: Bool) {
         let t0 = CACurrentMediaTime()
         teardownModeDependentWindows()
         let tTorn = CACurrentMediaTime()
@@ -4510,7 +4591,7 @@ class WindowManager {
         recreateModeDependentLayout(snapshot)
 
         // Restore Compact Mode last so it captures the freshly rebuilt window set, not stale state.
-        if wasCompact { enterCompactMode() }
+        if reenterCompact { enterCompactMode() }
         let tDone = CACurrentMediaTime()
 
         NSLog("WindowManager: reloadUI — teardown %.1fms, recreate %.1fms (now %@ UI)",

--- a/Sources/NullPlayer/Windows/CompactMode/CompactModeWindowController.swift
+++ b/Sources/NullPlayer/Windows/CompactMode/CompactModeWindowController.swift
@@ -166,11 +166,19 @@ final class CompactModeWindowController: NSWindowController {
             ?? NSScreen.screens.first { $0.frame.contains(buttonScreenRect.origin) }
             ?? NSScreen.main
         guard let screen else { return false }
-        // The only reliable readiness signal is menu-bar proximity: NSStatusBar creates the
-        // button's window eagerly (so button.window/.screen are non-nil before layout), but a
-        // not-yet-laid-out item sits near the origin. Compare against screen.frame.maxY (the
-        // menu-bar edge), not visibleFrame.maxY which excludes the menu bar.
-        return abs(buttonScreenRect.maxY - screen.frame.maxY) < statusAnchorReadyThreshold
+        // NSStatusBar creates the button's window eagerly (so button.window/.screen are non-nil
+        // before layout), but a not-yet-laid-out item sits near the origin. Two independent
+        // signals must both hold before the anchor is trustworthy:
+        //   (1) Menu-bar proximity (Y): the laid-out item sits at the top edge. Compare against
+        //       screen.frame.maxY (the menu-bar edge), not visibleFrame.maxY which excludes it.
+        let nearMenuBar = abs(buttonScreenRect.maxY - screen.frame.maxY) < statusAnchorReadyThreshold
+        //   (2) Horizontal validity (X): a still-settling item reports an x near the screen's left
+        //       origin, which would center the compact window hard against the left margin (the
+        //       intermittent "left-aligned" bug). Real status items live in the right portion of
+        //       the menu bar — the left is occupied by the app menus — so treat any anchor whose
+        //       center lands in the left quarter of the screen as not yet laid out and retry.
+        let validX = (buttonScreenRect.midX - screen.frame.minX) > screen.frame.width * 0.25
+        return nearMenuBar && validX
     }
 
     func hide() {

--- a/Sources/NullPlayer/Windows/CompactMode/CompactModeWindowController.swift
+++ b/Sources/NullPlayer/Windows/CompactMode/CompactModeWindowController.swift
@@ -109,6 +109,21 @@ final class CompactModeWindowController: NSWindowController {
         browserController.updateCompactBarPlaybackState()
     }
 
+    /// Order the compact window front on the *current* Space while still invisible (alpha 0),
+    /// without revealing or repositioning it. Called at Compact-Mode entry **before** the regular
+    /// windows are hidden and the app drops to `.accessory`, so NullPlayer always has a window on
+    /// the user's current Space for the entry path's `NSApp.activate(ignoringOtherApps:)` to focus.
+    /// Without this, re-activation after `.accessory` has no current-Space window to land on. The
+    /// real fade-in/positioning still happens later in `show`.
+    func establishPresenceOnActiveSpace() {
+        guard let window else { return }
+        window.alphaValue = 0
+        window.hasShadow = false
+        window.collectionBehavior = [.moveToActiveSpace, .transient, .ignoresCycle]
+        window.orderFrontRegardless()
+        window.makeKey()
+    }
+
     func show(anchoredTo button: NSStatusBarButton?) {
         guard let window else { return }
         revealWorkItem?.cancel()

--- a/skills/ui-guide/SKILL.md
+++ b/skills/ui-guide/SKILL.md
@@ -609,7 +609,7 @@ de-risks the live switch. Requires a debug build: `./scripts/kill_build_run.sh -
 Compact Mode is a WindowManager state transition, not a second main window style.
 
 Key implementation details:
-- `WindowManager.enterCompactMode(revealWindow:)` snapshots regular windows, detaches docked child windows, orders regular windows out, switches the app to `.accessory`, creates the status item, and owns the Compact Mode state (`regular`, `compactVisible`, `compactHidden`).
+- `WindowManager.enterCompactMode(revealWindow:)` snapshots regular windows, establishes the compact window's presence on the current Space, detaches docked child windows, orders regular windows out, switches the app to `.accessory`, **re-activates NullPlayer** (`NSApp.activate`) so the `.accessory` transition doesn't hand the Space to a fullscreen app, creates the status item, and owns the Compact Mode state (`regular`, `compactVisible`, `compactHidden`). See the Spaces gotchas below.
 - `Windows/CompactMode/CompactModeWindowController.swift` owns a private browser controller (`PlexBrowserWindowController` or `ModernLibraryBrowserWindowController`) and calls `setCompactMode(true)`. Do not replace this with a custom compact-only view; Compact Mode must keep the same browser compact surface and embedded compact player bar behavior as the old implementation.
 - Compact updates are forwarded through the compact controller (`updateCompactBarTime`, `updateCompactBarTrack`, `updateCompactBarPlaybackState`) so playback state stays live while the regular windows are hidden.
 - The status item left-click toggles compact visibility. Right-click opens the compact menu. Hidden compact mode remains in `.accessory` until explicitly exited.
@@ -623,6 +623,26 @@ Placement rules:
 - Keep the compact width based on the browser surface's `minimumCompactContentWidth`. Do not force a narrower hard-coded width, and do not abbreviate/truncate browser tab labels just to make the window thinner.
 - Use `.moveToActiveSpace` for the compact window, not `.canJoinAllSpaces`. Showing/hiding from the status item should reveal the compact window on the user's current desktop/Space, not stick to a previous Space or appear everywhere.
 - Avoid transition flashes by giving the compact window a top-right fallback frame during setup, using `display: false` for hidden frame changes, and delaying shadow/key/display until the final frame is applied on reveal.
+
+### Spaces / virtual-desktop gotchas (hard-won)
+
+These are subtle and only reproduce with multiple Spaces / a fullscreen app on another desktop. Verify any change to the enter/exit sequence against that setup.
+
+- **`.accessory` transition steals the Space.** `NSApp.setActivationPolicy(.accessory)` makes macOS resign NullPlayer and **activate the next app in the stack**. If that app is in native fullscreen on another Space (e.g. Console), macOS switches the user to that Space, and the `.moveToActiveSpace` compact window then follows. The diagnostic signature is a `NSWorkspace.didActivateApplicationNotification` for another app firing immediately after the policy change. Fix: call `NSApp.activate(ignoringOtherApps:)` right after `setActivationPolicy(.accessory)` so NullPlayer stays frontmost on the current Space. The exit path already does this after `setActivationPolicy(.regular)`; entry must mirror it. (Merely ordering the compact window front/key does **not** prevent the handoff — the policy change yields activation regardless.)
+- **Re-activation needs a current-Space window to land on.** Because the regular windows are ordered out before the policy change, call `compactWindowController?.establishPresenceOnActiveSpace()` (orders the invisible alpha-0 compact window front on the current Space) *before* `orderOutRegularWindows()`, so the `NSApp.activate` above has a NullPlayer window on the current Space to focus.
+- **Never `orderOut`/`orderFront` a native-fullscreen window.** Doing so forces macOS to switch to that window's own Space to run the show/hide animation. `orderOutRegularWindows`, `orderOutOrphanedAppWindows`, and `restoreRegularWindowSnapshot` all skip windows where `isInNativeFullScreen(_:)` (`styleMask.contains(.fullScreen)`); leave them untouched on their Space.
+
+### Live UI switch (Classic↔Modern) while in Compact Mode
+
+`reloadUI(toModernUI:)` must not naively call `exitCompactMode()` then `enterCompactMode()`:
+
+- `exitCompactMode` restores asynchronously (state stays `.exiting` until a deferred block), so a synchronous re-enter hits the `.regular` guard and is silently dropped. `exitCompactMode` is **completion-based**; run the teardown/rebuild/re-enter inside the completion.
+- Pass `exitCompactMode(restoreRegularWindows: false)` on this path: re-showing the still-hidden `.managed` regular windows would pull the user to whatever Space they live on. Derive the rebuild snapshot from the pre-compact capture (`modeDependentLayout(from: regularWindowSnapshot)`) instead of the live (hidden) windows.
+- `enterCompactMode()` re-captures `regularWindowSnapshot` from the live windows, which **loses the mode-independent windows** (video player, debug console, app panels — they survive teardown but stay hidden). Carry those fields forward with `reapplyModeIndependentWindows(from:)` after the rebuild, or a video player open before the switch won't restore on the eventual Compact-Mode exit.
+
+### Compact window reveal positioning
+
+- Reveal readiness (`isStatusAnchorReady`) must validate **both** the status item's Y (menu-bar proximity) **and** X. A freshly created status item can report a settled Y while its X is still near the screen origin; centering on that X clamps the window hard against the left margin (intermittent "left-aligned" bug). Require the anchor's center to be right of the screen's left quarter before revealing, and retry until it is.
 
 ## Window Docking
 


### PR DESCRIPTION
Compact Mode fixes, in `WindowManager.swift` and `CompactModeWindowController.swift`, plus gotchas documented in the `ui-guide` skill.

## 1. Live UI switch dropped out of Compact Mode
Switching Classic↔Modern while in Compact Mode silently exited it. `reloadUI` called `exitCompactMode()` then immediately `enterCompactMode()`, but the exit's restore is deferred, so `compactModeState` was still `.exiting` and the re-enter's `.regular` guard swallowed it.

**Fix:** `exitCompactMode` is completion-based; the window swap runs inside the completion. The rebuild snapshot is derived from the pre-compact capture (`regularWindowSnapshot`) so the still-hidden regular windows are never re-shown mid-switch.

## 2. Mode-independent windows lost across a UI switch
On the switch path `exitCompactMode(restoreRegularWindows: false)` leaves the video player / debug console / app panels hidden; `enterCompactMode()` then re-captures the snapshot from those still-hidden windows and drops their state, so a later Compact-Mode exit failed to restore them.

**Fix:** `reapplyModeIndependentWindows(from:)` carries the mode-independent snapshot fields forward after the rebuild.

## 3. Space-jump from an own-app fullscreen window
`orderOut`/`orderFront` on a native-fullscreen window forces macOS to switch to that window's own Space to animate.

**Fix:** `isInNativeFullScreen(_:)` guard skips fullscreen windows in all hide/restore paths.

## 4. Space-jump from a *different* app's fullscreen window (e.g. Console)
Entering Compact Mode switched desktops when another app was in native fullscreen on another Space. Confirmed via instrumentation: `NSApp.setActivationPolicy(.accessory)` makes macOS resign NullPlayer and activate the next app in the stack; if that app is fullscreen on another Space, macOS switches the user there and the `.moveToActiveSpace` compact window follows.

**Fix:** after going `.accessory`, re-activate NullPlayer (`NSApp.activate(ignoringOtherApps:)`) so it stays frontmost on the current Space — mirroring what the exit path already did. `establishPresenceOnActiveSpace()` orders the invisible compact window front on the current Space *before* the regular windows are hidden, giving the re-activation a current-Space window to focus.

## 5. Compact window occasionally revealed left-aligned
Reveal readiness only validated the status item's Y (menu-bar proximity); a settled Y with a not-yet-laid-out, near-origin X centered the window against the left margin.

**Fix:** `isStatusAnchorReady` also requires a valid X (right of the screen's left quarter) before revealing, retrying until the anchor settles.

## Testing
- Enter Compact Mode, switch Classic↔Modern → stays in Compact Mode on the current desktop; a video player open beforehand restores on exit.
- With another app (Console) fullscreen on a second desktop, enter Compact Mode from desktop 1 → stays on desktop 1.
- Put a NullPlayer window in native fullscreen, toggle Compact Mode → no desktop switch; the fullscreen window is untouched.
- Toggle Compact Mode repeatedly → window consistently centers under the status-bar icon.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Improved Compact Mode switching to rebuild windows smoothly during live UI changes, coordinating exit with window teardown/recreation.
  * Enhanced status-item/Compact window readiness and reveal positioning for more reliable placement.

* **Bug Fixes**
  * Prevented native fullscreen windows from being disturbed during Compact Mode restore, reducing unwanted macOS Space changes.
  * Ensured deferred exit/restore operations still complete correctly even when restoration is skipped or delayed.

* **Documentation**
  * Updated the Compact Mode UI guide with activation/Spaces edge cases and refined reveal positioning rules.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->