### PR TITLE
Fix duplicate Plex artists in library browser

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,15 @@
 # Changelog
 
+## 0.26.2
+
+### Improvements
+
+- **License and branding terms clarified** — the project license notice and README now state GPL-3.0-only distribution terms and clarify that modified distributions must not reuse the NullPlayer name, icon, logo, bundle identity, or other branding without permission.
+
+### Bug Fixes
+
+- **Plex Artists no longer show duplicate same-name rows** — the Library Browser now groups Plex artist records with the same display name into one visible artist row in both classic and modern UI. Expanding, playing, or queueing that row still fans out across every underlying Plex `ratingKey`, so albums and tracks attached to duplicate server-side artist records remain accessible instead of being hidden.
+
 ## 0.26.1
 
 ### Bug Fixes

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,10 +5,13 @@
 ### Improvements
 
 - **License and branding terms clarified** — the project license notice and README now state GPL-3.0-only distribution terms and clarify that modified distributions must not reuse the NullPlayer name, icon, logo, bundle identity, or other branding without permission.
+- **Balance control added to Playback menu** — the Playback options now include a Balance submenu with a slider and common left/center/right presets, giving modern UI and menu-only workflows access to stereo balance without adding more controls to the player face.
 
 ### Bug Fixes
 
 - **Plex Artists no longer show duplicate same-name rows** — the Library Browser now groups Plex artist records with the same display name into one visible artist row in both classic and modern UI. Expanding, playing, or queueing that row still fans out across every underlying Plex `ratingKey`, so albums and tracks attached to duplicate server-side artist records remain accessible instead of being hidden.
+- **Plex artist expansion no longer beachballs on large grouped artists** — grouped Plex artist rows now reuse precomputed artist/album indexes instead of rescanning the whole Plex library while expanding a row like Rush.
+- **Compact Mode art ratings fit the small UI** — the modern Library Browser's art-view rating stars now shrink in Compact Mode, preventing them from crowding or overlapping the source/library picker row.
 
 ## 0.26.1
 

--- a/LICENSE
+++ b/LICENSE
@@ -1,3 +1,28 @@
+NullPlayer Project License Notice
+=================================
+
+NullPlayer is distributed under the GNU General Public License version 3
+only (GPL-3.0-only), with the following additional trademark and branding
+term under GPLv3 section 7(e):
+
+No trademark license is granted for the NullPlayer name, logo, icon, or
+other NullPlayer brand identifiers. Modified versions, forks, derivative
+works, and redistributed builds may not be named "NullPlayer", may not use
+a confusingly similar name, and may not use NullPlayer branding in a way
+that suggests they are the original NullPlayer project or are endorsed by
+the NullPlayer project, unless prior written permission is granted by the
+NullPlayer trademark owner.
+
+Redistributors of modified versions must rename the application and replace
+or remove NullPlayer branding from user-facing product names, bundle names,
+bundle identifiers, executable names, icons, and public marketing materials.
+Accurate attribution such as "based on NullPlayer" is permitted, provided
+it does not imply endorsement or that the modified version is the original
+NullPlayer application.
+
+This trademark and branding term does not limit the GPL rights to copy,
+modify, or distribute the covered source code.
+
                     GNU GENERAL PUBLIC LICENSE
                        Version 3, 29 June 2007
 

--- a/LICENSE
+++ b/LICENSE
@@ -95,4 +95,4 @@ modification follow.
 
 For the complete license text, see: https://www.gnu.org/licenses/gpl-3.0.txt
 
-SPDX-License-Identifier: GPL-3.0-only
+SPDX-License-Identifier: GPL-3.0-only AND LicenseRef-NullPlayer-Trademark

--- a/README.md
+++ b/README.md
@@ -346,7 +346,13 @@ A hi-fi hardware faceplate look, selected from **Skins > Metal**, with seven fin
 
 This project is open source. Because it bundles GPL-licensed components
 (KSPlayer, FFmpegKit, and aubio), the combined application is distributed under
-the terms of the **GNU GPL v3.0 or later**.
+the terms of the **GNU GPL v3.0 only**.
+
+The **NullPlayer** name, logo, icon, and other brand identifiers are not licensed
+for use by modified distributions. Forks, derivative works, and redistributed
+builds must use a different application name and replace or remove NullPlayer
+branding unless they have prior written permission. Accurate attribution such as
+"based on NullPlayer" is allowed when it does not imply endorsement.
 
 The full text of every third-party notice ships inside the app bundle at
 `Contents/Resources/ThirdPartyLicenses/` (aggregated in `ThirdPartyNotices.txt`,

--- a/README.md
+++ b/README.md
@@ -351,8 +351,10 @@ the terms of the **GNU GPL v3.0 only**.
 The **NullPlayer** name, logo, icon, and other brand identifiers are not licensed
 for use by modified distributions. Forks, derivative works, and redistributed
 builds must use a different application name and replace or remove NullPlayer
-branding unless they have prior written permission. Accurate attribution such as
-"based on NullPlayer" is allowed when it does not imply endorsement.
+branding from user-facing product names, bundle names, bundle identifiers,
+executable names, icons, and public marketing materials unless they have prior
+written permission. Accurate attribution such as "based on NullPlayer" is allowed
+when it does not imply endorsement.
 
 The full text of every third-party notice ships inside the app bundle at
 `Contents/Resources/ThirdPartyLicenses/` (aggregated in `ThirdPartyNotices.txt`,

--- a/Sources/NullPlayer/App/ContextMenuBuilder.swift
+++ b/Sources/NullPlayer/App/ContextMenuBuilder.swift
@@ -1055,6 +1055,10 @@ class ContextMenuBuilder {
             keyEquivalent: ""
         )
         balanceRoot.submenu = buildBalanceMenu()
+        if engine.isAnyCastingActive {
+            balanceRoot.isEnabled = false
+            balanceRoot.toolTip = "Not available while casting"
+        }
         optionsMenu.addItem(balanceRoot)
 
         optionsMenu.addItem(NSMenuItem.separator())

--- a/Sources/NullPlayer/App/ContextMenuBuilder.swift
+++ b/Sources/NullPlayer/App/ContextMenuBuilder.swift
@@ -345,6 +345,72 @@ class ContextMenuBuilder {
         return menu
     }
 
+    /// Builds the Balance submenu.
+    static func buildBalanceMenu() -> NSMenu {
+        let menu = NSMenu()
+        menu.autoenablesItems = false
+
+        let current = WindowManager.shared.audioEngine.balance
+
+        let sliderItem = NSMenuItem()
+        sliderItem.view = makeBalanceSliderView(current: current)
+        menu.addItem(sliderItem)
+
+        menu.addItem(NSMenuItem.separator())
+
+        let presets: [(title: String, value: Float)] = [
+            ("Left 100%", -1.0),
+            ("Left 50%", -0.5),
+            ("Center", 0.0),
+            ("Right 50%", 0.5),
+            ("Right 100%", 1.0)
+        ]
+
+        for preset in presets {
+            let item = NSMenuItem(title: preset.title, action: #selector(MenuActions.setPlaybackBalancePreset(_:)), keyEquivalent: "")
+            item.target = MenuActions.shared
+            item.representedObject = preset.value
+            item.state = abs(current - preset.value) < 0.001 ? .on : .off
+            menu.addItem(item)
+        }
+
+        return menu
+    }
+
+    private static func makeBalanceSliderView(current: Float) -> NSView {
+        let view = NSView(frame: NSRect(x: 0, y: 0, width: 230, height: 42))
+
+        let slider = NSSlider(value: Double(current), minValue: -1.0, maxValue: 1.0, target: MenuActions.shared, action: #selector(MenuActions.setPlaybackBalanceFromSlider(_:)))
+        slider.frame = NSRect(x: 16, y: 17, width: 198, height: 18)
+        slider.isContinuous = true
+        slider.numberOfTickMarks = 5
+        slider.allowsTickMarkValuesOnly = false
+        view.addSubview(slider)
+
+        let labels: [(String, CGFloat, NSTextAlignment)] = [
+            ("L", 16, .left),
+            ("Center", 82, .center),
+            ("R", 196, .right)
+        ]
+        for label in labels {
+            let field = NSTextField(labelWithString: label.0)
+            field.frame = NSRect(x: label.1, y: 2, width: label.0 == "Center" ? 66 : 18, height: 14)
+            field.font = .menuFont(ofSize: 10)
+            field.textColor = .secondaryLabelColor
+            field.alignment = label.2
+            view.addSubview(field)
+        }
+
+        return view
+    }
+
+    static func balanceDisplayName(_ balance: Float) -> String {
+        let clamped = max(-1.0, min(1.0, balance))
+        if abs(clamped) < 0.001 { return "Center" }
+        let percent = Int(round(abs(clamped) * 100))
+        return clamped < 0 ? "L \(percent)%" : "R \(percent)%"
+    }
+
     /// Builds the top-level "Visuals" menu content for the macOS menu bar.
     static func buildMenuBarVisualsMenu() -> NSMenu {
         let menu = NSMenu()
@@ -981,6 +1047,15 @@ class ContextMenuBuilder {
             speedRoot.toolTip = "Not available while casting"
         }
         optionsMenu.addItem(speedRoot)
+
+        // Balance submenu
+        let balanceRoot = NSMenuItem(
+            title: "Balance: \(balanceDisplayName(engine.balance))",
+            action: nil,
+            keyEquivalent: ""
+        )
+        balanceRoot.submenu = buildBalanceMenu()
+        optionsMenu.addItem(balanceRoot)
 
         optionsMenu.addItem(NSMenuItem.separator())
 
@@ -4145,6 +4220,17 @@ class MenuActions: NSObject {
         }
 
         engine.setPlaybackSpeed(speed)
+    }
+
+    // MARK: - Balance
+
+    @objc func setPlaybackBalanceFromSlider(_ sender: NSSlider) {
+        WindowManager.shared.audioEngine.balance = Float(sender.doubleValue)
+    }
+
+    @objc func setPlaybackBalancePreset(_ sender: NSMenuItem) {
+        guard let value = sender.representedObject as? Float else { return }
+        WindowManager.shared.audioEngine.balance = value
     }
     
     @objc func toggleSweetFade() {

--- a/Sources/NullPlayer/App/DebugConsoleManager.swift
+++ b/Sources/NullPlayer/App/DebugConsoleManager.swift
@@ -14,8 +14,10 @@ class DebugConsoleManager {
     // MARK: - Properties
     
     private var messages: [String] = []
+    private var nonUPnPMessages: [String] = []
     private let messagesLock = NSLock()
-    private let maxMessages = 1000
+    private let maxMessages = 25000
+    private let maxVisibleMessages = 10000
     
     private var pipe: Pipe?
     private var originalStderr: Int32 = -1
@@ -75,17 +77,19 @@ class DebugConsoleManager {
         pipe = nil
     }
     
-    /// Get all captured messages
-    func getMessages() -> [String] {
+    /// Get captured messages. When UPnP is hidden, return the dedicated non-UPnP buffer so
+    /// relentless discovery/casting logs cannot evict useful visible backscroll.
+    func getMessages(hidingUPnP: Bool = false) -> [String] {
         messagesLock.lock()
         defer { messagesLock.unlock() }
-        return messages
+        return hidingUPnP ? nonUPnPMessages : messages
     }
     
     /// Clear all messages
     func clearMessages() {
         messagesLock.lock()
         messages.removeAll()
+        nonUPnPMessages.removeAll()
         messagesLock.unlock()
         
         DispatchQueue.main.async {
@@ -101,10 +105,14 @@ class DebugConsoleManager {
         // Split by newlines and add each line
         let lines = message.components(separatedBy: .newlines).filter { !$0.isEmpty }
         messages.append(contentsOf: lines)
+        nonUPnPMessages.append(contentsOf: lines.filter { !Self.isUPnPMessage($0) })
         
         // Trim if over limit
         if messages.count > maxMessages {
             messages.removeFirst(messages.count - maxMessages)
+        }
+        if nonUPnPMessages.count > maxVisibleMessages {
+            nonUPnPMessages.removeFirst(nonUPnPMessages.count - maxVisibleMessages)
         }
         
         messagesLock.unlock()
@@ -113,5 +121,9 @@ class DebugConsoleManager {
         DispatchQueue.main.async {
             NotificationCenter.default.post(name: Self.messageReceivedNotification, object: nil)
         }
+    }
+
+    private static func isUPnPMessage(_ message: String) -> Bool {
+        message.contains("UPnPManager")
     }
 }

--- a/Sources/NullPlayer/App/WindowManager.swift
+++ b/Sources/NullPlayer/App/WindowManager.swift
@@ -1151,10 +1151,9 @@ class WindowManager {
     }
 
     private func orderOutRegularWindows() {
-        // The video player window is the one regular window allowed to stay in Compact Mode:
-        // a playing video (e.g. a downloaded YouTube video) keeps showing on entry and may be
-        // opened while compact. It is deliberately excluded here and skipped by the orphan sweep
-        // below, so Compact Mode never hides or restores it.
+        // The video player and debug console are allowed to stay in Compact Mode. They are
+        // deliberately excluded here and skipped by the orphan sweep below, so Compact Mode
+        // never hides or restores them.
         for window in [mainWindowController?.window,
                        equalizerWindowController?.window,
                        playlistWindowController?.window,
@@ -1162,8 +1161,7 @@ class WindowManager {
                        audioAnalysisWindowController?.window,
                        waveformWindowController?.window,
                        projectMWindowController?.window,
-                       plexBrowserWindowController?.window,
-                       debugWindowController?.window].compactMap({ $0 })
+                       plexBrowserWindowController?.window].compactMap({ $0 })
         where !isInNativeFullScreen(window) {
             window.orderOut(nil)
         }
@@ -1195,8 +1193,9 @@ class WindowManager {
         let compactWindow = compactWindowController?.window
         for window in NSApp.windows where window.isVisible {
             if window === compactWindow { continue }
-            // The video player is allowed to remain visible in Compact Mode (see orderOutRegularWindows).
+            // These windows are allowed to remain visible in Compact Mode (see orderOutRegularWindows).
             if window === videoPlayerWindowController?.window { continue }
+            if window === debugWindowController?.window { continue }
             if isSystemOrTransientWindow(window) { continue }
             // Leave fullscreen windows on their own Space — hiding them would switch Spaces.
             if isInNativeFullScreen(window) { continue }
@@ -1245,15 +1244,6 @@ class WindowManager {
             }
         }
 
-        func restoreWindow(_ snapshot: WindowSnapshot?, window: NSWindow?) {
-            guard let snapshot, let window else { return }
-            if isInNativeFullScreen(window) { return }
-            if snapshot.frame != .zero {
-                window.setFrame(snapshot.frame, display: true)
-            }
-            snapshot.wasVisible ? window.orderFront(nil) : window.orderOut(nil)
-        }
-
         restore(snapshot.main, controller: mainWindowController)
         restore(snapshot.equalizer, controller: equalizerWindowController)
         restore(snapshot.playlist, controller: playlistWindowController)
@@ -1262,8 +1252,7 @@ class WindowManager {
         restore(snapshot.waveform, controller: waveformWindowController)
         restore(snapshot.projectM, controller: projectMWindowController)
         restore(snapshot.library, controller: plexBrowserWindowController)
-        // The video player is never hidden by Compact Mode, so it is not restored here either.
-        restoreWindow(snapshot.debug, window: debugWindowController?.window)
+        // The video player and debug console are never hidden by Compact Mode, so they are not restored here either.
 
         for window in snapshot.additionalWindows where !isInNativeFullScreen(window) {
             window.orderFront(nil)
@@ -1288,9 +1277,8 @@ class WindowManager {
         case "waveform": return snapshot.waveform?.wasVisible ?? current
         case "projectM": return snapshot.projectM?.wasVisible ?? current
         case "plexBrowser": return snapshot.library?.wasVisible ?? current
-        // "video" is intentionally omitted: Compact Mode no longer hides the video player,
-        // so its live visibility is already the value worth saving (falls through to `current`).
-        case "debug": return snapshot.debug?.wasVisible ?? current
+        // "video" and "debug" are intentionally omitted: Compact Mode no longer hides them,
+        // so their live visibility is already the value worth saving (falls through to `current`).
         default: return current
         }
     }
@@ -4715,11 +4703,11 @@ class WindowManager {
         // `compactModeState == .regular` instead of a no-op `.exiting` guard.
         if compactModeEnabled {
             let snapshot = modeDependentLayout(from: regularWindowSnapshot)
-            // The hidden mode-independent windows (debug, app panels) survive teardown but were
+            // The hidden mode-independent windows (app panels) survive teardown but were
             // hidden on compact entry and are not re-shown here. enterCompactMode() will re-capture
             // the snapshot from the live (still-hidden) windows, losing their visibility — so carry
-            // their pre-switch state forward afterward. (The video player is exempt from Compact
-            // Mode hiding and stays visible throughout.) See reapplyModeIndependentWindows(from:).
+            // their pre-switch state forward afterward. (The video player and debug console are
+            // exempt from Compact Mode hiding and stay visible throughout.) See reapplyModeIndependentWindows(from:).
             let preSwitchSnapshot = regularWindowSnapshot
             exitCompactMode(restoreRegularWindows: false) { [weak self] in
                 guard let self else { return }
@@ -4733,18 +4721,17 @@ class WindowManager {
         }
     }
 
-    /// A Compact-Mode-preserving UI switch leaves the hidden mode-independent windows (debug
-    /// console, app-owned panels) hidden without re-showing them, then `enterCompactMode()`
+    /// A Compact-Mode-preserving UI switch leaves hidden mode-independent app-owned panels
+    /// hidden without re-showing them, then `enterCompactMode()`
     /// re-captures `regularWindowSnapshot` from those still-hidden windows — recording them as not
     /// visible and dropping `additionalWindows`. Carry those fields forward from the pre-switch
     /// capture so a later Compact-Mode exit restores them. The mode-dependent fields in the fresh
-    /// capture are correct (rebuilt then captured) and are left untouched. (The video player is
-    /// exempt from Compact Mode hiding, so it needs no carry-forward.)
+    /// capture are correct (rebuilt then captured) and are left untouched. (The video player and
+    /// debug console are exempt from Compact Mode hiding, so they need no carry-forward.)
     private func reapplyModeIndependentWindows(from previous: CompactWindowSnapshot?) {
         guard let previous, regularWindowSnapshot != nil else { return }
-        // The video player is exempt from Compact Mode hiding, so it needs no carry-forward;
-        // only the debug console and additional app windows are hidden and must be preserved.
-        regularWindowSnapshot?.debug = previous.debug
+        // The video player and debug console are exempt from Compact Mode hiding, so they need
+        // no carry-forward; only additional app windows are hidden and must be preserved.
         regularWindowSnapshot?.additionalWindows = previous.additionalWindows
     }
 

--- a/Sources/NullPlayer/Audio/AudioEngine.swift
+++ b/Sources/NullPlayer/Audio/AudioEngine.swift
@@ -79,6 +79,7 @@ protocol AudioEngineDelegate: AnyObject {
 class AudioEngine {
 
     static var isHeadless = false
+    private static let balanceDefaultsKey = "audioBalance"
 
     struct LocalPlaybackSleepClockState: Equatable {
         let currentTime: TimeInterval
@@ -282,11 +283,16 @@ class AudioEngine {
     }
     
     /// Balance (-1.0 left, 0.0 center, 1.0 right)
-    var balance: Float = 0.0 {
+    var balance: Float = AudioEngine.loadSavedBalance() {
         didSet {
+            balance = Self.clampedBalance(balance)
             // Apply to both players since they alternate during crossfades
             playerNode.pan = balance
             crossfadePlayerNode.pan = balance
+            streamingPlayer?.balance = balance
+            crossfadeStreamingPlayer?.balance = balance
+            UserDefaults.standard.set(balance, forKey: Self.balanceDefaultsKey)
+            notifyPlaybackOptionsChanged()
         }
     }
     
@@ -726,6 +732,15 @@ class AudioEngine {
         NotificationCenter.default.post(name: .audioPlaybackOptionsChanged, object: self)
     }
 
+    private static func clampedBalance(_ value: Float) -> Float {
+        max(-1.0, min(1.0, value))
+    }
+
+    private static func loadSavedBalance() -> Float {
+        guard UserDefaults.standard.object(forKey: balanceDefaultsKey) != nil else { return 0.0 }
+        return clampedBalance(UserDefaults.standard.float(forKey: balanceDefaultsKey))
+    }
+
     private func captureShufflePlaybackState() -> ShufflePlaybackStateSnapshot {
         ShufflePlaybackStateSnapshot(
             order: shufflePlaybackOrder,
@@ -1096,6 +1111,8 @@ class AudioEngine {
         // This ensures the spectrum tap captures volume-independent audio
         playerNode.volume = 1.0
         crossfadePlayerNode.volume = 0  // Still starts silent for crossfade
+        playerNode.pan = balance
+        crossfadePlayerNode.pan = balance
         
         // Apply initial volume to mainMixerNode (after EQ, before output)
         engine.mainMixerNode.outputVolume = volume
@@ -4433,6 +4450,7 @@ class AudioEngine {
             streamingPlayer?.stereoNeeded = stereoNeeded
             streamingPlayer?.magnitudesNeeded = magnitudesNeeded
         }
+        streamingPlayer?.balance = balance
 
         // Sync EQ settings from main EQ to streaming player
         syncEQToStreamingPlayer()
@@ -5043,6 +5061,7 @@ class AudioEngine {
             pitchNode: tuningController.makeStreamingPitchNode()
         )
         crossfadeStreamingPlayer?.rate = tuningController.rate
+        crossfadeStreamingPlayer?.balance = balance
         // Note: We don't set delegate - we handle state internally during crossfade
         
         // Sync EQ settings to crossfade player

--- a/Sources/NullPlayer/Audio/AudioEngine.swift
+++ b/Sources/NullPlayer/Audio/AudioEngine.swift
@@ -79,7 +79,6 @@ protocol AudioEngineDelegate: AnyObject {
 class AudioEngine {
 
     static var isHeadless = false
-    private static let balanceDefaultsKey = "audioBalance"
 
     struct LocalPlaybackSleepClockState: Equatable {
         let currentTime: TimeInterval
@@ -282,8 +281,9 @@ class AudioEngine {
         }
     }
     
-    /// Balance (-1.0 left, 0.0 center, 1.0 right)
-    var balance: Float = AudioEngine.loadSavedBalance() {
+    /// Balance (-1.0 left, 0.0 center, 1.0 right).
+    /// Intentionally not persisted — playback always starts centered on each launch.
+    var balance: Float = 0.0 {
         didSet {
             balance = Self.clampedBalance(balance)
             // Apply to both players since they alternate during crossfades
@@ -291,7 +291,6 @@ class AudioEngine {
             crossfadePlayerNode.pan = balance
             streamingPlayer?.balance = balance
             crossfadeStreamingPlayer?.balance = balance
-            UserDefaults.standard.set(balance, forKey: Self.balanceDefaultsKey)
             notifyPlaybackOptionsChanged()
         }
     }
@@ -734,11 +733,6 @@ class AudioEngine {
 
     private static func clampedBalance(_ value: Float) -> Float {
         max(-1.0, min(1.0, value))
-    }
-
-    private static func loadSavedBalance() -> Float {
-        guard UserDefaults.standard.object(forKey: balanceDefaultsKey) != nil else { return 0.0 }
-        return clampedBalance(UserDefaults.standard.float(forKey: balanceDefaultsKey))
     }
 
     private func captureShufflePlaybackState() -> ShufflePlaybackStateSnapshot {

--- a/Sources/NullPlayer/Audio/StreamingAudioPlayer.swift
+++ b/Sources/NullPlayer/Audio/StreamingAudioPlayer.swift
@@ -34,6 +34,10 @@ class StreamingAudioPlayer {
     /// Equalizer attached to the player
     private let eqNode: AVAudioUnitEQ
 
+    /// Balance/pan node attached before EQ so streaming playback follows the same
+    /// left/right balance setting as local AVAudioPlayerNode playback.
+    private let balanceNode = AVAudioMixerNode()
+
     /// Optional Reference Tuning pitch node. Retained here because AudioStreaming's
     /// custom node list is private to its AudioPlayer.
     private let pitchNode: AVAudioUnitTimePitch?
@@ -183,6 +187,12 @@ class StreamingAudioPlayer {
 
     /// Cached volume for use inside tap callbacks (avoids mainMixerNode access from realtime thread)
     private var _cachedVolume: Float = 1.0
+
+    /// Stereo balance (-1.0 full left, 0.0 center, 1.0 full right).
+    var balance: Float {
+        get { balanceNode.pan }
+        set { balanceNode.pan = max(-1.0, min(1.0, newValue)) }
+    }
     
     /// Playback rate (1.0 = normal speed)
     var rate: Float {
@@ -213,8 +223,10 @@ class StreamingAudioPlayer {
         eqNode = AVAudioUnitEQ(numberOfBands: EQBandProgram.physicalBandCount)
         setupEQ()
 
-        // Attach EQ to the player's audio graph
-        player.attach(node: eqNode)
+        balanceNode.outputVolume = 1.0
+
+        // Attach balance and EQ to the player's audio graph.
+        player.attach(nodes: [balanceNode, eqNode])
 
         // Attach the Reference Tuning pitch node (after EQ, before output) when provided.
         // AudioStreaming's own private `rateNode` (AVAudioUnitTimePitch) is bypassed while

--- a/Sources/NullPlayer/Windows/Debug/DebugWindowController.swift
+++ b/Sources/NullPlayer/Windows/Debug/DebugWindowController.swift
@@ -94,11 +94,7 @@ class DebugWindowController: NSWindowController, NSWindowDelegate {
     }
     
     private func getFilteredMessages() -> [String] {
-        var messages = DebugConsoleManager.shared.getMessages()
-        if hideUPnPMessages {
-            messages = messages.filter { !$0.contains("UPnPManager") }
-        }
-        return messages
+        DebugConsoleManager.shared.getMessages(hidingUPnP: hideUPnPMessages)
     }
     
     private func subscribeToMessages() {

--- a/Sources/NullPlayer/Windows/ModernLibraryBrowser/ModernLibraryBrowserView.swift
+++ b/Sources/NullPlayer/Windows/ModernLibraryBrowser/ModernLibraryBrowserView.swift
@@ -345,6 +345,9 @@ class ModernLibraryBrowserView: NSView {
     private var artistAlbums: [String: [PlexAlbum]] = [:]
     private var albumTracks: [String: [PlexTrack]] = [:]
     private var artistAlbumCounts: [String: Int] = [:]
+    private var plexArtistGroupsByName: [String: [PlexArtist]] = [:]
+    private var plexAlbumsByArtistGroupKey: [String: [PlexAlbum]] = [:]
+    private var plexAlbumCountsByArtistGroupKey: [String: Int] = [:]
     private var artistAlbumsByName: [String: [PlexAlbum]] = [:]
     
     // Cached data - Local
@@ -1514,11 +1517,12 @@ class ModernLibraryBrowserView: NSView {
         if isArtOnlyMode,
            let currentTrack = WindowManager.shared.audioEngine.currentTrack,
            currentTrack.plexRatingKey != nil || currentTrack.subsonicId != nil || currentTrack.jellyfinId != nil || currentTrack.embyId != nil || currentTrack.url.isFileURL {
-            let starSize: CGFloat = 14 * m
-            let starSpacing: CGFloat = 4 * m
+            let starSize: CGFloat = (compactMode ? 11 : 14) * m
+            let starSpacing: CGFloat = (compactMode ? 2 : 4) * m
+            let starButtonGap: CGFloat = (compactMode ? 10 : 16) * m
             let totalStars = 5
             let starsWidth = CGFloat(totalStars) * starSize + CGFloat(totalStars - 1) * starSpacing
-            let starsX = visEndX - starsWidth - 16 * m
+            let starsX = visEndX - starsWidth - starButtonGap
             let starY = barRect.minY + (barRect.height - starSize) / 2
             
             // Get current rating (0-10 scale -> 0-5 filled stars)
@@ -9524,10 +9528,27 @@ class ModernLibraryBrowserView: NSView {
     
     private func buildArtistAlbumCounts() {
         artistAlbumCounts.removeAll()
+        plexArtistGroupsByName = Dictionary(grouping: cachedArtists, by: { normalizedPlexArtistName($0.title) })
+        plexAlbumsByArtistGroupKey.removeAll()
+        plexAlbumCountsByArtistGroupKey.removeAll()
+
+        var artistsById: [String: PlexArtist] = [:]
+        for artist in cachedArtists {
+            artistsById[artist.id] = artist
+        }
         for album in cachedAlbums {
             if let parentKey = album.parentKey, let artistId = extractArtistId(from: parentKey) {
                 artistAlbumCounts[artistId, default: 0] += 1
+                if let artist = artistsById[artistId] {
+                    plexAlbumsByArtistGroupKey[plexArtistGroupKey(for: artist), default: []].append(album)
+                }
             }
+        }
+
+        for (groupKey, albums) in plexAlbumsByArtistGroupKey {
+            let deduplicated = deduplicatedPlexAlbums(albums)
+            plexAlbumsByArtistGroupKey[groupKey] = deduplicated
+            plexAlbumCountsByArtistGroupKey[groupKey] = deduplicated.count
         }
     }
     
@@ -10524,28 +10545,29 @@ class ModernLibraryBrowserView: NSView {
     }
 
     private func uniquePlexArtistsByName(_ artists: [PlexArtist]) -> [PlexArtist] {
-        var artistsByName: [String: PlexArtist] = [:]
-        for artist in artists {
-            let key = normalizedPlexArtistName(artist.title)
-            if let existing = artistsByName[key] {
-                if artist.albumCount > existing.albumCount {
-                    artistsByName[key] = artist
-                }
-            } else {
-                artistsByName[key] = artist
-            }
+        var groups = Dictionary(grouping: artists, by: { normalizedPlexArtistName($0.title) })
+        if artists.count == cachedArtists.count && !plexArtistGroupsByName.isEmpty {
+            groups = plexArtistGroupsByName
         }
-        return Array(artistsByName.values)
+        let representatives = groups.values.compactMap { group in
+            group.max { lhs, rhs in lhs.albumCount < rhs.albumCount }
+        }
+        return representatives
     }
 
     private func plexArtistGroup(for artist: PlexArtist) -> [PlexArtist] {
         guard browseMode != .search else { return [artist] }
         let key = normalizedPlexArtistName(artist.title)
-        let matches = cachedArtists.filter { normalizedPlexArtistName($0.title) == key }
+        let matches = plexArtistGroupsByName[key] ?? cachedArtists.filter { normalizedPlexArtistName($0.title) == key }
         return matches.isEmpty ? [artist] : matches
     }
 
     private func plexArtistAlbumCount(for artist: PlexArtist) -> Int? {
+        let groupKey = plexArtistGroupKey(for: artist)
+        if let count = plexAlbumCountsByArtistGroupKey[groupKey], count > 0 {
+            return count
+        }
+
         let group = plexArtistGroup(for: artist)
         let memberIds = Set(group.map { $0.id })
         let cachedGroupAlbums = cachedAlbums.filter { album in
@@ -10596,6 +10618,11 @@ class ModernLibraryBrowserView: NSView {
     }
 
     private func fetchAlbumsForPlexArtistGroup(_ artist: PlexArtist) async throws -> [PlexAlbum] {
+        let groupKey = plexArtistGroupKey(for: artist)
+        if let cached = plexAlbumsByArtistGroupKey[groupKey], !cached.isEmpty {
+            return cached
+        }
+
         var albums: [PlexAlbum] = []
         for member in plexArtistGroup(for: artist) {
             albums.append(contentsOf: try await PlexManager.shared.fetchAlbums(forArtist: member))

--- a/Sources/NullPlayer/Windows/ModernLibraryBrowser/ModernLibraryBrowserView.swift
+++ b/Sources/NullPlayer/Windows/ModernLibraryBrowser/ModernLibraryBrowserView.swift
@@ -5193,7 +5193,7 @@ class ModernLibraryBrowserView: NSView {
             playNextItem.target = self; playNextItem.representedObject = artist; menu.addItem(playNextItem)
             let queueItem = NSMenuItem(title: "Add Artist to Queue", action: #selector(contextMenuAddArtistToQueue(_:)), keyEquivalent: "")
             queueItem.target = self; queueItem.representedObject = artist; menu.addItem(queueItem)
-            let expandItem = NSMenuItem(title: expandedArtists.contains(artist.id) ? "Collapse" : "Expand",
+            let expandItem = NSMenuItem(title: expandedArtists.contains(item.id) ? "Collapse" : "Expand",
                                          action: #selector(contextMenuToggleExpand(_:)), keyEquivalent: "")
             expandItem.target = self; expandItem.representedObject = item; menu.addItem(expandItem)
         case .localTrack(let track):
@@ -6462,10 +6462,7 @@ class ModernLibraryBrowserView: NSView {
         guard let artist = sender.representedObject as? PlexArtist else { return }
         Task { @MainActor in
             do {
-                let albums = try await PlexManager.shared.fetchAlbums(forArtist: artist)
-                var all: [PlexTrack] = []
-                for album in albums { all.append(contentsOf: try await PlexManager.shared.fetchTracks(forAlbum: album)) }
-                if all.isEmpty { all = try await PlexManager.shared.fetchTracks(forArtist: artist) }
+                let all = try await self.fetchTracksForPlexArtistGroup(artist)
                 WindowManager.shared.audioEngine.loadTracks(PlexManager.shared.convertToTracks(all))
             } catch { NSLog("Failed: %@", error.localizedDescription) }
         }
@@ -6769,12 +6766,7 @@ class ModernLibraryBrowserView: NSView {
         guard let artist = sender.representedObject as? PlexArtist else { return }
         Task { @MainActor in
             do {
-                let albums = try await PlexManager.shared.fetchAlbums(forArtist: artist)
-                var allTracks: [PlexTrack] = []
-                for album in albums {
-                    let tracks = try await PlexManager.shared.fetchTracks(forAlbum: album)
-                    allTracks.append(contentsOf: tracks)
-                }
+                let allTracks = try await self.fetchTracksForPlexArtistGroup(artist)
                 let converted = PlexManager.shared.convertToTracks(allTracks)
                 WindowManager.shared.audioEngine.insertTracksAfterCurrent(converted)
             } catch { NSLog("Failed to play artist next: %@", error.localizedDescription) }
@@ -6784,12 +6776,7 @@ class ModernLibraryBrowserView: NSView {
         guard let artist = sender.representedObject as? PlexArtist else { return }
         Task { @MainActor in
             do {
-                let albums = try await PlexManager.shared.fetchAlbums(forArtist: artist)
-                var allTracks: [PlexTrack] = []
-                for album in albums {
-                    let tracks = try await PlexManager.shared.fetchTracks(forAlbum: album)
-                    allTracks.append(contentsOf: tracks)
-                }
+                let allTracks = try await self.fetchTracksForPlexArtistGroup(artist)
                 let converted = PlexManager.shared.convertToTracks(allTracks)
                 let engine = WindowManager.shared.audioEngine
                 let wasEmpty = engine.playlist.isEmpty
@@ -7027,13 +7014,7 @@ class ModernLibraryBrowserView: NSView {
             }
         case .artist(let artist):
             Task { @MainActor in
-                if let albums = try? await PlexManager.shared.fetchAlbums(forArtist: artist) {
-                    var allTracks: [PlexTrack] = []
-                    for album in albums.sorted(by: { ($0.year ?? 0) < ($1.year ?? 0) }) {
-                        if let tracks = try? await PlexManager.shared.fetchTracks(forAlbum: album) {
-                            allTracks.append(contentsOf: tracks)
-                        }
-                    }
+                if let allTracks = try? await self.fetchTracksForPlexArtistGroup(artist) {
                     WindowManager.shared.audioEngine.insertTracksAfterCurrent(PlexManager.shared.convertToTracks(allTracks), startPlaybackIfEmpty: false)
                 }
             }
@@ -7165,13 +7146,7 @@ class ModernLibraryBrowserView: NSView {
             }
         case .artist(let artist):
             Task { @MainActor in
-                if let albums = try? await PlexManager.shared.fetchAlbums(forArtist: artist) {
-                    var allTracks: [PlexTrack] = []
-                    for album in albums.sorted(by: { ($0.year ?? 0) < ($1.year ?? 0) }) {
-                        if let tracks = try? await PlexManager.shared.fetchTracks(forAlbum: album) {
-                            allTracks.append(contentsOf: tracks)
-                        }
-                    }
+                if let allTracks = try? await self.fetchTracksForPlexArtistGroup(artist) {
                     engine.appendTracks(PlexManager.shared.convertToTracks(allTracks))
                 }
             }
@@ -9558,16 +9533,16 @@ class ModernLibraryBrowserView: NSView {
     
     private func buildArtistItems() {
         displayItems.removeAll()
-        let sorted = sortPlexArtists(cachedArtists)
+        let sorted = sortPlexArtists(uniquePlexArtistsByName(cachedArtists))
         for artist in sorted {
-            let expanded = expandedArtists.contains(artist.id)
+            let groupKey = plexArtistGroupKey(for: artist)
+            let expanded = expandedArtists.contains(groupKey)
             let info: String?
-            if let count = artistAlbumCounts[artist.id], count > 0 { info = "\(count) album\(count == 1 ? "" : "s")" }
-            else if let albums = artistAlbums[artist.id] { info = "\(albums.count) album\(albums.count == 1 ? "" : "s")" }
-            else if artist.albumCount > 0 { info = "\(artist.albumCount) album\(artist.albumCount == 1 ? "" : "s")" }
+            if let albums = artistAlbums[groupKey] { info = "\(albums.count) album\(albums.count == 1 ? "" : "s")" }
+            else if let count = plexArtistAlbumCount(for: artist), count > 0 { info = "\(count) album\(count == 1 ? "" : "s")" }
             else { info = nil }
-            displayItems.append(ModernDisplayItem(id: artist.id, title: artist.title, info: info, indentLevel: 0, hasChildren: true, type: .artist(artist)))
-            if expanded, let albums = artistAlbums[artist.id] {
+            displayItems.append(ModernDisplayItem(id: groupKey, title: artist.title, info: info, indentLevel: 0, hasChildren: true, type: .artist(artist)))
+            if expanded, let albums = artistAlbums[groupKey] {
                 for album in sortPlexAlbums(albums) {
                     displayItems.append(ModernDisplayItem(id: album.id, title: album.title, info: album.year.map { String($0) }, indentLevel: 1, hasChildren: true, type: .album(album)))
                     if expandedAlbums.contains(album.id), let tracks = albumTracks[album.id] {
@@ -10537,6 +10512,110 @@ class ModernLibraryBrowserView: NSView {
         default: return artists.sorted { compareNameStrings($0.title, $1.title, ascending: true) }
         }
     }
+
+    private func normalizedPlexArtistName(_ title: String) -> String {
+        title.trimmingCharacters(in: .whitespacesAndNewlines)
+            .folding(options: [.caseInsensitive, .diacriticInsensitive], locale: .current)
+            .lowercased()
+    }
+
+    private func plexArtistGroupKey(for artist: PlexArtist) -> String {
+        "plex-artist-\(normalizedPlexArtistName(artist.title))"
+    }
+
+    private func uniquePlexArtistsByName(_ artists: [PlexArtist]) -> [PlexArtist] {
+        var artistsByName: [String: PlexArtist] = [:]
+        for artist in artists {
+            let key = normalizedPlexArtistName(artist.title)
+            if let existing = artistsByName[key] {
+                if artist.albumCount > existing.albumCount {
+                    artistsByName[key] = artist
+                }
+            } else {
+                artistsByName[key] = artist
+            }
+        }
+        return Array(artistsByName.values)
+    }
+
+    private func plexArtistGroup(for artist: PlexArtist) -> [PlexArtist] {
+        guard browseMode != .search else { return [artist] }
+        let key = normalizedPlexArtistName(artist.title)
+        let matches = cachedArtists.filter { normalizedPlexArtistName($0.title) == key }
+        return matches.isEmpty ? [artist] : matches
+    }
+
+    private func plexArtistAlbumCount(for artist: PlexArtist) -> Int? {
+        let group = plexArtistGroup(for: artist)
+        let memberIds = Set(group.map { $0.id })
+        let cachedGroupAlbums = cachedAlbums.filter { album in
+            guard let parentKey = album.parentKey,
+                  let artistId = extractArtistId(from: parentKey) else { return false }
+            return memberIds.contains(artistId)
+        }
+        if !cachedGroupAlbums.isEmpty {
+            return deduplicatedPlexAlbums(cachedGroupAlbums).count
+        }
+
+        var count = 0
+        var foundCount = false
+        for member in group {
+            if let cached = artistAlbumCounts[member.id], cached > 0 {
+                count += cached
+                foundCount = true
+            } else if member.albumCount > 0 {
+                count += member.albumCount
+                foundCount = true
+            }
+        }
+        return foundCount ? count : nil
+    }
+
+    private func deduplicatedPlexAlbums(_ albums: [PlexAlbum]) -> [PlexAlbum] {
+        var seen = Set<String>()
+        var result: [PlexAlbum] = []
+        for album in albums {
+            let key = "\(normalizedPlexArtistName(album.parentTitle ?? ""))|\(normalizedPlexArtistName(album.title))|\(album.year.map { String($0) } ?? "")"
+            if seen.insert(key).inserted {
+                result.append(album)
+            }
+        }
+        return result
+    }
+
+    private func deduplicatedPlexTracks(_ tracks: [PlexTrack]) -> [PlexTrack] {
+        var seen = Set<String>()
+        var result: [PlexTrack] = []
+        for track in tracks {
+            let key = "\(normalizedPlexArtistName(track.grandparentTitle ?? ""))|\(normalizedPlexArtistName(track.parentTitle ?? ""))|\(normalizedPlexArtistName(track.title))|\(track.parentIndex ?? 1)|\(track.index ?? 0)"
+            if seen.insert(key).inserted {
+                result.append(track)
+            }
+        }
+        return result
+    }
+
+    private func fetchAlbumsForPlexArtistGroup(_ artist: PlexArtist) async throws -> [PlexAlbum] {
+        var albums: [PlexAlbum] = []
+        for member in plexArtistGroup(for: artist) {
+            albums.append(contentsOf: try await PlexManager.shared.fetchAlbums(forArtist: member))
+        }
+        return deduplicatedPlexAlbums(albums)
+    }
+
+    private func fetchTracksForPlexArtistGroup(_ artist: PlexArtist) async throws -> [PlexTrack] {
+        let albums = try await fetchAlbumsForPlexArtistGroup(artist)
+        var tracks: [PlexTrack] = []
+        for album in albums {
+            tracks.append(contentsOf: try await PlexManager.shared.fetchTracks(forAlbum: album))
+        }
+        if tracks.isEmpty {
+            for member in plexArtistGroup(for: artist) {
+                tracks.append(contentsOf: try await PlexManager.shared.fetchTracks(forArtist: member))
+            }
+        }
+        return deduplicatedPlexTracks(tracks)
+    }
     
     private func sortPlexAlbums(_ albums: [PlexAlbum]) -> [PlexAlbum] {
         switch currentSort {
@@ -11018,25 +11097,26 @@ class ModernLibraryBrowserView: NSView {
     private func toggleExpand(_ item: ModernDisplayItem) {
         switch item.type {
         case .artist(let artist):
-            if expandedArtists.contains(artist.id) { expandedArtists.remove(artist.id) }
+            let groupKey = item.id
+            if expandedArtists.contains(groupKey) { expandedArtists.remove(groupKey) }
             else {
-                expandedArtists.insert(artist.id)
-                if artistAlbums[artist.id] == nil {
+                expandedArtists.insert(groupKey)
+                if artistAlbums[groupKey] == nil {
                     Task { @MainActor in
                         do {
-                            NSLog("ModernLibraryBrowser: Fetching albums for artist '%@' (id=%@)", artist.title, artist.id)
-                            let albums = try await PlexManager.shared.fetchAlbums(forArtist: artist)
-                            if albums.isEmpty && artist.albumCount > 0 {
-                                NSLog("ModernLibraryBrowser: Warning - API returned 0 albums for '%@' (id=%@) but albumCount=%d - allowing retry", artist.title, artist.id, artist.albumCount)
-                                expandedArtists.remove(artist.id)
+                            NSLog("ModernLibraryBrowser: Fetching albums for artist group '%@' (key=%@)", artist.title, groupKey)
+                            let albums = try await self.fetchAlbumsForPlexArtistGroup(artist)
+                            if albums.isEmpty && (self.plexArtistAlbumCount(for: artist) ?? 0) > 0 {
+                                NSLog("ModernLibraryBrowser: Warning - API returned 0 albums for artist group '%@' (key=%@) - allowing retry", artist.title, groupKey)
+                                expandedArtists.remove(groupKey)
                             } else {
-                                NSLog("ModernLibraryBrowser: Loaded %d albums for '%@' (id=%@)", albums.count, artist.title, artist.id)
-                                artistAlbums[artist.id] = albums
+                                NSLog("ModernLibraryBrowser: Loaded %d albums for artist group '%@' (key=%@)", albums.count, artist.title, groupKey)
+                                artistAlbums[groupKey] = albums
                             }
                             rebuildCurrentModeItems()
                         } catch {
-                            NSLog("ModernLibraryBrowser: Failed to load albums for '%@' (id=%@): %@", artist.title, artist.id, error.localizedDescription)
-                            expandedArtists.remove(artist.id)
+                            NSLog("ModernLibraryBrowser: Failed to load albums for artist group '%@' (key=%@): %@", artist.title, groupKey, error.localizedDescription)
+                            expandedArtists.remove(groupKey)
                             rebuildCurrentModeItems()
                         }
                     }; return
@@ -11370,14 +11450,7 @@ class ModernLibraryBrowserView: NSView {
     private func playArtist(_ artist: PlexArtist) {
         Task { @MainActor in
             do {
-                let albums = try await PlexManager.shared.fetchAlbums(forArtist: artist)
-                var all: [PlexTrack] = []
-                for album in albums { all.append(contentsOf: try await PlexManager.shared.fetchTracks(forAlbum: album)) }
-                // Last-resort fallback: if no tracks found via albums, fetch tracks directly
-                if all.isEmpty {
-                    NSLog("ModernLibraryBrowser: No tracks found via albums for '%@', trying direct track fetch", artist.title)
-                    all = try await PlexManager.shared.fetchTracks(forArtist: artist)
-                }
+                let all = try await fetchTracksForPlexArtistGroup(artist)
                 WindowManager.shared.audioEngine.playNow(PlexManager.shared.convertToTracks(all))
             } catch { NSLog("Failed: %@", error.localizedDescription) }
         }
@@ -12100,7 +12173,14 @@ extension ModernDisplayItem {
         case .jellyfinAlbum(let a): return jellyfinAlbumValue(a, for: column)
         case .embyAlbum(let a): return embyAlbumValue(a, for: column)
         case .localAlbum(let a): return localAlbumValue(a, for: column)
-        case .artist(let a): return plexArtistValue(a, for: column)
+        case .artist(let a):
+            if column.id == "albums",
+               let info,
+               let first = info.split(separator: " ").first,
+               let count = Int(first) {
+                return String(count)
+            }
+            return plexArtistValue(a, for: column)
         case .subsonicArtist(let a):
             if column.id == "albums" { return String(a.albumCount) }
             if column.id == "rating" { return a.starred != nil ? "★★★★★" : "" }

--- a/Sources/NullPlayer/Windows/ModernLibraryBrowser/ModernLibraryBrowserView.swift
+++ b/Sources/NullPlayer/Windows/ModernLibraryBrowser/ModernLibraryBrowserView.swift
@@ -10550,7 +10550,10 @@ class ModernLibraryBrowserView: NSView {
             groups = plexArtistGroupsByName
         }
         let representatives = groups.values.compactMap { group in
-            group.max { lhs, rhs in lhs.albumCount < rhs.albumCount }
+            // Highest albumCount wins; ties broken by smallest id for a deterministic representative.
+            group.max { lhs, rhs in
+                lhs.albumCount != rhs.albumCount ? lhs.albumCount < rhs.albumCount : lhs.id > rhs.id
+            }
         }
         return representatives
     }

--- a/Sources/NullPlayer/Windows/PlexBrowser/PlexBrowserView.swift
+++ b/Sources/NullPlayer/Windows/PlexBrowser/PlexBrowserView.swift
@@ -1025,6 +1025,9 @@ class PlexBrowserView: NSView {
     private var artistAlbums: [String: [PlexAlbum]] = [:]
     private var albumTracks: [String: [PlexTrack]] = [:]
     private var artistAlbumCounts: [String: Int] = [:]  // Album count per artist (from parentKey)
+    private var plexArtistGroupsByName: [String: [PlexArtist]] = [:]
+    private var plexAlbumsByArtistGroupKey: [String: [PlexAlbum]] = [:]
+    private var plexAlbumCountsByArtistGroupKey: [String: Int] = [:]
     
     /// Paginated local library state
     private var localArtistPageOffset = 0
@@ -13739,12 +13742,29 @@ class PlexBrowserView: NSView {
     
     private func buildArtistAlbumCounts() {
         artistAlbumCounts.removeAll()
+        plexArtistGroupsByName = Dictionary(grouping: cachedArtists, by: { normalizedPlexArtistName($0.title) })
+        plexAlbumsByArtistGroupKey.removeAll()
+        plexAlbumCountsByArtistGroupKey.removeAll()
+
+        var artistsById: [String: PlexArtist] = [:]
+        for artist in cachedArtists {
+            artistsById[artist.id] = artist
+        }
         for album in cachedAlbums {
             // Albums have parentKey which is the artist's key (e.g., "/library/metadata/12345")
             // Extract the artist ID from parentKey, handling various Plex server formats
             if let parentKey = album.parentKey, let artistId = extractArtistId(from: parentKey) {
                 artistAlbumCounts[artistId, default: 0] += 1
+                if let artist = artistsById[artistId] {
+                    plexAlbumsByArtistGroupKey[plexArtistGroupKey(for: artist), default: []].append(album)
+                }
             }
+        }
+
+        for (groupKey, albums) in plexAlbumsByArtistGroupKey {
+            let deduplicated = deduplicatedPlexAlbums(albums)
+            plexAlbumsByArtistGroupKey[groupKey] = deduplicated
+            plexAlbumCountsByArtistGroupKey[groupKey] = deduplicated.count
         }
     }
     
@@ -16032,28 +16052,28 @@ class PlexBrowserView: NSView {
     }
 
     private func uniquePlexArtistsByName(_ artists: [PlexArtist]) -> [PlexArtist] {
-        var artistsByName: [String: PlexArtist] = [:]
-        for artist in artists {
-            let key = normalizedPlexArtistName(artist.title)
-            if let existing = artistsByName[key] {
-                if artist.albumCount > existing.albumCount {
-                    artistsByName[key] = artist
-                }
-            } else {
-                artistsByName[key] = artist
-            }
+        var groups = Dictionary(grouping: artists, by: { normalizedPlexArtistName($0.title) })
+        if artists.count == cachedArtists.count && !plexArtistGroupsByName.isEmpty {
+            groups = plexArtistGroupsByName
         }
-        return Array(artistsByName.values)
+        return groups.values.compactMap { group in
+            group.max { lhs, rhs in lhs.albumCount < rhs.albumCount }
+        }
     }
 
     private func plexArtistGroup(for artist: PlexArtist) -> [PlexArtist] {
         guard browseMode != .search else { return [artist] }
         let key = normalizedPlexArtistName(artist.title)
-        let matches = cachedArtists.filter { normalizedPlexArtistName($0.title) == key }
+        let matches = plexArtistGroupsByName[key] ?? cachedArtists.filter { normalizedPlexArtistName($0.title) == key }
         return matches.isEmpty ? [artist] : matches
     }
 
     private func plexArtistAlbumCount(for artist: PlexArtist) -> Int? {
+        let groupKey = plexArtistGroupKey(for: artist)
+        if let count = plexAlbumCountsByArtistGroupKey[groupKey], count > 0 {
+            return count
+        }
+
         let group = plexArtistGroup(for: artist)
         let memberIds = Set(group.map { $0.id })
         let cachedGroupAlbums = cachedAlbums.filter { album in
@@ -16104,6 +16124,11 @@ class PlexBrowserView: NSView {
     }
 
     private func fetchAlbumsForPlexArtistGroup(_ artist: PlexArtist) async throws -> [PlexAlbum] {
+        let groupKey = plexArtistGroupKey(for: artist)
+        if let cached = plexAlbumsByArtistGroupKey[groupKey], !cached.isEmpty {
+            return cached
+        }
+
         var albums: [PlexAlbum] = []
         for member in plexArtistGroup(for: artist) {
             albums.append(contentsOf: try await PlexManager.shared.fetchAlbums(forArtist: member))

--- a/Sources/NullPlayer/Windows/PlexBrowser/PlexBrowserView.swift
+++ b/Sources/NullPlayer/Windows/PlexBrowser/PlexBrowserView.swift
@@ -9984,7 +9984,7 @@ class PlexBrowserView: NSView {
             queueItem.representedObject = artist
             menu.addItem(queueItem)
             
-            let expandItem = NSMenuItem(title: expandedArtists.contains(artist.id) ? "Collapse" : "Expand", action: #selector(contextMenuToggleExpand(_:)), keyEquivalent: "")
+            let expandItem = NSMenuItem(title: expandedArtists.contains(item.id) ? "Collapse" : "Expand", action: #selector(contextMenuToggleExpand(_:)), keyEquivalent: "")
             expandItem.target = self
             expandItem.representedObject = item
             menu.addItem(expandItem)
@@ -11011,10 +11011,7 @@ class PlexBrowserView: NSView {
         guard let artist = sender.representedObject as? PlexArtist else { return }
         Task { @MainActor in
             do {
-                let albums = try await PlexManager.shared.fetchAlbums(forArtist: artist)
-                var all: [PlexTrack] = []
-                for album in albums { all.append(contentsOf: try await PlexManager.shared.fetchTracks(forAlbum: album)) }
-                if all.isEmpty { all = try await PlexManager.shared.fetchTracks(forArtist: artist) }
+                let all = try await self.fetchTracksForPlexArtistGroup(artist)
                 WindowManager.shared.audioEngine.loadTracks(PlexManager.shared.convertToTracks(all))
             } catch { NSLog("Failed: %@", error.localizedDescription) }
         }
@@ -11878,12 +11875,7 @@ class PlexBrowserView: NSView {
         guard let artist = sender.representedObject as? PlexArtist else { return }
         Task { @MainActor in
             do {
-                let albums = try await PlexManager.shared.fetchAlbums(forArtist: artist)
-                var allTracks: [PlexTrack] = []
-                for album in albums {
-                    let tracks = try await PlexManager.shared.fetchTracks(forAlbum: album)
-                    allTracks.append(contentsOf: tracks)
-                }
+                let allTracks = try await self.fetchTracksForPlexArtistGroup(artist)
                 let converted = PlexManager.shared.convertToTracks(allTracks)
                 WindowManager.shared.audioEngine.insertTracksAfterCurrent(converted)
             } catch { NSLog("Failed to play artist next: %@", error.localizedDescription) }
@@ -11893,12 +11885,7 @@ class PlexBrowserView: NSView {
         guard let artist = sender.representedObject as? PlexArtist else { return }
         Task { @MainActor in
             do {
-                let albums = try await PlexManager.shared.fetchAlbums(forArtist: artist)
-                var allTracks: [PlexTrack] = []
-                for album in albums {
-                    let tracks = try await PlexManager.shared.fetchTracks(forAlbum: album)
-                    allTracks.append(contentsOf: tracks)
-                }
+                let allTracks = try await self.fetchTracksForPlexArtistGroup(artist)
                 let converted = PlexManager.shared.convertToTracks(allTracks)
                 let engine = WindowManager.shared.audioEngine
                 let wasEmpty = engine.playlist.isEmpty
@@ -12154,13 +12141,7 @@ class PlexBrowserView: NSView {
             }
         case .artist(let artist):
             Task { @MainActor in
-                if let albums = try? await PlexManager.shared.fetchAlbums(forArtist: artist) {
-                    var allTracks: [PlexTrack] = []
-                    for album in albums {
-                        if let tracks = try? await PlexManager.shared.fetchTracks(forAlbum: album) {
-                            allTracks.append(contentsOf: tracks)
-                        }
-                    }
+                if let allTracks = try? await self.fetchTracksForPlexArtistGroup(artist) {
                     WindowManager.shared.audioEngine.insertTracksAfterCurrent(PlexManager.shared.convertToTracks(allTracks))
                 }
             }
@@ -12298,13 +12279,7 @@ class PlexBrowserView: NSView {
             }
         case .artist(let artist):
             Task { @MainActor in
-                if let albums = try? await PlexManager.shared.fetchAlbums(forArtist: artist) {
-                    var allTracks: [PlexTrack] = []
-                    for album in albums {
-                        if let tracks = try? await PlexManager.shared.fetchTracks(forAlbum: album) {
-                            allTracks.append(contentsOf: tracks)
-                        }
-                    }
+                if let allTracks = try? await self.fetchTracksForPlexArtistGroup(artist) {
                     let converted = PlexManager.shared.convertToTracks(allTracks)
                     let wasEmpty = engine.playlist.isEmpty
                     engine.appendTracks(converted)
@@ -13777,29 +13752,27 @@ class PlexBrowserView: NSView {
         displayItems.removeAll()
         
         // Sort artists
-        let sortedArtists = sortPlexArtists(cachedArtists)
+        let sortedArtists = sortPlexArtists(uniquePlexArtistsByName(cachedArtists))
         
         for artist in sortedArtists {
-            let isExpanded = expandedArtists.contains(artist.id)
+            let groupKey = plexArtistGroupKey(for: artist)
+            let isExpanded = expandedArtists.contains(groupKey)
             
             // Show album count - prefer counted from albums, then API count, then fetched albums
             let info: String?
-            if let count = artistAlbumCounts[artist.id], count > 0 {
-                // We have a count from the albums fetch
-                info = "\(count) \(count == 1 ? "album" : "albums")"
-            } else if let albums = artistAlbums[artist.id] {
+            if let albums = artistAlbums[groupKey] {
                 // We've expanded this artist - show actual count
                 info = "\(albums.count) \(albums.count == 1 ? "album" : "albums")"
-            } else if artist.albumCount > 0 {
+            } else if let count = plexArtistAlbumCount(for: artist), count > 0 {
                 // API returned a count
-                info = "\(artist.albumCount) \(artist.albumCount == 1 ? "album" : "albums")"
+                info = "\(count) \(count == 1 ? "album" : "albums")"
             } else {
                 // No count available - show nothing
                 info = nil
             }
             
             displayItems.append(PlexDisplayItem(
-                id: artist.id,
+                id: groupKey,
                 title: artist.title,
                 info: info,
                 indentLevel: 0,
@@ -13807,7 +13780,7 @@ class PlexBrowserView: NSView {
                 type: .artist(artist)
             ))
             
-            if isExpanded, let albums = artistAlbums[artist.id] {
+            if isExpanded, let albums = artistAlbums[groupKey] {
                 // Sort albums within artist
                 let sortedAlbums = sortPlexAlbums(albums)
                 for album in sortedAlbums {
@@ -16048,6 +16021,110 @@ class PlexBrowserView: NSView {
         }
     }
 
+    private func normalizedPlexArtistName(_ title: String) -> String {
+        title.trimmingCharacters(in: .whitespacesAndNewlines)
+            .folding(options: [.caseInsensitive, .diacriticInsensitive], locale: .current)
+            .lowercased()
+    }
+
+    private func plexArtistGroupKey(for artist: PlexArtist) -> String {
+        "plex-artist-\(normalizedPlexArtistName(artist.title))"
+    }
+
+    private func uniquePlexArtistsByName(_ artists: [PlexArtist]) -> [PlexArtist] {
+        var artistsByName: [String: PlexArtist] = [:]
+        for artist in artists {
+            let key = normalizedPlexArtistName(artist.title)
+            if let existing = artistsByName[key] {
+                if artist.albumCount > existing.albumCount {
+                    artistsByName[key] = artist
+                }
+            } else {
+                artistsByName[key] = artist
+            }
+        }
+        return Array(artistsByName.values)
+    }
+
+    private func plexArtistGroup(for artist: PlexArtist) -> [PlexArtist] {
+        guard browseMode != .search else { return [artist] }
+        let key = normalizedPlexArtistName(artist.title)
+        let matches = cachedArtists.filter { normalizedPlexArtistName($0.title) == key }
+        return matches.isEmpty ? [artist] : matches
+    }
+
+    private func plexArtistAlbumCount(for artist: PlexArtist) -> Int? {
+        let group = plexArtistGroup(for: artist)
+        let memberIds = Set(group.map { $0.id })
+        let cachedGroupAlbums = cachedAlbums.filter { album in
+            guard let parentKey = album.parentKey,
+                  let artistId = extractArtistId(from: parentKey) else { return false }
+            return memberIds.contains(artistId)
+        }
+        if !cachedGroupAlbums.isEmpty {
+            return deduplicatedPlexAlbums(cachedGroupAlbums).count
+        }
+
+        var count = 0
+        var foundCount = false
+        for member in group {
+            if let cached = artistAlbumCounts[member.id], cached > 0 {
+                count += cached
+                foundCount = true
+            } else if member.albumCount > 0 {
+                count += member.albumCount
+                foundCount = true
+            }
+        }
+        return foundCount ? count : nil
+    }
+
+    private func deduplicatedPlexAlbums(_ albums: [PlexAlbum]) -> [PlexAlbum] {
+        var seen = Set<String>()
+        var result: [PlexAlbum] = []
+        for album in albums {
+            let key = "\(normalizedPlexArtistName(album.parentTitle ?? ""))|\(normalizedPlexArtistName(album.title))|\(album.year.map { String($0) } ?? "")"
+            if seen.insert(key).inserted {
+                result.append(album)
+            }
+        }
+        return result
+    }
+
+    private func deduplicatedPlexTracks(_ tracks: [PlexTrack]) -> [PlexTrack] {
+        var seen = Set<String>()
+        var result: [PlexTrack] = []
+        for track in tracks {
+            let key = "\(normalizedPlexArtistName(track.grandparentTitle ?? ""))|\(normalizedPlexArtistName(track.parentTitle ?? ""))|\(normalizedPlexArtistName(track.title))|\(track.parentIndex ?? 1)|\(track.index ?? 0)"
+            if seen.insert(key).inserted {
+                result.append(track)
+            }
+        }
+        return result
+    }
+
+    private func fetchAlbumsForPlexArtistGroup(_ artist: PlexArtist) async throws -> [PlexAlbum] {
+        var albums: [PlexAlbum] = []
+        for member in plexArtistGroup(for: artist) {
+            albums.append(contentsOf: try await PlexManager.shared.fetchAlbums(forArtist: member))
+        }
+        return deduplicatedPlexAlbums(albums)
+    }
+
+    private func fetchTracksForPlexArtistGroup(_ artist: PlexArtist) async throws -> [PlexTrack] {
+        let albums = try await fetchAlbumsForPlexArtistGroup(artist)
+        var tracks: [PlexTrack] = []
+        for album in albums {
+            tracks.append(contentsOf: try await PlexManager.shared.fetchTracks(forAlbum: album))
+        }
+        if tracks.isEmpty {
+            for member in plexArtistGroup(for: artist) {
+                tracks.append(contentsOf: try await PlexManager.shared.fetchTracks(forArtist: member))
+            }
+        }
+        return deduplicatedPlexTracks(tracks)
+    }
+
     private func sortPlexPlaylists(_ playlists: [PlexPlaylist]) -> [PlexPlaylist] {
         switch currentSort {
         case .nameAsc:
@@ -16912,30 +16989,32 @@ class PlexBrowserView: NSView {
                     }
                 }
             } else {
-                // Normal mode - track by ID
-                if expandedArtists.contains(artist.id) {
-                    expandedArtists.remove(artist.id)
+                // Normal mode tracks the grouped display row so same-name Plex
+                // artist records expand together without hiding any albums.
+                let groupKey = item.id
+                if expandedArtists.contains(groupKey) {
+                    expandedArtists.remove(groupKey)
                 } else {
-                    expandedArtists.insert(artist.id)
-                    if artistAlbums[artist.id] == nil {
+                    expandedArtists.insert(groupKey)
+                    if artistAlbums[groupKey] == nil {
                         Task { @MainActor in
                             do {
-                                NSLog("PlexBrowser: Fetching albums for artist '%@' (id=%@)", artist.title, artist.id)
-                                let albums = try await PlexManager.shared.fetchAlbums(forArtist: artist)
-                                if albums.isEmpty && artist.albumCount > 0 {
-                                    NSLog("PlexBrowser: Warning - API returned 0 albums for '%@' (id=%@) but albumCount=%d - allowing retry", artist.title, artist.id, artist.albumCount)
+                                NSLog("PlexBrowser: Fetching albums for artist group '%@' (key=%@)", artist.title, groupKey)
+                                let albums = try await self.fetchAlbumsForPlexArtistGroup(artist)
+                                if albums.isEmpty && (self.plexArtistAlbumCount(for: artist) ?? 0) > 0 {
+                                    NSLog("PlexBrowser: Warning - API returned 0 albums for artist group '%@' (key=%@) - allowing retry", artist.title, groupKey)
                                     // Don't cache empty result so user can retry
-                                    expandedArtists.remove(artist.id)
+                                    expandedArtists.remove(groupKey)
                                 } else {
-                                    NSLog("PlexBrowser: Loaded %d albums for '%@' (id=%@)", albums.count, artist.title, artist.id)
-                                    artistAlbums[artist.id] = albums
+                                    NSLog("PlexBrowser: Loaded %d albums for artist group '%@' (key=%@)", albums.count, artist.title, groupKey)
+                                    artistAlbums[groupKey] = albums
                                 }
                                 rebuildCurrentModeItems()
                                 needsDisplay = true
                             } catch {
-                                NSLog("PlexBrowser: Failed to load albums for '%@' (id=%@): %@", artist.title, artist.id, error.localizedDescription)
+                                NSLog("PlexBrowser: Failed to load albums for artist group '%@' (key=%@): %@", artist.title, groupKey, error.localizedDescription)
                                 // Remove from expanded so user can retry
-                                expandedArtists.remove(artist.id)
+                                expandedArtists.remove(groupKey)
                                 rebuildCurrentModeItems()
                                 needsDisplay = true
                             }
@@ -17568,19 +17647,7 @@ class PlexBrowserView: NSView {
     private func playArtist(_ artist: PlexArtist) {
         Task { @MainActor in
             do {
-                let albums = try await PlexManager.shared.fetchAlbums(forArtist: artist)
-                var allTracks: [PlexTrack] = []
-                for album in albums {
-                    let tracks = try await PlexManager.shared.fetchTracks(forAlbum: album)
-                    allTracks.append(contentsOf: tracks)
-                }
-                
-                // Last-resort fallback: if no tracks found via albums, fetch tracks directly
-                if allTracks.isEmpty {
-                    NSLog("PlexBrowser: No tracks found via albums for '%@', trying direct track fetch", artist.title)
-                    allTracks = try await PlexManager.shared.fetchTracks(forArtist: artist)
-                }
-                
+                let allTracks = try await fetchTracksForPlexArtistGroup(artist)
                 let convertedTracks = PlexManager.shared.convertToTracks(allTracks)
                 NSLog("Playing artist %@ with %d tracks", artist.title, convertedTracks.count)
                 WindowManager.shared.audioEngine.playNow(convertedTracks)
@@ -18669,6 +18736,12 @@ extension PlexDisplayItem {
         case .localAlbum(let album):
             return localAlbumValue(album, for: column)
         case .artist(let artist):
+            if column.id == "albums",
+               let info,
+               let first = info.split(separator: " ").first,
+               let count = Int(first) {
+                return String(count)
+            }
             return plexArtistValue(artist, for: column)
         case .subsonicArtist(let artist):
             return subsonicArtistValue(artist, for: column)

--- a/Sources/NullPlayer/Windows/PlexBrowser/PlexBrowserView.swift
+++ b/Sources/NullPlayer/Windows/PlexBrowser/PlexBrowserView.swift
@@ -16057,7 +16057,10 @@ class PlexBrowserView: NSView {
             groups = plexArtistGroupsByName
         }
         return groups.values.compactMap { group in
-            group.max { lhs, rhs in lhs.albumCount < rhs.albumCount }
+            // Highest albumCount wins; ties broken by smallest id for a deterministic representative.
+            group.max { lhs, rhs in
+                lhs.albumCount != rhs.albumCount ? lhs.albumCount < rhs.albumCount : lhs.id > rhs.id
+            }
         }
     }
 

--- a/skills/plex-integration/SKILL.md
+++ b/skills/plex-integration/SKILL.md
@@ -58,6 +58,19 @@ Type values:
 | 1 | Movies |
 | 2 | TV Shows |
 
+## Library Browser Artist Grouping
+
+Plex can expose multiple artist records with the same display name but different `ratingKey` values. In the Library Browser, normal Plex artist browsing shows one visible row per normalized artist name while keeping every underlying Plex artist record reachable.
+
+Current behavior in both classic `PlexBrowserView` and modern `ModernLibraryBrowserView`:
+
+- Normalize artist names with lowercase + trimmed whitespace and use `plex-artist-{normalizedName}` as the grouped display key.
+- Pick the visible representative from the same-name group by highest `albumCount`.
+- When expanding, playing, or queueing a grouped row, fan out across every artist record in the group and then deduplicate albums/tracks by stable metadata keys.
+- Search mode intentionally treats the selected Plex artist as a single record instead of expanding all same-name records.
+
+Performance requirement: build group indexes once when artist/album counts are rebuilt. `buildArtistAlbumCounts()` should populate `plexArtistGroupsByName`, `plexAlbumsByArtistGroupKey`, and `plexAlbumCountsByArtistGroupKey` from `cachedArtists` and `cachedAlbums`. Expanding a grouped artist row should first use `plexAlbumsByArtistGroupKey[groupKey]` and avoid rescanning the full album cache on the main actor, because large same-name groups can otherwise beachball the UI.
+
 ## Popular Tracks (Last.fm Integration)
 
 Plex identifies "hit" tracks using the `ratingCount` field, which contains **global popularity data from Last.fm** - the number of unique listeners who have scrobbled the track worldwide.

--- a/skills/plex-integration/SKILL.md
+++ b/skills/plex-integration/SKILL.md
@@ -64,7 +64,7 @@ Plex can expose multiple artist records with the same display name but different
 
 Current behavior in both classic `PlexBrowserView` and modern `ModernLibraryBrowserView`:
 
-- Normalize artist names with lowercase + trimmed whitespace and use `plex-artist-{normalizedName}` as the grouped display key.
+- Normalize artist names with trimmed whitespace, case-insensitive + diacritic-insensitive folding, and lowercasing (so e.g. "Motörhead" groups with "Motorhead"), then use `plex-artist-{normalizedName}` as the grouped display key.
 - Pick the visible representative from the same-name group by highest `albumCount`.
 - When expanding, playing, or queueing a grouped row, fan out across every artist record in the group and then deduplicate albums/tracks by stable metadata keys.
 - Search mode intentionally treats the selected Plex artist as a single record instead of expanding all same-name records.

--- a/skills/ui-guide/SKILL.md
+++ b/skills/ui-guide/SKILL.md
@@ -640,7 +640,7 @@ These are subtle and only reproduce with multiple Spaces / a fullscreen app on a
 
 - `exitCompactMode` restores asynchronously (state stays `.exiting` until a deferred block), so a synchronous re-enter hits the `.regular` guard and is silently dropped. `exitCompactMode` is **completion-based**; run the teardown/rebuild/re-enter inside the completion.
 - Pass `exitCompactMode(restoreRegularWindows: false)` on this path: re-showing the still-hidden `.managed` regular windows would pull the user to whatever Space they live on. Derive the rebuild snapshot from the pre-compact capture (`modeDependentLayout(from: regularWindowSnapshot)`) instead of the live (hidden) windows.
-- `enterCompactMode()` re-captures `regularWindowSnapshot` from the live windows, which **loses the mode-independent windows** (video player, debug console, app panels — they survive teardown but stay hidden). Carry those fields forward with `reapplyModeIndependentWindows(from:)` after the rebuild, or a video player open before the switch won't restore on the eventual Compact-Mode exit.
+- `enterCompactMode()` re-captures `regularWindowSnapshot` from the live windows, which **loses hidden mode-independent app panels** (they survive teardown but stay hidden). Carry those fields forward with `reapplyModeIndependentWindows(from:)` after the rebuild. The video player and debug console are exempt from Compact Mode hiding and stay visible throughout.
 
 ### Compact window reveal positioning
 

--- a/skills/user-guide/SKILL.md
+++ b/skills/user-guide/SKILL.md
@@ -77,7 +77,7 @@ Windows automatically snap together when dragged near each other:
 - Left-clicking the status-bar item toggles the compact window shown/hidden. Right-clicking opens the Compact Mode menu.
 - The compact window opens at the top-right of the screen, aligned directly below the menu bar with no extra gap.
 - The sole window is the **Library Browser** with a stripped-down player bar embedded across the top (transport, seek + time, a scrolling title marquee, and volume), built from the active UI's own components (classic skin sprites in classic, modern controls in modern).
-- All other windows (Main, EQ, Playlist, Spectrum, etc.) are hidden; their prior visibility is remembered and restored when you exit. **Exception:** the video player window is allowed in Compact Mode — a playing video stays visible on entry, and videos opened while compact (e.g. a downloaded YouTube video) appear normally.
+- All other windows (Main, EQ, Playlist, Spectrum, etc.) are hidden; their prior visibility is remembered and restored when you exit. **Exceptions:** the video player and debug console windows are allowed in Compact Mode — a playing video stays visible on entry, videos opened while compact (e.g. a downloaded YouTube video) appear normally, and an open debug console remains visible.
 - Exiting restores the Dock icon, the macOS menu bar, and the previously open windows.
 
 ### Main Window Elements


### PR DESCRIPTION
## Summary
- group same-name Plex artist records into one visible Artists row in classic and modern library browsers
- fan out expand/play/queue actions across all grouped Plex ratingKeys so albums and tracks are not hidden
- precompute grouped Plex artist/album indexes so expanding large artists does not beachball the app
- shrink Compact Mode art-view rating stars so they fit beside the source/library picker
- add 0.26.2 changelog notes and roll in the GPL-3.0-only/branding clarification in LICENSE and README

## Tests
- swift build
- swift test

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added a Playback **Balance** submenu with a balance slider and left/center/right presets.
  * Balance applies to both local and streaming playback (reset to center each launch).

* **Bug Fixes**
  * Improved Plex Library Browser “duplicate artist” handling by grouping same-named artists into one visible row while still expanding/playing/queuing all matches.
  * Reduced UI stalling when expanding large grouped Plex artists; improved compact-mode library art star sizing.
  * Refined Compact Mode handling so the video player and debug console stay visible as intended.

* **Documentation**
  * Updated GPL license wording and clarified NullPlayer branding/trademark restrictions.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->
