### PR TITLE
Fix library browser scrolling

### DIFF
--- a/Sources/NullPlayer/Skin/SkinRegion.swift
+++ b/Sources/NullPlayer/Skin/SkinRegion.swift
@@ -381,10 +381,7 @@ class RegionManager {
             }
         }
         
-        // Check if in title bar area (for window dragging)
-        let titleBarRect = NSRect(x: 0, y: windowSize.height - SkinElements.titleBarHeight,
-                                  width: windowSize.width - 30, height: SkinElements.titleBarHeight)
-        if titleBarRect.contains(point) {
+        if isInTitleBar(point, windowType: windowType, windowSize: windowSize) {
             return .openHand
         }
         
@@ -469,8 +466,24 @@ class RegionManager {
         // Convert to skin coordinates
         let skinY = windowSize.height - point.y
         
-        // Title bar is at the top, 14 pixels high, excluding buttons on the right
-        return skinY < SkinElements.titleBarHeight && point.x < windowSize.width - 30
+        guard skinY < SkinElements.titleBarHeight else { return false }
+
+        let regions: [ClickableRegion]
+        switch windowType {
+        case .main:
+            regions = mainWindowRegions
+        case .equalizer:
+            regions = equalizerRegions
+        case .playlist:
+            regions = playlistRegions(for: NSRect(origin: .zero, size: windowSize))
+        case .mediaLibrary:
+            return false
+        }
+
+        let skinPoint = NSPoint(x: point.x, y: skinY)
+        return !regions.contains { region in
+            region.cursorType == .pointer && region.rect.contains(skinPoint)
+        }
     }
 }
 
@@ -495,4 +508,3 @@ extension RegionManager {
         // custom hit testing, or by setting the window's shape mask
     }
 }
-

--- a/Sources/NullPlayer/Windows/ModernLibraryBrowser/ModernLibraryBrowserView.swift
+++ b/Sources/NullPlayer/Windows/ModernLibraryBrowser/ModernLibraryBrowserView.swift
@@ -3798,22 +3798,24 @@ class ModernLibraryBrowserView: NSView {
         if browseMode == .search { contentTopY -= Layout.searchBarHeight }
         let listHeight = contentTopY - Layout.statusBarHeight
         let totalHeight = CGFloat(displayItems.count) * itemHeight
+        let verticalDelta = verticalScrollDelta(from: event)
 
-        if totalHeight > listHeight && abs(event.deltaY) > 0 {
-            scrollOffset = max(0, min(totalHeight - listHeight, scrollOffset - event.deltaY * 3))
+        if totalHeight > listHeight && verticalDelta != 0 {
+            scrollOffset = max(0, min(totalHeight - listHeight, scrollOffset - verticalDelta))
 
             let listRect = NSRect(x: 0, y: Layout.statusBarHeight, width: bounds.width, height: listHeight)
             setNeedsDisplay(listRect)
         }
 
-        if abs(event.deltaX) > 0 {
+        let horizontalDelta = horizontalScrollDelta(from: event)
+        if horizontalDelta != 0 {
             let columns = currentVisibleColumns()
             let group = currentColumnGroup()
             let availableWidth = bounds.width - Layout.borderWidth * 2 - Layout.scrollbarWidth - Layout.alphabetWidth
             let totalWidth = totalColumnsWidth(columns: columns, availableWidth: availableWidth, group: group)
             let maxOffset = max(0, totalWidth - availableWidth)
             if maxOffset > 0 {
-                horizontalScrollOffset = max(0, min(maxOffset, horizontalScrollOffset - event.deltaX * 3))
+                horizontalScrollOffset = max(0, min(maxOffset, horizontalScrollOffset - horizontalDelta))
                 let listRect = NSRect(x: 0, y: Layout.statusBarHeight, width: bounds.width, height: listHeight)
                 setNeedsDisplay(listRect)
             }
@@ -3821,6 +3823,20 @@ class ModernLibraryBrowserView: NSView {
 
         // Trigger next-page load when scrolled near the bottom of a local paginated list
         if case .local = currentSource { loadNextLocalPageIfNeeded(listHeight: listHeight) }
+    }
+
+    private func verticalScrollDelta(from event: NSEvent) -> CGFloat {
+        if event.hasPreciseScrollingDeltas, event.scrollingDeltaY != 0 {
+            return event.scrollingDeltaY
+        }
+        return event.deltaY * 3
+    }
+
+    private func horizontalScrollDelta(from event: NSEvent) -> CGFloat {
+        if event.hasPreciseScrollingDeltas, event.scrollingDeltaX != 0 {
+            return event.scrollingDeltaX
+        }
+        return event.deltaX * 3
     }
 
     private func loadNextLocalPageIfNeeded(listHeight: CGFloat) {

--- a/Sources/NullPlayer/Windows/PlexBrowser/PlexBrowserView.swift
+++ b/Sources/NullPlayer/Windows/PlexBrowser/PlexBrowserView.swift
@@ -12963,6 +12963,66 @@ class PlexBrowserView: NSView {
             }
         }
     }
+
+    override func scrollWheel(with event: NSEvent) {
+        if browseMode.isHistoryMode {
+            super.scrollWheel(with: event)
+            return
+        }
+
+        var listY = Layout.titleBarHeight + Layout.serverBarHeight + Layout.tabBarHeight
+        if browseMode == .search {
+            listY += Layout.searchBarHeight
+        }
+        let listHeight = originalWindowSize.height - listY - Layout.statusBarHeight
+        let totalHeight = CGFloat(displayItems.count) * itemHeight
+        let verticalDelta = verticalScrollDelta(from: event)
+        let horizontalDelta = horizontalScrollDelta(from: event)
+        let columns = currentVisibleColumns()
+        let group = currentColumnGroup()
+        var needsRedraw = false
+
+        if !columns.isEmpty,
+           event.modifierFlags.contains(.shift) || abs(horizontalDelta) > abs(verticalDelta) {
+            let availableWidth = originalWindowSize.width - Layout.leftBorder - Layout.rightBorder - Layout.scrollbarWidth - Layout.alphabetWidth
+            let totalWidth = totalColumnsWidth(columns: columns, group: group)
+            let maxOffset = max(0, totalWidth - availableWidth)
+            if maxOffset > 0 {
+                let delta = event.modifierFlags.contains(.shift) ? verticalDelta : horizontalDelta
+                horizontalScrollOffset = max(0, min(maxOffset, horizontalScrollOffset - delta))
+                needsRedraw = true
+            }
+        }
+
+        if totalHeight > listHeight && verticalDelta != 0 && !event.modifierFlags.contains(.shift) {
+            scrollOffset = max(0, min(totalHeight - listHeight, scrollOffset - verticalDelta))
+            needsRedraw = true
+        }
+
+        if needsRedraw {
+            let scale = bounds.width / originalWindowSize.width
+            let scaledListY = bounds.height - (listY + listHeight) * scale
+            let scaledListHeight = (listHeight + Layout.statusBarHeight) * scale
+            let listRect = NSRect(x: 0, y: scaledListY, width: bounds.width, height: scaledListHeight)
+            setNeedsDisplay(listRect)
+        }
+
+        if case .local = currentSource { loadNextLocalPageIfNeeded(listHeight: listHeight) }
+    }
+
+    private func verticalScrollDelta(from event: NSEvent) -> CGFloat {
+        if event.hasPreciseScrollingDeltas, event.scrollingDeltaY != 0 {
+            return event.scrollingDeltaY
+        }
+        return event.deltaY * 3
+    }
+
+    private func horizontalScrollDelta(from event: NSEvent) -> CGFloat {
+        if event.hasPreciseScrollingDeltas, event.scrollingDeltaX != 0 {
+            return event.scrollingDeltaX
+        }
+        return event.deltaX * 3
+    }
     
     // MARK: - Keyboard Events
     

--- a/Tests/NullPlayerUITests/EqualizerTests.swift
+++ b/Tests/NullPlayerUITests/EqualizerTests.swift
@@ -59,7 +59,7 @@ final class EqualizerTests: NullPlayerUITestCase {
     
     // MARK: - Interaction Test
     
-    /// Tests window drag, context menu, and shade mode
+    /// Tests window drag, context menu, and title-bar double-click behavior
     func testEqualizerInteractions() {
         // Window drag
         let startPoint = equalizerWindow.coordinate(withNormalizedOffset: CGVector(dx: 0.5, dy: 0.05))
@@ -73,7 +73,7 @@ final class EqualizerTests: NullPlayerUITestCase {
         XCTAssertTrue(menu.waitForExistence(timeout: 1))
         app.pressEscape()
         
-        // Shade mode
+        // Title-bar double-click should not disturb the window.
         let titleBar = equalizerWindow.coordinate(withNormalizedOffset: CGVector(dx: 0.5, dy: 0.05))
         titleBar.doubleTap()
         XCTAssertTrue(equalizerWindow.exists)

--- a/Tests/NullPlayerUITests/Helpers/AccessibilityIdentifiers.swift
+++ b/Tests/NullPlayerUITests/Helpers/AccessibilityIdentifiers.swift
@@ -31,7 +31,6 @@ enum AccessibilityIdentifiers {
         // Window controls
         static let closeButton = "mainWindow.closeButton"
         static let minimizeButton = "mainWindow.minimizeButton"
-        static let shadeButton = "mainWindow.shadeButton"
         
         // Display elements
         static let timeDisplay = "mainWindow.timeDisplay"
@@ -59,7 +58,6 @@ enum AccessibilityIdentifiers {
         
         // Window controls
         static let closeButton = "playlist.closeButton"
-        static let shadeButton = "playlist.shadeButton"
         
         // Scrollbar
         static let scrollbar = "playlist.scrollbar"
@@ -92,7 +90,6 @@ enum AccessibilityIdentifiers {
         
         // Window controls
         static let closeButton = "equalizer.closeButton"
-        static let shadeButton = "equalizer.shadeButton"
         
         // Toggle buttons
         static let onOffButton = "equalizer.onOffButton"
@@ -128,7 +125,6 @@ enum AccessibilityIdentifiers {
         
         // Window controls
         static let closeButton = "plexBrowser.closeButton"
-        static let shadeButton = "plexBrowser.shadeButton"
         
         // Source selector
         static let sourceButton = "plexBrowser.sourceButton"
@@ -168,7 +164,6 @@ enum AccessibilityIdentifiers {
         
         // Window controls
         static let closeButton = "visualization.closeButton"
-        static let shadeButton = "visualization.shadeButton"
         
         // Content
         static let glView = "visualization.glView"

--- a/Tests/NullPlayerUITests/PlexBrowserTests.swift
+++ b/Tests/NullPlayerUITests/PlexBrowserTests.swift
@@ -47,7 +47,7 @@ final class PlexBrowserTests: NullPlayerUITestCase {
     
     // MARK: - Interaction Test
     
-    /// Tests window drag, resize, context menu, and shade mode
+    /// Tests window drag, resize, context menu, and title-bar double-click behavior
     func testPlexBrowserInteractions() {
         // Window drag
         let startPoint = plexBrowserWindow.coordinate(withNormalizedOffset: CGVector(dx: 0.5, dy: 0.01))
@@ -67,7 +67,7 @@ final class PlexBrowserTests: NullPlayerUITestCase {
         XCTAssertTrue(menu.waitForExistence(timeout: 1))
         app.pressEscape()
         
-        // Shade mode
+        // Title-bar double-click should not disturb the window.
         let titleBar = plexBrowserWindow.coordinate(withNormalizedOffset: CGVector(dx: 0.5, dy: 0.01))
         titleBar.doubleTap()
         XCTAssertTrue(plexBrowserWindow.exists)

--- a/Tests/NullPlayerUITests/VisualizationTests.swift
+++ b/Tests/NullPlayerUITests/VisualizationTests.swift
@@ -57,7 +57,7 @@ final class VisualizationTests: NullPlayerUITestCase {
     
     // MARK: - Interaction Test
     
-    /// Tests window drag, resize, context menu, and shade mode
+    /// Tests window drag, resize, context menu, and title-bar double-click behavior
     func testVisualizationInteractions() {
         // Window drag
         let startPoint = visualizationWindow.coordinate(withNormalizedOffset: CGVector(dx: 0.5, dy: 0.02))
@@ -77,7 +77,7 @@ final class VisualizationTests: NullPlayerUITestCase {
         XCTAssertTrue(menu.waitForExistence(timeout: 1))
         app.pressEscape()
         
-        // Shade mode
+        // Title-bar double-click should not disturb the window.
         let titleBar = visualizationWindow.coordinate(withNormalizedOffset: CGVector(dx: 0.5, dy: 0.02))
         titleBar.doubleTap()
         XCTAssertTrue(visualizationWindow.exists)


### PR DESCRIPTION
## Summary
- restore classic Library Browser wheel scrolling that was removed during shade-mode cleanup
- make modern Library Browser scroll handling use precise AppKit deltas when available
- clean up stale shade-mode UI test references and title-bar cursor hit testing

## Testing
- swift build
- swift test

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Improved scrolling behavior in browser views, including smoother mouse-wheel handling and better support for horizontal scrolling.

* **Bug Fixes**
  * Refined title-bar drag detection so window dragging works more reliably without interfering with clickable areas.
  * Updated browser scrolling to better respect content size and viewport limits, reducing unnecessary movement.

* **Tests**
  * Updated interaction test descriptions to reflect current title-bar double-click behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->