### PR TITLE
Fix YouTube channel listing showing Videos/Live/Shorts tabs instead of uploads

### DIFF
--- a/Sources/NullPlayer/YouTube/YouTubeManager.swift
+++ b/Sources/NullPlayer/YouTube/YouTubeManager.swift
@@ -172,10 +172,20 @@ final class YouTubeManager {
         let title = try await Self.fetchChannelTitle(from: listURL)
         try Task.checkCancellation()
 
+        // `deletingLastPathComponent()` on ".../@handle/videos" leaves a trailing
+        // slash (".../@handle/"); strip it so `channelVideosURL` doesn't build a
+        // double-slash listing URL.
+        var baseComponents = URLComponents(url: listURL, resolvingAgainstBaseURL: false)
+        var basePath = baseComponents?.path ?? ""
+        if basePath.hasSuffix("/videos") { basePath.removeLast("/videos".count) }
+        while basePath.hasSuffix("/") { basePath.removeLast() }
+        baseComponents?.path = basePath
+        let baseURL = baseComponents?.url ?? listURL.deletingLastPathComponent()
+
         let channel = YouTubeChannel(
             id: key,
             title: title,
-            url: listURL.deletingLastPathComponent(),
+            url: baseURL,
             dateAdded: Date()
         )
 
@@ -339,15 +349,22 @@ final class YouTubeManager {
     // MARK: - Private Helpers
 
     /// Construct the URL to list videos from a channel
-    private static func channelVideosURL(channel: YouTubeChannel) -> URL? {
-        // Attempt to append /videos if not already present
-        if channel.url.path.hasSuffix("/videos") {
-            return channel.url
+    nonisolated static func channelVideosURL(channel: YouTubeChannel) -> URL? {
+        guard var components = URLComponents(url: channel.url, resolvingAgainstBaseURL: false) else {
+            return nil
         }
-        if channel.url.path == "/" || channel.url.path.isEmpty {
-            return channel.url.appendingPathComponent("videos")
+        // Strip any trailing slashes before appending so we never produce a
+        // double slash like "@handle//videos". yt-dlp treats the double-slash
+        // form as the channel root and returns the Videos/Live/Shorts tab list
+        // instead of the uploads. This also repairs channels whose stored URL
+        // already carries a trailing slash (e.g. from `addChannel`).
+        var path = components.path
+        while path.hasSuffix("/") { path.removeLast() }
+        if !path.hasSuffix("/videos") {
+            path += "/videos"
         }
-        return URL(string: channel.url.absoluteString.appending("/videos"))
+        components.path = path
+        return components.url
     }
 
     /// Single-segment YouTube paths that are not channel handles and must not be


### PR DESCRIPTION
## Problem

Expanding a YouTube channel in the Radio tab sometimes shows three non-expandable rows — **Videos**, **Live**, and **Shorts** — instead of the channel's uploads. The same channel works on another machine, which made it look like a yt-dlp version or environment difference.

## Root cause

The listing URL was malformed with a **double slash**:

```
https://www.youtube.com/@RickBeato//videos
```

- `addChannel` stored the channel URL via `listURL.deletingLastPathComponent()`, which leaves a **trailing slash** (`.../@handle/`).
- `channelVideosURL` then did `absoluteString + "/videos"`, producing `.../@handle//videos`.

Recent yt-dlp (e.g. **2026.06.09**) treats the double-slash form as the channel **root** and returns the Videos/Live/Shorts tab list instead of the uploads. Older yt-dlp tolerated it, so machines with an older binary or a channel stored without a trailing slash appeared to work.

Captured with a logging shim in front of yt-dlp:
```
ARG: https://www.youtube.com/@RickBeato//videos
```

## Fix

- `channelVideosURL` normalizes the path (strips trailing slashes before appending `/videos`) so it can never emit a double slash. This also **repairs existing channels** whose stored URL already has a trailing slash — no need to remove/re-add.
- `addChannel` now stores a clean base URL without a trailing slash.

## Testing

- `swift build` succeeds.
- Manual: expand a YouTube channel that previously showed the 3 tab rows; it now lists the channel's videos.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved YouTube channel link handling to better normalize channel URLs.
  * Fixed video page links so they consistently point to the correct channel videos page, even when URLs include extra slashes or a trailing `/videos` path.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->