### PR TITLE
Add floating Compact Window

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## 0.27.0
 
+### New Features
+
+- **Compact Window adds a free-floating mini player** — the Windows menu and main-window context menu now include **Compact Window**, which uses the same compact Library Browser mini-player as Compact Mode but keeps NullPlayer as a regular Dock/menu-bar app. It hides only the main window, leaves Playlist/EQ/Spectrum/Library/visualization windows where they are, uses normal window level unless Always on Top is enabled, can be dragged from both the player bar and browser area, remembers its frame, and restores across launches.
+
 ### Improvements
 
 - **Modern and Metal UI now use a modern system font** — the retro low-fi bitmap font (Departure Mono) has been replaced throughout the Modern and Metal windows — Library tabs and headers, the main window, playlist, EQ, and spectrum — with the crisp macOS system font. Time and track digits stay monospaced so they don't jitter. Skins that ship their own custom font still render it as before.
@@ -18,6 +22,7 @@
 - **Metal skin transport icons are now fully filled** — the previous/next (and eject) icons in the Metal finishes no longer show a stray light vertical line: the icon bars now draw in the same transport-button color as the rest of the glyph instead of the skin's light primary color.
 - **Plex Artists no longer show duplicate same-name rows** — the Library Browser now groups Plex artist records with the same display name into one visible artist row in both classic and modern UI. Expanding, playing, or queueing that row still fans out across every underlying Plex `ratingKey`, so albums and tracks attached to duplicate server-side artist records remain accessible instead of being hidden.
 - **Compact Mode art ratings fit the small UI** — the modern Library Browser's art-view rating stars now shrink in Compact Mode, preventing them from crowding or overlapping the source/library picker row.
+- **Compact Window no longer reopens the main window after Space switches** — returning from another desktop or fullscreen app now focuses the floating compact mini-player instead of treating the hidden main window as something to restore, so Compact Window stays a one-window main-player replacement until you exit it.
 - **Library window remembers where you put it** — after unlocking the connected windows and moving the Library/browser window, it now reopens at the exact position and size you left it — across closing and reopening it (via the menu or the red close button) and across full app restarts, even when it was closed at quit. First-ever opens still dock to the right of the window stack, and the position survives Compact Mode. Playlist, EQ, and Spectrum still intentionally snap back into the column below the main window.
 - **Classic Large UI toggles instantly — no restart** — turning Large UI on or off in the classic skin now resizes the windows in place, matching the modern UI, instead of asking you to relaunch. The player, EQ, playlist, and other windows redraw crisply at the new size (no leftover "ghost" of the old size), and switching between Classic, Modern, and Metal while Large UI is on no longer distorts the new look.
 - **ProjectM visualizer recovers from a preset that crashes mid-playback** — a rare bug inside the MilkDrop preset engine could crash the app while a preset was on screen — including minutes into a track, not just when the preset first appeared. The crash-guard now watches a preset for its entire time on screen (previously only its first frame), so the offending preset is automatically skipped on the next launch and the crash never recurs. Normal quits never flag a good preset.

--- a/Sources/NullPlayer/App/AppDelegate.swift
+++ b/Sources/NullPlayer/App/AppDelegate.swift
@@ -69,15 +69,17 @@ class AppDelegate: NSObject, NSApplicationDelegate {
         // entered only after the asynchronous window restoration has completed, so it
         // can capture and hide the actual restored window set.
         let shouldRestoreCompactMode = UserDefaults.standard.bool(forKey: "compactModeEnabled")
+        let shouldRestoreCompactWindow = !shouldRestoreCompactMode
+            && UserDefaults.standard.bool(forKey: "compactWindowEnabled")
 
         // Create the main window, but only reveal it when we are NOT launching straight into
-        // the menu-bar Compact Mode — otherwise the regular window flashes onscreen before
-        // compact mode hides it (~0.1s later, after async restore completes).
-        windowManager.showMainWindow(reveal: !shouldRestoreCompactMode)
+        // Compact Mode / Compact Window — otherwise the regular window flashes onscreen before
+        // the compact surface hides it (~0.1s later, after async restore completes).
+        windowManager.showMainWindow(reveal: !shouldRestoreCompactMode && !shouldRestoreCompactWindow)
 
         // Bring app to foreground after windows are created (skip when starting in Compact
-        // Mode, where the app is a menu-bar accessory and the main window stays hidden).
-        if !shouldRestoreCompactMode {
+        // Mode/Window, where the main window stays hidden until the compact surface is ready).
+        if !shouldRestoreCompactMode && !shouldRestoreCompactWindow {
             NSApp.activate(ignoringOtherApps: true)
             windowManager.mainWindowController?.window?.makeKeyAndOrderFront(nil)
         }
@@ -89,10 +91,14 @@ class AppDelegate: NSObject, NSApplicationDelegate {
         CastManager.shared.startDiscovery()
 
         AppStateManager.shared.restoreSettingsState { [weak self] in
-            guard shouldRestoreCompactMode else { return }
-            // The main window was created but never revealed, so force its snapshot to
-            // "visible" — exiting Compact Mode must restore it onscreen.
-            self?.windowManager.enterCompactMode(revealWindow: false, treatMainAsVisible: true)
+            if shouldRestoreCompactMode {
+                // The main window was created but never revealed, so force its snapshot to
+                // "visible" — exiting Compact Mode must restore it onscreen.
+                self?.windowManager.enterCompactMode(revealWindow: false, treatMainAsVisible: true)
+            } else if shouldRestoreCompactWindow {
+                self?.windowManager.enterCompactWindow(treatMainAsVisible: true)
+                NSApp.activate(ignoringOtherApps: true)
+            }
         }
         
         // Mark app as ready for file opens
@@ -196,7 +202,7 @@ class AppDelegate: NSObject, NSApplicationDelegate {
     }
     
     func applicationShouldHandleReopen(_ sender: NSApplication, hasVisibleWindows flag: Bool) -> Bool {
-        windowManager.mainWindowController?.window?.makeKeyAndOrderFront(nil)
+        windowManager.handleAppReopen()
         return true
     }
     

--- a/Sources/NullPlayer/App/ContextMenuBuilder.swift
+++ b/Sources/NullPlayer/App/ContextMenuBuilder.swift
@@ -47,6 +47,10 @@ class ContextMenuBuilder {
         compactMode.target = MenuActions.shared
         compactMode.state = wm.compactModeEnabled ? .on : .off
         menu.addItem(compactMode)
+        let compactWindow = NSMenuItem(title: "Compact Window", action: #selector(MenuActions.toggleCompactWindow), keyEquivalent: "")
+        compactWindow.target = MenuActions.shared
+        compactWindow.state = wm.compactWindowEnabled ? .on : .off
+        menu.addItem(compactWindow)
         menu.addItem(NSMenuItem.separator())
 
         // Display toggles
@@ -120,6 +124,10 @@ class ContextMenuBuilder {
         compactMode.target = MenuActions.shared
         compactMode.state = wm.compactModeEnabled ? .on : .off
         menu.addItem(compactMode)
+        let compactWindow = NSMenuItem(title: "Compact Window", action: #selector(MenuActions.toggleCompactWindow), keyEquivalent: "")
+        compactWindow.target = MenuActions.shared
+        compactWindow.state = wm.compactWindowEnabled ? .on : .off
+        menu.addItem(compactWindow)
         menu.addItem(NSMenuItem.separator())
 
         let alwaysOnTop = NSMenuItem(title: "Always On Top", action: #selector(MenuActions.toggleAlwaysOnTop), keyEquivalent: "")
@@ -4716,6 +4724,10 @@ class MenuActions: NSObject {
 
     @objc func toggleCompactMode() {
         WindowManager.shared.toggleCompactMode()
+    }
+
+    @objc func toggleCompactWindow() {
+        WindowManager.shared.toggleCompactWindow()
     }
 
     @objc func toggleDoubleSize() {

--- a/Sources/NullPlayer/App/WindowManager.swift
+++ b/Sources/NullPlayer/App/WindowManager.swift
@@ -257,9 +257,14 @@ class WindowManager {
     /// `compactModeEnabled` mirrors this so the mode can be restored on the next launch.
     private(set) var compactModeEnabled = false
 
+    /// Whether Compact Window (free-floating mini-player) is currently active. Unlike
+    /// Compact Mode, this keeps the app regular and hides only the main window.
+    private(set) var compactWindowEnabled = false
+
     private var compactModeState: CompactModeState = .regular
 
     private var regularWindowSnapshot: CompactWindowSnapshot?
+    private var mainWasVisibleBeforeCompactWindow = false
 
     /// Status-bar item shown while Compact Mode is active.
     private var compactStatusItem: NSStatusItem?
@@ -579,7 +584,8 @@ class WindowManager {
             "hideTitleBars": true,
             "waveformShowCuePoints": false,
             "waveformHideTooltip": false,
-            "compactModeEnabled": false
+            "compactModeEnabled": false,
+            "compactWindowEnabled": false
         ])
     }
     
@@ -627,13 +633,17 @@ class WindowManager {
         if isRunningModernUI {
             normalizeModernMainWindowForHTIfNeeded()
         }
-        if reveal {
+        if reveal && !compactWindowEnabled {
             mainWindowController?.showWindow(nil)
         }
         applyAlwaysOnTopToWindow(mainWindowController?.window)
     }
     
     func toggleMainWindow() {
+        if compactWindowEnabled {
+            exitCompactWindow()
+            return
+        }
         if let controller = mainWindowController, controller.window?.isVisible == true {
             controller.window?.orderOut(nil)
         } else {
@@ -1026,6 +1036,72 @@ class WindowManager {
         }
     }
 
+    /// Toggle the free-floating Compact Window. This reuses the compact mini-player surface
+    /// without changing activation policy or hiding any secondary windows.
+    func toggleCompactWindow() {
+        if compactWindowEnabled {
+            exitCompactWindow()
+        } else {
+            enterCompactWindow()
+        }
+    }
+
+    /// Enter the free-floating Compact Window variant.
+    ///
+    /// - Parameter treatMainAsVisible: Used at launch restore when the main window was created
+    ///   hidden only to avoid flash. Exiting Compact Window should still bring it back.
+    func enterCompactWindow(treatMainAsVisible: Bool = false) {
+        if compactModeState != .regular {
+            exitCompactMode { [weak self] in
+                self?.enterCompactWindow(treatMainAsVisible: treatMainAsVisible)
+            }
+            return
+        }
+        guard !compactWindowEnabled else { return }
+
+        compactWindowEnabled = true
+        UserDefaults.standard.set(true, forKey: "compactWindowEnabled")
+        UserDefaults.standard.set(false, forKey: "compactModeEnabled")
+
+        mainWasVisibleBeforeCompactWindow = treatMainAsVisible
+            || (mainWindowController?.window?.isVisible ?? false)
+        mainWindowController?.window?.orderOut(nil)
+
+        createCompactWindowControllerIfNeeded()
+        compactWindowController?.showFloating(level: isAlwaysOnTop ? .floating : .normal)
+        postLayoutChangeNotification()
+    }
+
+    func exitCompactWindow(restoreMainWindow: Bool = true) {
+        guard compactWindowEnabled else { return }
+        compactWindowEnabled = false
+        UserDefaults.standard.set(false, forKey: "compactWindowEnabled")
+
+        compactWindowController?.hide()
+        compactWindowController = nil
+
+        if restoreMainWindow, mainWasVisibleBeforeCompactWindow,
+           let mainWindow = mainWindowController?.window {
+            mainWindow.makeKeyAndOrderFront(nil)
+            applyAlwaysOnTopToWindow(mainWindow)
+        }
+        mainWasVisibleBeforeCompactWindow = false
+        postLayoutChangeNotification()
+    }
+
+    func handleAppReopen() {
+        if compactWindowEnabled {
+            mainWindowController?.window?.orderOut(nil)
+            createCompactWindowControllerIfNeeded()
+            compactWindowController?.showFloating(level: isAlwaysOnTop ? .floating : .normal)
+            postLayoutChangeNotification()
+            return
+        }
+
+        showMainWindow()
+        mainWindowController?.window?.makeKeyAndOrderFront(nil)
+    }
+
     /// - Parameter revealWindow: When `true` (live toggle from the menu) the compact window is
     ///   shown and positioned under the status item. When `false` (restore on launch) the window
     ///   is left hidden behind the status item so the *first* click reveals it — otherwise the
@@ -1036,6 +1112,9 @@ class WindowManager {
     ///   regular layout, so this matches the live-toggle behavior. Defaults to `false` so the
     ///   live menu toggle keeps recording the main window's actual visibility.
     func enterCompactMode(revealWindow: Bool = true, treatMainAsVisible: Bool = false) {
+        if compactWindowEnabled {
+            exitCompactWindow()
+        }
         guard compactModeState == .regular else { return }
         compactModeState = .entering
         compactModeEnabled = true
@@ -1311,6 +1390,9 @@ class WindowManager {
     /// While Compact Mode is active, state persistence must record the windows that were
     /// visible before entry rather than the intentionally hidden compact-mode window set.
     func visibilityForStateSaving(_ key: String, current: Bool) -> Bool {
+        if compactWindowEnabled, key == "main" {
+            return mainWasVisibleBeforeCompactWindow
+        }
         guard compactModeState != .regular, let snapshot = regularWindowSnapshot else { return current }
         switch key {
         case "main": return snapshot.main?.wasVisible ?? current
@@ -1452,6 +1534,10 @@ class WindowManager {
     }
 
     func compactSurfaceDidHide() {
+        if compactWindowEnabled {
+            exitCompactWindow()
+            return
+        }
         guard compactModeState == .compactVisible || compactModeState == .entering else { return }
         compactModeState = .compactHidden
     }
@@ -1462,17 +1548,17 @@ class WindowManager {
 
     // Forwarders from the AudioEngine broadcast hub to the embedded compact player bar.
     func compactBarUpdateTime(current: TimeInterval, duration: TimeInterval) {
-        guard compactModeEnabled else { return }
+        guard compactModeEnabled || compactWindowEnabled else { return }
         compactWindowController?.updateTime(current: current, duration: duration)
     }
 
     func compactBarUpdateTrack(_ track: Track?) {
-        guard compactModeEnabled else { return }
+        guard compactModeEnabled || compactWindowEnabled else { return }
         compactWindowController?.updateTrack(track)
     }
 
     func compactBarUpdatePlaybackState() {
-        guard compactModeEnabled else { return }
+        guard compactModeEnabled || compactWindowEnabled else { return }
         compactWindowController?.updatePlaybackState()
     }
 
@@ -3062,6 +3148,9 @@ class WindowManager {
         spectrumWindowController?.window?.level = level
         audioAnalysisWindowController?.window?.level = level
         waveformWindowController?.window?.level = level
+        if compactWindowEnabled {
+            compactWindowController?.window?.level = level
+        }
     }
     
     /// Apply always on top level to a single window (used when showing windows)
@@ -4691,17 +4780,24 @@ class WindowManager {
                 self.performDebugRecreateModeDependentWindows(snapshot: snapshot, reenterCompact: true)
                 self.reapplyModeIndependentWindows(from: preSwitchSnapshot)
             }
+        } else if compactWindowEnabled {
+            exitCompactWindow()
+            performDebugRecreateModeDependentWindows(snapshot: captureModeDependentLayout(), reenterCompact: false,
+                                                     reenterCompactWindow: true)
         } else {
-            performDebugRecreateModeDependentWindows(snapshot: captureModeDependentLayout(), reenterCompact: false)
+            performDebugRecreateModeDependentWindows(snapshot: captureModeDependentLayout(), reenterCompact: false,
+                                                     reenterCompactWindow: false)
         }
     }
 
-    private func performDebugRecreateModeDependentWindows(snapshot: ModeDependentLayoutSnapshot, reenterCompact: Bool) {
+    private func performDebugRecreateModeDependentWindows(snapshot: ModeDependentLayoutSnapshot, reenterCompact: Bool,
+                                                         reenterCompactWindow: Bool = false) {
         let t0 = CACurrentMediaTime()
         teardownModeDependentWindows()
         let tTorn = CACurrentMediaTime()
         recreateModeDependentLayout(snapshot)
         if reenterCompact { enterCompactMode() }
+        if reenterCompactWindow { enterCompactWindow() }
         let tDone = CACurrentMediaTime()
 
         NSLog("WindowManager: debugRecreateModeDependentWindows — teardown %.1fms, recreate %.1fms",
@@ -4742,6 +4838,11 @@ class WindowManager {
             return
         }
         NSLog("WindowManager: reloadUI — switching to %@ UI", targetMode.displayName)
+
+        let restoreCompactWindow = compactWindowEnabled
+        if restoreCompactWindow {
+            exitCompactWindow()
+        }
 
         // If Large UI is active, collapse it to 1x in the *current* mode before the switch and
         // re-apply it in the target mode afterward (inside performReloadUI). The two UI systems
@@ -4785,12 +4886,14 @@ class WindowManager {
             exitCompactMode(restoreRegularWindows: false) { [weak self] in
                 guard let self else { return }
                 self.performReloadUI(to: targetMode, snapshot: snapshot, reenterCompact: true,
+                                     reenterCompactWindow: false,
                                      restoreLargeUI: restoreLargeUI, preservedSideFrames: preservedSideFrames)
                 self.reapplyModeIndependentWindows(from: preSwitchSnapshot)
                 completion?()
             }
         } else {
             performReloadUI(to: targetMode, snapshot: captureModeDependentLayout(), reenterCompact: false,
+                            reenterCompactWindow: restoreCompactWindow,
                             restoreLargeUI: restoreLargeUI, preservedSideFrames: preservedSideFrames)
             completion?()
         }
@@ -4907,6 +5010,7 @@ class WindowManager {
     /// The actual mode-dependent window swap. Runs synchronously when not in Compact Mode, or as
     /// the `exitCompactMode` completion when it was — see `reloadUI(toModernUI:)`.
     private func performReloadUI(to targetMode: PlayerUIMode, snapshot: ModeDependentLayoutSnapshot, reenterCompact: Bool,
+                                 reenterCompactWindow: Bool = false,
                                  restoreLargeUI: Bool, preservedSideFrames: SideWindowFrames) {
         let t0 = CACurrentMediaTime()
         teardownModeDependentWindows()
@@ -4932,6 +5036,7 @@ class WindowManager {
 
         // Restore Compact Mode last so it captures the freshly rebuilt window set, not stale state.
         if reenterCompact { enterCompactMode() }
+        if reenterCompactWindow { enterCompactWindow() }
         let tDone = CACurrentMediaTime()
 
         NSLog("WindowManager: reloadUI — teardown %.1fms, recreate %.1fms (now %@ UI)",

--- a/Sources/NullPlayer/App/WindowManager.swift
+++ b/Sources/NullPlayer/App/WindowManager.swift
@@ -5135,6 +5135,7 @@ class WindowManager {
     
     func saveWindowPositions() {
         let defaults = UserDefaults.standard
+        compactWindowController?.persistFloatingFrameForStateSaving()
         
         if let frame = mainWindowController?.window?.frame {
             defaults.set(NSStringFromRect(frame), forKey: "MainWindowFrame")

--- a/Sources/NullPlayer/App/WindowManager.swift
+++ b/Sources/NullPlayer/App/WindowManager.swift
@@ -1112,8 +1112,9 @@ class WindowManager {
     ///   regular layout, so this matches the live-toggle behavior. Defaults to `false` so the
     ///   live menu toggle keeps recording the main window's actual visibility.
     func enterCompactMode(revealWindow: Bool = true, treatMainAsVisible: Bool = false) {
+        let compactWindowMainWasVisible = compactWindowEnabled && mainWasVisibleBeforeCompactWindow
         if compactWindowEnabled {
-            exitCompactWindow()
+            exitCompactWindow(restoreMainWindow: false)
         }
         guard compactModeState == .regular else { return }
         compactModeState = .entering
@@ -1121,7 +1122,7 @@ class WindowManager {
         UserDefaults.standard.set(true, forKey: "compactModeEnabled")
 
         regularWindowSnapshot = captureRegularWindowSnapshot()
-        if treatMainAsVisible {
+        if treatMainAsVisible || compactWindowMainWasVisible {
             regularWindowSnapshot?.main?.wasVisible = true
         }
 

--- a/Sources/NullPlayer/Windows/CompactMode/CompactModeWindowController.swift
+++ b/Sources/NullPlayer/Windows/CompactMode/CompactModeWindowController.swift
@@ -420,6 +420,10 @@ final class CompactModeWindowController: NSWindowController {
         UserDefaults.standard.set(NSStringFromRect(window.frame), forKey: Self.floatingFrameKey)
     }
 
+    func persistFloatingFrameForStateSaving() {
+        persistFloatingFrameIfNeeded()
+    }
+
     private static func savedFloatingFrame() -> NSRect? {
         guard let string = UserDefaults.standard.string(forKey: floatingFrameKey), !string.isEmpty else {
             return nil

--- a/Sources/NullPlayer/Windows/CompactMode/CompactModeWindowController.swift
+++ b/Sources/NullPlayer/Windows/CompactMode/CompactModeWindowController.swift
@@ -224,14 +224,22 @@ final class CompactModeWindowController: NSWindowController {
 
         if !hasAppliedFloatingFrame {
             let savedFrame = Self.savedFloatingFrame()
+            var shouldCenter = savedFrame == nil
             var frame = savedFrame ?? window.frame
             if savedFrame == nil {
                 frame.size.width = compactBaseWidth
             }
             frame.size.width = max(frame.width, compactBaseWidth)
             frame.size.height = max(frame.height, window.minSize.height)
+            if savedFrame != nil {
+                if let visibleFrame = Self.visibleFloatingFrame(for: frame) {
+                    frame = visibleFrame
+                } else {
+                    shouldCenter = true
+                }
+            }
             window.setFrame(frame, display: false, animate: false)
-            if savedFrame == nil {
+            if shouldCenter {
                 window.center()
             }
             hasAppliedFloatingFrame = true
@@ -418,6 +426,32 @@ final class CompactModeWindowController: NSWindowController {
         }
         let frame = NSRectFromString(string)
         return frame == .zero ? nil : frame
+    }
+
+    private static func visibleFloatingFrame(for frame: NSRect) -> NSRect? {
+        guard !NSScreen.screens.isEmpty else { return frame }
+
+        let bestScreen = NSScreen.screens
+            .map { screen -> (screen: NSScreen, area: CGFloat) in
+                let intersection = frame.intersection(screen.visibleFrame)
+                let area = intersection.isNull || intersection.isEmpty
+                    ? 0
+                    : intersection.width * intersection.height
+                return (screen, area)
+            }
+            .max { $0.area < $1.area }
+
+        guard let bestScreen, bestScreen.area > 0 else { return nil }
+
+        let visibleFrame = bestScreen.screen.visibleFrame
+        var adjusted = frame
+        adjusted.size.width = min(adjusted.width, visibleFrame.width)
+        adjusted.size.height = min(adjusted.height, visibleFrame.height)
+        adjusted.origin.x = min(max(adjusted.origin.x, visibleFrame.minX),
+                                visibleFrame.maxX - adjusted.width)
+        adjusted.origin.y = min(max(adjusted.origin.y, visibleFrame.minY),
+                                visibleFrame.maxY - adjusted.height)
+        return adjusted
     }
 
     func updateTime(current: TimeInterval, duration: TimeInterval) {

--- a/Sources/NullPlayer/Windows/CompactMode/CompactModeWindowController.swift
+++ b/Sources/NullPlayer/Windows/CompactMode/CompactModeWindowController.swift
@@ -18,6 +18,7 @@ final class CompactModeWindowController: NSWindowController {
 
     private let browserController: CompactModeBrowserSurface
     private var needsInitialSizing = true
+    private var isFloatingMode = false
 
     /// Observer for status-item window move notifications (initial reveal + display-reconfig).
     private var statusButtonWindowMoveObserver: NSObjectProtocol?
@@ -45,6 +46,8 @@ final class CompactModeWindowController: NSWindowController {
     private var compactBaseWidth: CGFloat {
         browserController.minimumCompactContentWidth * compactWidthFactor
     }
+
+    private static let floatingFrameKey = "compactWindowFrame"
 
     init(modernUI: Bool) {
         if modernUI {
@@ -74,6 +77,7 @@ final class CompactModeWindowController: NSWindowController {
 
     deinit {
         NotificationCenter.default.removeObserver(self)
+        persistFloatingFrameIfNeeded()
         stopObservingStatusButtonFrame()
         stopObservingDisplayConfig()
         anchorDiagnosticTimer?.invalidate()
@@ -107,6 +111,7 @@ final class CompactModeWindowController: NSWindowController {
     }
 
     @objc private func handleWindowDidBecomeKey(_ note: Notification) {
+        guard !isFloatingMode else { return }
         guard let window, window.isVisible else { return }
         guard let keyWindow = note.object as? NSWindow else { return }
         // A dialog/panel from our app took key — let it sit above the floating compact window.
@@ -119,6 +124,7 @@ final class CompactModeWindowController: NSWindowController {
     /// this the video would launch *behind* the floating mini-player. The compact window
     /// returns to its floating level the next time it becomes key (see handleWindowDidBecomeKey).
     func yieldFrontForVideoPlayer() {
+        guard !isFloatingMode else { return }
         window?.level = .normal
     }
 
@@ -127,6 +133,7 @@ final class CompactModeWindowController: NSWindowController {
     /// user happens to click it. Called when video playback stops/closes so always-on-top behavior
     /// returns automatically.
     func restoreFloatingLevelAfterVideoPlayer() {
+        guard !isFloatingMode else { return }
         window?.level = .statusBar
     }
 
@@ -145,6 +152,7 @@ final class CompactModeWindowController: NSWindowController {
     /// real fade-in/positioning still happens later in `show`.
     func establishPresenceOnActiveSpace() {
         guard let window else { return }
+        isFloatingMode = false
         window.alphaValue = 0
         window.hasShadow = false
         window.collectionBehavior = [.moveToActiveSpace, .transient, .ignoresCycle]
@@ -154,11 +162,14 @@ final class CompactModeWindowController: NSWindowController {
 
     func show(anchoredTo button: NSStatusBarButton?) {
         guard let window else { return }
+        isFloatingMode = false
         stopObservingStatusButtonFrame()
         anchorDiagnosticTimer?.invalidate()
 
         window.level = .statusBar
         window.collectionBehavior = [.moveToActiveSpace, .transient, .ignoresCycle]
+        window.title = "Compact Mode"
+        window.setAccessibilityLabel("Compact Mode")
 
         let wasVisible = window.isVisible && window.alphaValue > 0
         if wasVisible {
@@ -193,6 +204,47 @@ final class CompactModeWindowController: NSWindowController {
         if isStatusAnchorReady(button) {
             revealNow(anchoredTo: button)
         }
+    }
+
+    func showFloating(level: NSWindow.Level = .normal) {
+        guard let window else { return }
+        isFloatingMode = true
+        hasRevealed = true
+        anchorButton = nil
+        stopObservingStatusButtonFrame()
+        stopObservingDisplayConfig()
+        anchorDiagnosticTimer?.invalidate()
+        anchorDiagnosticTimer = nil
+
+        window.level = level
+        window.collectionBehavior = [.managed, .fullScreenAuxiliary]
+        window.title = "Compact Window"
+        window.setAccessibilityLabel("Compact Window")
+
+        if needsInitialSizing {
+            let savedFrame = Self.savedFloatingFrame()
+            var frame = savedFrame ?? window.frame
+            if savedFrame == nil {
+                frame.size.width = compactBaseWidth
+            }
+            frame.size.width = max(frame.width, compactBaseWidth)
+            frame.size.height = max(frame.height, window.minSize.height)
+            window.setFrame(frame, display: false, animate: false)
+            if savedFrame == nil {
+                window.center()
+            }
+            needsInitialSizing = false
+        } else {
+            var frame = window.frame
+            frame.size.width = max(frame.width, compactBaseWidth)
+            frame.size.height = max(frame.height, window.minSize.height)
+            window.setFrame(frame, display: false, animate: false)
+        }
+
+        window.alphaValue = 1
+        window.hasShadow = true
+        window.orderFront(nil)
+        window.makeKey()
     }
 
     /// Start observing the status-item window's move and resize notifications to detect
@@ -344,6 +396,7 @@ final class CompactModeWindowController: NSWindowController {
     }
 
     func hide() {
+        persistFloatingFrameIfNeeded()
         stopObservingStatusButtonFrame()
         stopObservingDisplayConfig()
         anchorDiagnosticTimer?.invalidate()
@@ -351,6 +404,19 @@ final class CompactModeWindowController: NSWindowController {
         anchorButton = nil
         window?.alphaValue = 0
         window?.orderOut(nil)
+    }
+
+    private func persistFloatingFrameIfNeeded() {
+        guard isFloatingMode, let window, window.frame != .zero else { return }
+        UserDefaults.standard.set(NSStringFromRect(window.frame), forKey: Self.floatingFrameKey)
+    }
+
+    private static func savedFloatingFrame() -> NSRect? {
+        guard let string = UserDefaults.standard.string(forKey: floatingFrameKey), !string.isEmpty else {
+            return nil
+        }
+        let frame = NSRectFromString(string)
+        return frame == .zero ? nil : frame
     }
 
     func updateTime(current: TimeInterval, duration: TimeInterval) {

--- a/Sources/NullPlayer/Windows/CompactMode/CompactModeWindowController.swift
+++ b/Sources/NullPlayer/Windows/CompactMode/CompactModeWindowController.swift
@@ -19,6 +19,7 @@ final class CompactModeWindowController: NSWindowController {
     private let browserController: CompactModeBrowserSurface
     private var needsInitialSizing = true
     private var isFloatingMode = false
+    private var hasAppliedFloatingFrame = false
 
     /// Observer for status-item window move notifications (initial reveal + display-reconfig).
     private var statusButtonWindowMoveObserver: NSObjectProtocol?
@@ -221,7 +222,7 @@ final class CompactModeWindowController: NSWindowController {
         window.title = "Compact Window"
         window.setAccessibilityLabel("Compact Window")
 
-        if needsInitialSizing {
+        if !hasAppliedFloatingFrame {
             let savedFrame = Self.savedFloatingFrame()
             var frame = savedFrame ?? window.frame
             if savedFrame == nil {
@@ -233,7 +234,7 @@ final class CompactModeWindowController: NSWindowController {
             if savedFrame == nil {
                 window.center()
             }
-            needsInitialSizing = false
+            hasAppliedFloatingFrame = true
         } else {
             var frame = window.frame
             frame.size.width = max(frame.width, compactBaseWidth)

--- a/Sources/NullPlayer/Windows/ModernLibraryBrowser/CompactPlayerBarView.swift
+++ b/Sources/NullPlayer/Windows/ModernLibraryBrowser/CompactPlayerBarView.swift
@@ -255,6 +255,7 @@ final class CompactPlayerBarView: NSView {
         else if t.stop.contains(p) { pressedButton = "btn_stop" }
         else if t.next.contains(p) { pressedButton = "btn_next" }
         if pressedButton != nil { needsDisplay = true }
+        else { beginFloatingCompactWindowDrag(with: event) }
     }
 
     override func mouseDragged(with event: NSEvent) {
@@ -291,6 +292,11 @@ final class CompactPlayerBarView: NSView {
         }
         pressedButton = nil
         needsDisplay = true
+    }
+
+    private func beginFloatingCompactWindowDrag(with event: NSEvent) {
+        guard WindowManager.shared.compactWindowEnabled, let window else { return }
+        window.performDrag(with: event)
     }
 
     private func updateSeekPosition(from point: NSPoint) {

--- a/Sources/NullPlayer/Windows/PlexBrowser/ClassicCompactPlayerBarView.swift
+++ b/Sources/NullPlayer/Windows/PlexBrowser/ClassicCompactPlayerBarView.swift
@@ -394,6 +394,8 @@ final class ClassicCompactPlayerBarView: NSView {
         if p.y < titleBarHeight {
             // Compact Mode is anchored beneath the status item. Consume titlebar clicks
             // without initiating a window drag so it cannot be detached from the menu bar.
+            // Compact Window is free-floating, so the same region should drag normally.
+            beginFloatingCompactWindowDrag(with: event)
             return
         }
 
@@ -418,6 +420,8 @@ final class ClassicCompactPlayerBarView: NSView {
             needsDisplay = true
             return
         }
+
+        beginFloatingCompactWindowDrag(with: event)
     }
 
     override func mouseDragged(with event: NSEvent) {
@@ -463,6 +467,11 @@ final class ClassicCompactPlayerBarView: NSView {
         }
         pressedButton = nil
         needsDisplay = true
+    }
+
+    private func beginFloatingCompactWindowDrag(with event: NSEvent) {
+        guard WindowManager.shared.compactWindowEnabled, let window else { return }
+        window.performDrag(with: event)
     }
 
     private func updateSeekPosition(from point: NSPoint) {

--- a/skills/ui-guide/SKILL.md
+++ b/skills/ui-guide/SKILL.md
@@ -673,6 +673,35 @@ The reveal is **event-driven with no fallback** (this replaced the old retry-pol
 - Tear down both frame observers, the display-config observer, and the diagnostic timer in `hide()` and `deinit`.
 - The logic lives entirely in the shared `CompactModeWindowController` (`modernUI` only selects the embedded browser surface), so classic, modern, and metal skins all reveal through this one path — there is no mode-specific positioning to keep in sync.
 
+## Compact Window
+
+Compact Window is the free-floating sibling of menu-bar Compact Mode. It reuses
+`CompactModeWindowController` and the embedded browser compact surface, but it must not
+change activation policy or create a status item.
+
+Implementation rules:
+- `WindowManager.compactWindowEnabled` is the source of truth and persists under
+  `compactWindowEnabled`. It is mutually exclusive with `compactModeEnabled`.
+- Entering Compact Window hides **only** the main window, records whether main was visible,
+  creates the shared compact controller if needed, and calls `showFloating(level:)`.
+  Secondary windows stay visible and keep their frames.
+- `CompactModeWindowController.showFloating(level:)` uses `.normal` level by default,
+  `.managed` / `.fullScreenAuxiliary` collection behavior, immediate alpha-1 reveal, and
+  frame persistence via `compactWindowFrame`. Do not run status-anchor observers,
+  display-reconfig anchoring, diagnostic timers, or `.statusBar` level juggling in floating mode.
+- `showMainWindow(reveal:)` must not reveal main while `compactWindowEnabled` is true. Generic
+  app reopen handling should call `WindowManager.handleAppReopen()`, which focuses/re-shows
+  Compact Window and keeps main ordered out. This prevents returning from another Space or a
+  fullscreen app from reopening both Compact Window and the main window.
+- The compact-bar update forwarders must run for `compactModeEnabled || compactWindowEnabled`
+  so track/time/play state stays live in both variants.
+- The classic and modern compact player bars should start a window drag from non-control
+  regions when `compactWindowEnabled` is true. Keep playback buttons, seek, volume,
+  close/minimize hit targets consuming their own events. Menu-bar Compact Mode remains anchored
+  and should not become draggable from the title/player bar.
+- Live UI switching should exit Compact Window, rebuild the mode-dependent window layer, then
+  re-enter Compact Window so the embedded classic/modern compact surface matches the new mode.
+
 ## Window Docking
 
 Complex snapping logic in `WindowManager`:

--- a/skills/user-guide/SKILL.md
+++ b/skills/user-guide/SKILL.md
@@ -80,6 +80,16 @@ Windows automatically snap together when dragged near each other:
 - All other windows (Main, EQ, Playlist, Spectrum, etc.) are hidden; their prior visibility is remembered and restored when you exit. **Exceptions:** the video player and debug console windows are allowed in Compact Mode — a playing video stays visible on entry, videos opened while compact (e.g. a downloaded YouTube video) appear normally, and an open debug console remains visible.
 - Exiting restores the Dock icon, the macOS menu bar, and the previously open windows.
 
+### Compact Window
+
+**Compact Window** opens the same compact Library Browser mini-player as a normal free-floating window. Toggle it from the main window's right-click context menu (**Compact Window**) or the `Windows` top menu. It is mutually exclusive with menu-bar Compact Mode.
+
+- NullPlayer stays a regular app: Dock icon and menu bar remain visible.
+- Only the main window is hidden. Playlist, EQ, Spectrum, Library, Visualizations, video, and other windows stay where they are.
+- The compact window uses normal window level so it can sit behind other apps; enabling **Always on Top** raises it like the other app windows.
+- Drag it from the compact player bar or the browser area. Playback controls, seek, volume, close, and minimize keep their normal click behavior.
+- The window remembers its last frame and can restore across launches. Returning to NullPlayer from another desktop or fullscreen app focuses Compact Window instead of reopening the hidden main window.
+
 ### Main Window Elements
 
 | Element | Description |


### PR DESCRIPTION
## Summary
- add a free-floating Compact Window variant that reuses the compact Library Browser mini-player without switching to accessory/menu-bar mode
- keep Compact Window mutually exclusive with menu-bar Compact Mode, preserve main-window hiding/restoration, frame persistence, Always on Top level, live updates, and UI-mode switching
- route app reopen/Space returns back to Compact Window so the hidden main window does not reappear, and allow dragging from non-control compact player bar areas
- update CHANGELOG and Compact Window documentation in skills

## Testing
- git diff --check
- swift test

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added a new **Compact Window** mode from the Windows menu and context menus.
  * The floating mini-player can be dragged (including from compact player bars), stays available alongside other windows, and remembers its last position between launches.
  * Always-on-top now applies to the Compact Window.
* **Bug Fixes**
  * Returning from other apps focuses the active Compact Window instead of reopening the main window.
  * Compact Window no longer reopens the main window after Space switching.
* **Documentation**
  * Updated user and UI guide with Compact Window behavior and rules.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->