### PR TITLE
Fix Visualizations window opening render-suspended in a phantom drag state

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -23,6 +23,7 @@
 
 ### Bug Fixes
 
+- **Visualizations window now loads on open instead of after a click** — opening the Visualizations window on top of an already-connected window cluster could leave it showing just its background color (with the connected-window drag tint) until you clicked a window. Opening/positioning windows no longer starts a phantom "drag" that stranded the visualization render-suspended; it now starts rendering immediately.
 - **Metal mode — Library Browser top bar no longer flickers darker** — in Metal mode the Library Browser's top strip occasionally flashed the darker modern styling before correcting itself; it now stays consistent with the metal finish.
 - **Library search now lands on the artist you picked (Plex)** — choosing an artist from Library search results reliably switches to the Artists tab and selects that artist, in both classic and modern UI.
 - **Cleartext `http://` radio stations play again (#310)** — after 0.25.0, many `http://` Icecast/SHOUTcast stations connected but produced no sound (they sat stuck at `0:00`); they now play again. `https://` stations were unaffected.

--- a/Sources/NullPlayer/App/WindowManager.swift
+++ b/Sources/NullPlayer/App/WindowManager.swift
@@ -3434,17 +3434,33 @@ class WindowManager {
     /// Programmatic moves (startup restore, snapping, frame repair) must not arm drag state.
     static func shouldTreatMoveAsDrag(
         holdPrimed: Bool,
-        pressedMouseButtons: Int,
-        currentEventType: NSEvent.EventType?
+        pressedMouseButtons: Int
     ) -> Bool {
+        // A move counts as an interactive drag only if a drag was primed by the window's own
+        // mouse-down handler, or the left mouse button is physically held right now.
+        //
+        // We deliberately do NOT key off `currentEventType` alone: `NSApp.currentEvent` can be a
+        // stale `.leftMouseDown` from the click that opened a window via a menu/toolbar item, long
+        // after the button was released. Programmatic positioning `setFrame`s during window open or
+        // docking then emit `windowDidMove`, and treating those as drags starts a phantom drag that
+        // never ends — leaving the cluster tinted in drag-highlight and the visualization window
+        // render-suspended until a real click finishes the imaginary drag.
         if holdPrimed { return true }
-        if (pressedMouseButtons & 0x1) != 0 { return true } // Left mouse button.
-        switch currentEventType {
-        case .leftMouseDown, .leftMouseDragged:
-            return true
-        default:
-            return false
-        }
+        if (pressedMouseButtons & 0x1) != 0 { return true } // Left mouse button physically held.
+        return false
+    }
+
+    /// Whether a window drag is actually in progress right now. Consumers of the
+    /// `windowDragDidBegin` / `windowDragDidEnd` notifications (e.g. `VisualizationGLView`,
+    /// which suspends rendering during drags) use this to resync their suspended state and
+    /// recover if those notifications ever arrive unbalanced.
+    ///
+    /// A real interactive drag always has the left mouse button held down. Programmatic frame
+    /// changes (window open/dock/restore) can leave `draggingWindow` set without a matching
+    /// drag-end — a phantom "stuck drag". Requiring the button to be pressed rejects that stale
+    /// state so a just-opened visualization window doesn't strand itself drag-suspended.
+    var isWindowDragInProgress: Bool {
+        draggingWindow != nil && (NSEvent.pressedMouseButtons & 0x1) != 0
     }
 
     /// Called when a window drag begins
@@ -3611,8 +3627,7 @@ class WindowManager {
         let holdPrimedForWindow = (primedDragWindow === window && holdStartTime != nil)
         let treatAsDrag = WindowManager.shouldTreatMoveAsDrag(
             holdPrimed: holdPrimedForWindow,
-            pressedMouseButtons: Int(NSEvent.pressedMouseButtons),
-            currentEventType: NSApp.currentEvent?.type
+            pressedMouseButtons: Int(NSEvent.pressedMouseButtons)
         )
 
         // Ignore non-drag moves for drag-state purposes (e.g. startup/applyFrame).

--- a/Sources/NullPlayer/Visualization/VisualizationGLView.swift
+++ b/Sources/NullPlayer/Visualization/VisualizationGLView.swift
@@ -594,8 +594,18 @@ class VisualizationGLView: NSOpenGLView {
     
     func startRendering() {
         guard isRenderEligible() else { return }
+
+        // Resync the drag-suspend flag against the actual drag state. The flag is otherwise
+        // driven purely by the global windowDragDidBegin/End notifications, which can arrive
+        // unbalanced (e.g. when the visualization window is opened into an already-connected
+        // window cluster). A stale `true` here makes renderFrame early-return forever, so the
+        // window shows only its background color until a click runs a begin/end cycle. Pinning
+        // it to the authoritative state on every (re)start guarantees a freshly shown window
+        // renders without requiring user interaction.
+        isDragSuspended = WindowManager.shared.isWindowDragInProgress
+
         guard let displayLink = displayLink, !isRendering else { return }
-        
+
         // Re-register callback if it was previously cleared by stopRendering()
         if displayLinkContextRef == nil {
             let context = VisualizationDisplayLinkContext(view: self)


### PR DESCRIPTION
## Summary

Opening the **Visualizations** window on top of an already-connected window cluster could leave it showing only its background color — with the connected-window drag **tint** — until you clicked any window. The click is what loaded the visualization engine.

## Root cause

Programmatic positioning `setFrame`s during window open/dock emit `windowDidMove`, and `shouldTreatMoveAsDrag` misclassified them as drags: it keyed off a **stale** `NSApp.currentEvent` (a `.leftMouseDown` left over from the menu/toolbar click that opened the window) even after the button was released. That started a **phantom drag that never ended** — posting `windowDragDidBegin` (which suspends `VisualizationGLView` rendering cluster-wide via `isDragSuspended`) and the connected-window highlight tint — until a real click ran a begin/finish cycle that cleared it. Because the visualization's projectM engine initializes on the first render, the suspended view never loaded it.

## Fix (layered)

1. **Source** — `shouldTreatMoveAsDrag` only treats a move as a drag when it was primed by the window's own mouse-down handler, or the left mouse button is *physically held* (`pressedMouseButtons`). The unreliable `currentEvent` path is removed, so programmatic moves no longer start phantom drags. → no tint, no stuck drag state.
2. **Authoritative state** — new `WindowManager.isWindowDragInProgress`, also gated on the button being held, so a residual stuck `draggingWindow` can't be reported as an active drag.
3. **Defensive** — `VisualizationGLView.startRendering()` resyncs `isDragSuspended` to that authoritative state on every (re)start, as a safety net against unbalanced `windowDragDidBegin`/`End` notifications.

## Testing

Repro: classic UI, open every window, open the Visualizations window last → previously opened empty/tinted until a click. With this change it loads on open, and normal window opening no longer flashes the drag-highlight tint on other windows. Affects all UI modes (shared `VisualizationGLView` + drag machinery).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Visualizations now begin loading and rendering as soon as the window opens, instead of appearing stuck on a blank background until interaction.
  * Fixed an issue that could leave dragging in a “stuck” state after the window was moved programmatically.
  * Improved drag detection so rendering no longer pauses incorrectly due to stale drag state.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->