### PR TITLE
Metal LCD row highlights; larger library fonts in non-compact mode

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,10 +8,12 @@
 - **License and branding terms clarified** — the project license notice and README now state GPL-3.0-only distribution terms and clarify that modified distributions must not reuse the NullPlayer name, icon, logo, bundle identity, or other branding without permission.
 - **Balance control added to Playback menu** — the Playback options now include a Balance submenu with a slider and common left/center/right presets, giving modern UI and menu-only workflows access to stereo balance without adding more controls to the player face.
 - **Compact Mode player bar reads like the main window** — in Modern and Metal, the Compact Mode display now splits into two distinct LCD "windows" with a padded gap: a single elapsed/remaining time counter on the left and the scrolling track title on the right (previously the title sat left with a cramped "elapsed / total" reading pinned to the right). The counter matches the title's size and weight, and the transport buttons are slightly larger.
+- **Larger Library tab and control fonts** — the Library Browser's tab labels and control text render at a slightly larger size in non-compact mode for better legibility. Compact Mode is unchanged.
 
 ### Changes
 
 - **Window shade mode removed** — double-clicking a window's title bar no longer collapses it to a title-bar-only strip ("windowshade"). This legacy Winamp feature was the source of recurring layout glitches when combined with Large UI, Compact Mode, and live UI-mode switching; removing it makes window sizing and position memory behave consistently across every window in Classic, Modern, and Metal.
+- **Library source menu lists only sources** — the Library Browser's source picker no longer injects local-library settings ("Manage Folders…" and the "Clear Local Library" submenu) when the local source is active. Those are settings, not sources, and already live in the Library menu-bar item, so the source menu now lists sources only.
 
 ### Bug Fixes
 
@@ -21,6 +23,7 @@
 - **Library window remembers where you put it** — after unlocking the connected windows and moving the Library/browser window, it now reopens at the exact position and size you left it — across closing and reopening it (via the menu or the red close button) and across full app restarts, even when it was closed at quit. First-ever opens still dock to the right of the window stack, and the position survives Compact Mode. Playlist, EQ, and Spectrum still intentionally snap back into the column below the main window.
 - **Classic Large UI toggles instantly — no restart** — turning Large UI on or off in the classic skin now resizes the windows in place, matching the modern UI, instead of asking you to relaunch. The player, EQ, playlist, and other windows redraw crisply at the new size (no leftover "ghost" of the old size), and switching between Classic, Modern, and Metal while Large UI is on no longer distorts the new look.
 - **ProjectM visualizer recovers from a preset that crashes mid-playback** — a rare bug inside the MilkDrop preset engine could crash the app while a preset was on screen — including minutes into a track, not just when the preset first appeared. The crash-guard now watches a preset for its entire time on screen (previously only its first frame), so the offending preset is automatically skipped on the next launch and the crash never recurs. Normal quits never flag a good preset.
+- **Metal playlist and Library highlights are now clearly visible** — in Metal skins, the playlist's now-playing track and the Library Browser's selected/expanded row were indicated by text color alone, which several metal finishes render nearly identical to normal rows, so the active row was easy to miss. Both now draw a translucent green backlit-LCD highlight bar (matching the hi-fi display panels) as the cue. The metal playlist's row text is also unified at the Library window's brightness — previously it was dimmer — and the current track no longer recolors to the accent tone that clashed with the new highlight.
 
 ## 0.26.1
 

--- a/Sources/NullPlayer/Windows/ModernLibraryBrowser/ModernLibraryBrowserView.swift
+++ b/Sources/NullPlayer/Windows/ModernLibraryBrowser/ModernLibraryBrowserView.swift
@@ -2021,9 +2021,11 @@ class ModernLibraryBrowserView: NSView {
             }
             if isOffline { context.saveGState(); context.setAlpha(0.35) }
 
-            // Selection background - subtle to keep accent text readable
+            // Selection background - subtle to keep accent text readable.
+            // In metal mode, highlight with the green LCD display color (matching the
+            // playlist's now-playing row) instead of the metal control fill.
             if isSelected {
-                (isMetalRenderStyle ? metalControlActiveFill : skin.primaryColor.withAlphaComponent(0.06)).setFill()
+                (isMetalRenderStyle ? metalMaterial.displayFill.withAlphaComponent(0.30) : skin.primaryColor.withAlphaComponent(0.06)).setFill()
                 context.fill(itemRect)
             }
 

--- a/Sources/NullPlayer/Windows/ModernLibraryBrowser/ModernLibraryBrowserView.swift
+++ b/Sources/NullPlayer/Windows/ModernLibraryBrowser/ModernLibraryBrowserView.swift
@@ -515,6 +515,7 @@ class ModernLibraryBrowserView: NSView {
     private var cachedServerBarFontSkinName: String?
     private var cachedServerBarFontScale: CGFloat?
     private var cachedServerBarIsMetal: Bool?
+    private var cachedServerBarCompact: Bool?
     private var cachedPrefixAttrs: [NSAttributedString.Key: Any]?
     private var cachedDataAttrs: [NSAttributedString.Key: Any]?
     private var cachedActiveAttrs: [NSAttributedString.Key: Any]?
@@ -1273,8 +1274,8 @@ class ModernLibraryBrowserView: NSView {
         // Background
         (isMetalRenderStyle ? metalControlBandFill : skin.surfaceColor.withAlphaComponent(0.4)).setFill()
         context.fill(tabBarRect)
-        
-        let font = skin.libraryFont(size: 11)
+
+        let font = skin.libraryFont(size: compactMode ? 11 : 12)
         
         // Sort indicator width on right
         let sortText = "Sort"
@@ -1405,12 +1406,14 @@ class ModernLibraryBrowserView: NSView {
         if cachedServerBarFont == nil ||
             cachedServerBarFontSkinName != skinName ||
             cachedServerBarFontScale != currentScale ||
-            cachedServerBarIsMetal != isMetal {
-            let font = skin.libraryFont(size: 11)
+            cachedServerBarIsMetal != isMetal ||
+            cachedServerBarCompact != compactMode {
+            let font = skin.libraryFont(size: compactMode ? 11 : 12)
             cachedServerBarFont = font
             cachedServerBarFontSkinName = skinName
             cachedServerBarFontScale = currentScale
             cachedServerBarIsMetal = isMetal
+            cachedServerBarCompact = compactMode
             cachedPrefixAttrs = [.font: font, .foregroundColor: skin.applyTextOpacity(to: dimColor)]
             cachedDataAttrs   = [.font: font, .foregroundColor: skin.applyTextOpacity(to: dataColor)]
             cachedActiveAttrs = [.font: font, .foregroundColor: skin.applyTextOpacity(to: isMetal ? skin.textColor : accentColor)]
@@ -7108,6 +7111,7 @@ class ModernLibraryBrowserView: NSView {
         cachedServerBarFontSkinName = nil
         cachedServerBarFontScale = nil
         cachedServerBarIsMetal = nil
+        cachedServerBarCompact = nil
         cachedPrefixAttrs = nil
         cachedDataAttrs = nil
         cachedActiveAttrs = nil

--- a/Sources/NullPlayer/Windows/ModernPlaylist/ModernPlaylistView.swift
+++ b/Sources/NullPlayer/Windows/ModernPlaylist/ModernPlaylistView.swift
@@ -166,8 +166,9 @@ class ModernPlaylistView: NSView {
         let skin = renderer.skin
         // Must use playlistFont (8pt default), NOT bodyFont (9pt) which configure(with:) would set
         marquee.textFont = skin.playlistFont()
-        // Must use accentColor (magenta) to match current-track title color, NOT marqueeColor (yellow)
-        marquee.textColor = skin.applyTextOpacity(to: skin.accentColor)
+        // Must use accentColor (magenta) to match current-track title color, NOT marqueeColor (yellow).
+        // In metal the current-track title stays at textColor (the green highlight is the cue), so match that.
+        marquee.textColor = skin.applyTextOpacity(to: skin.renderStyle == .metal ? skin.textColor : skin.accentColor)
         marquee.glowEnabled = false  // Track list text has no glow
         marquee.scrollSpeed = 24.0   // Match original: ~24px/sec
         marquee.scrollGap = 30.0     // Match original separatorWidth
@@ -449,10 +450,25 @@ class ModernPlaylistView: NSView {
             let track = tracks[index]
             let isCurrent = index == currentIndex
             let isSelected = selectedIndices.contains(index)
-            
+
+            // In metal mode the current-track text color (accent, a light metal tone) reads
+            // too close to the normal/selected text colors to signal "now playing". Fill the
+            // current row with the green LCD display color so it stands out unambiguously.
+            // (Test color: the backlit hi-fi green used by the main-window display panels.)
+            if isCurrent && skin.renderStyle == .metal {
+                let fill = skin.metalMaterial.displayFill.withAlphaComponent(0.30)
+                context.setFillColor(fill.cgColor)
+                context.fill(itemRect)
+            }
+
             // Text color -- current track uses accent, selected uses primary text, normal uses playlist_text
             let titleColor: NSColor
-            if isCurrent {
+            if skin.renderStyle == .metal {
+                // Metal: the green highlight fill is the sole now-playing/selection cue. Keep
+                // every row at the same (library-matching) text color so accent-colored current
+                // text doesn't clash with / wash out against the green highlight.
+                titleColor = skin.textColor
+            } else if isCurrent {
                 titleColor = skin.accentColor
             } else if isSelected {
                 titleColor = skin.textColor

--- a/Sources/NullPlayer/Windows/ModernPlaylist/ModernPlaylistView.swift
+++ b/Sources/NullPlayer/Windows/ModernPlaylist/ModernPlaylistView.swift
@@ -451,12 +451,11 @@ class ModernPlaylistView: NSView {
             let isCurrent = index == currentIndex
             let isSelected = selectedIndices.contains(index)
 
-            // In metal mode the current-track text color (accent, a light metal tone) reads
-            // too close to the normal/selected text colors to signal "now playing". Fill the
-            // current row with the green LCD display color so it stands out unambiguously.
-            // (Test color: the backlit hi-fi green used by the main-window display panels.)
-            if isCurrent && skin.renderStyle == .metal {
-                let fill = skin.metalMaterial.displayFill.withAlphaComponent(0.30)
+            // In metal mode the text colors intentionally stay uniform. Use the green LCD
+            // display fill for row state: strong for now-playing, subtler for selection.
+            if skin.renderStyle == .metal, isCurrent || isSelected {
+                let fillAlpha: CGFloat = isCurrent ? 0.30 : 0.20
+                let fill = skin.metalMaterial.displayFill.withAlphaComponent(fillAlpha)
                 context.setFillColor(fill.cgColor)
                 context.fill(itemRect)
             }
@@ -464,9 +463,9 @@ class ModernPlaylistView: NSView {
             // Text color -- current track uses accent, selected uses primary text, normal uses playlist_text
             let titleColor: NSColor
             if skin.renderStyle == .metal {
-                // Metal: the green highlight fill is the sole now-playing/selection cue. Keep
-                // every row at the same (library-matching) text color so accent-colored current
-                // text doesn't clash with / wash out against the green highlight.
+                // Metal: green highlight fills are the sole row-state cue. Keep every row at
+                // the same (library-matching) text color so accent-colored text doesn't clash
+                // with / wash out against the green highlight.
                 titleColor = skin.textColor
             } else if isCurrent {
                 titleColor = skin.accentColor


### PR DESCRIPTION
## Summary
- Metal skin: green LCD highlight for the active playlist/library rows, and unify the metal playlist text styling
- Slightly enlarge the library window tab and control fonts in non-compact mode

## Commits
- Metal: green LCD highlight for playlist/library active rows; unify metal playlist text
- Slightly enlarge library window tab and control fonts in non-compact mode

## Test plan
- Build and run; verify active-row highlight in the playlist and library under a Metal skin
- Confirm library tab/control fonts are larger in non-compact mode and unchanged in compact mode

🤖 Generated with [Claude Code](https://claude.com/claude-code)