### PR TITLE
Improve release download workflow

### DIFF
--- a/.github/release_template.md
+++ b/.github/release_template.md
@@ -1,0 +1,21 @@
+## Download
+
+Download NullPlayer for macOS:
+
+https://github.com/ad-repo/nullplayer/releases/latest/download/NullPlayer.dmg
+
+Requires macOS 14 Sonoma or newer.
+
+## Install
+
+1. Open the downloaded DMG.
+2. Drag `NullPlayer.app` to Applications.
+3. Open NullPlayer from Applications.
+
+If macOS says the app is damaged or cannot verify that it is free from malware, see the install help:
+
+https://github.com/ad-repo/nullplayer/blob/main/docs/download.md#if-macos-blocks-the-app
+
+## What Changed
+
+{{CHANGELOG}}

--- a/.github/release_template.md
+++ b/.github/release_template.md
@@ -8,13 +8,17 @@ Requires macOS 14 Sonoma or newer.
 
 ## Install
 
+NullPlayer is not signed with an Apple Developer ID, so **macOS will block it on first launch** with an "app is damaged" or "cannot verify that it is free from malware" message. This is expected. Clearing the quarantine flag is a required install step:
+
 1. Open the downloaded DMG.
 2. Drag `NullPlayer.app` to Applications.
-3. Open NullPlayer from Applications.
+3. Open **Terminal** and run:
+   ```bash
+   xattr -cr /Applications/NullPlayer.app
+   ```
+4. Open NullPlayer from Applications.
 
-If macOS says the app is damaged or cannot verify that it is free from malware, see the install help:
-
-https://github.com/ad-repo/nullplayer/blob/main/docs/download.md#if-macos-blocks-the-app
+Prefer not to use the Terminal? Install with Homebrew, or clear the block via **System Settings -> Privacy & Security -> Open Anyway** — see the [install guide](https://github.com/ad-repo/nullplayer/blob/main/docs/download.md).
 
 ## What Changed
 

--- a/README.md
+++ b/README.md
@@ -66,13 +66,20 @@ https://github.com/ad-repo/nullplayer/releases/latest/download/NullPlayer.dmg
 
 Requires macOS 14 Sonoma or newer.
 
+NullPlayer is not signed with an Apple Developer ID — that requires a paid Apple developer account, which this project does not have and has no plans to buy. Because of that, **macOS Gatekeeper will block the app on first launch** with an "app is damaged" or "cannot verify that it is free from malware" message. This is expected, not a sign anything is wrong. Clearing the quarantine flag is a required install step — run it every time you install or update via the DMG:
+
 1. Open `NullPlayer.dmg`.
 2. Drag `NullPlayer.app` to Applications.
-3. Open NullPlayer from Applications.
+3. Clear the quarantine flag so macOS will open the app. Open **Terminal** (`Cmd + Space`, type `Terminal`, press Return) and run:
+
+   ```bash
+   xattr -cr /Applications/NullPlayer.app
+   ```
+4. Open NullPlayer from Applications.
 
 See [docs/download.md](docs/download.md) for the same install steps in a short download-only page.
 
-> **Tip:** Installing with Homebrew (next section) clears the macOS quarantine flag for you, so you skip the "app is damaged" security warning entirely.
+> **Tip:** Don't want to run a Terminal command every time you update? Install with Homebrew (next section) instead — the cask clears the quarantine flag for you automatically, so the app just opens.
 
 ### Install with Homebrew (recommended — no security warnings)
 
@@ -119,24 +126,16 @@ security delete-generic-password -s com.nullplayer.app
 
 </details>
 
-### Fixing "App is damaged" or "macOS cannot verify that this app is free from malware" Error
+### Opening the DMG build without the Terminal
 
-NullPlayer releases are currently ad-hoc signed, not Developer ID notarized. Because of that, macOS Gatekeeper may block the app on first launch.
+If you'd rather not run the `xattr` command in step 3 above, you can clear the block through System Settings instead:
 
-**Option 1: Terminal**
-
-```bash
-xattr -cr /Applications/NullPlayer.app
-```
-
-**Option 2: System Settings**
-
-1. Try to open NullPlayer once.
+1. Drag `NullPlayer.app` to Applications and double-click it once. macOS will refuse to open it — that's expected.
 2. Go to **System Settings -> Privacy & Security**.
 3. Scroll down and click **Open Anyway** next to the NullPlayer message.
 4. Click **Open** in the confirmation dialog.
 
-After either option, NullPlayer will open normally.
+After this NullPlayer opens normally. (Installing with Homebrew avoids this entirely — the cask clears the flag for you.)
 
 ### Optional command-line launcher
 

--- a/README.md
+++ b/README.md
@@ -60,29 +60,63 @@
 
 ## Installation
 
-    brew install --cask ad-repo/nullplayer/nullplayer
-    brew tap ad-repo/nullplayer        # one-time configuration  
+Download the latest DMG:
 
-    brew install --cask ad-repo/nullplayer/nullplayer  
-    or if already installed manually
-    brew install --cask --force ad-repo/nullplayer/nullplayer 
-    
-    To upgrade to a new release:   
-    brew update   
-    brew upgrade --cask ad-repo/nullplayer/nullplayer   
-    
-    To verify the tap is picking up the latest version:   
-    brew livecheck --cask ad-repo/nullplayer/nullplayer   
-    
-    Notes from the cask:   
-    - App is ad-hoc signed (not notarized). 
-    The cask's postflight runs xattr -cr to strip the quarantine bit so Gatekeeper allows first launch.   
-    - Requires macOS Sonoma or newer.   
-    - brew uninstall --cask --zap nullplayer removes app support/caches/prefs, but Keychain tokens (service com.nullplayer.app) must be removed manually: security 
-    
-    The Homebrew cask strips the quarantine attribute on install because the app is currently ad-hoc signed (Apple Developer ID notarization is on the roadmap). `brew     uninstall --cask --zap nullplayer` removes app data under `~/Library/Application Support/NullPlayer` and the app's preferences/caches, but **does not** remove Keychain entries for Plex/Subsonic/Jellyfin/Emby tokens. To clear those:
+https://github.com/ad-repo/nullplayer/releases/latest/download/NullPlayer.dmg
 
-    security delete-generic-password -s com.nullplayer.app
+Requires macOS 14 Sonoma or newer.
+
+1. Open `NullPlayer.dmg`.
+2. Drag `NullPlayer.app` to Applications.
+3. Open NullPlayer from Applications.
+
+See [docs/download.md](docs/download.md) for the same install steps in a short download-only page.
+
+### Fixing "App is damaged" or "macOS cannot verify that this app is free from malware" Error
+
+NullPlayer releases are currently ad-hoc signed, not Developer ID notarized. Because of that, macOS Gatekeeper may block the app on first launch.
+
+**Option 1: Terminal**
+
+```bash
+xattr -cr /Applications/NullPlayer.app
+```
+
+**Option 2: System Settings**
+
+1. Try to open NullPlayer once.
+2. Go to **System Settings -> Privacy & Security**.
+3. Scroll down and click **Open Anyway** next to the NullPlayer message.
+4. Click **Open** in the confirmation dialog.
+
+After either option, NullPlayer will open normally.
+
+### Advanced: Homebrew
+
+Terminal users can install NullPlayer through the personal Homebrew tap:
+
+```bash
+brew install --cask ad-repo/nullplayer/nullplayer
+```
+
+To upgrade to a new release:
+
+```bash
+brew update
+brew upgrade --cask ad-repo/nullplayer/nullplayer
+```
+
+To verify the tap is picking up the latest version:
+
+```bash
+brew livecheck --cask ad-repo/nullplayer/nullplayer
+```
+
+The Homebrew cask strips the quarantine attribute on install because the app is currently ad-hoc signed. `brew uninstall --cask --zap nullplayer` removes app data under `~/Library/Application Support/NullPlayer` and the app's preferences/caches, but **does not** remove Keychain entries for Plex/Subsonic/Jellyfin/Emby tokens. To clear those:
+
+```bash
+security delete-generic-password -s com.nullplayer.app
+```
 
 ### Optional command-line launcher
 
@@ -102,24 +136,6 @@ The launcher looks for:
 
 - `/Applications/NullPlayer.app`
 - `~/Applications/NullPlayer.app`
-
-
-### Fixing "App is damaged" or "macOS cannot verify that this app is free from malware" Error
-
-Since the app is in beta testing and not code-signed (it costs $99 a year to sign the app and I am not sure yet I want to pay that yet) macOS Gatekeeper will block it. To fix this:
-
-**Option 1: Terminal (Recommended)**
-```bash
-xattr -cr /Applications/NullPlayer.app
-```
-
-**Option 2: System Settings**
-1. Try to open NullPlayer (it will be blocked)
-2. Go to **System Settings → Privacy & Security**
-3. Scroll down and click **Open Anyway** next to the NullPlayer message
-4. Click **Open** in the confirmation dialog
-
-After either option, NullPlayer will open normally.
 
 ## Requirements
 

--- a/README.md
+++ b/README.md
@@ -95,17 +95,25 @@ See [docs/download.md](docs/download.md) for the same install steps in a short d
    ```
 
    Already have Homebrew? Skip this step.
-3. Add the NullPlayer tap (one-time configuration):
+3. Add Homebrew to your shell so the `brew` command is found. The installer finishes by printing a **Next steps** section — run the two commands it lists. On Apple Silicon Macs (M1/M2/M3/M4) they are:
+
+   ```bash
+   echo 'eval "$(/opt/homebrew/bin/brew shellenv)"' >> ~/.zprofile
+   eval "$(/opt/homebrew/bin/brew shellenv)"
+   ```
+
+   On older Intel Macs, replace `/opt/homebrew` with `/usr/local`. If `brew` already worked before you started, skip this step.
+4. Add the NullPlayer tap (one-time configuration):
 
    ```bash
    brew tap ad-repo/nullplayer
    ```
-4. Install NullPlayer:
+5. Install NullPlayer:
 
    ```bash
    brew install --cask ad-repo/nullplayer/nullplayer
    ```
-5. Open NullPlayer from your Applications folder or Launchpad — no security prompt.
+6. Open NullPlayer from your Applications folder or Launchpad — no security prompt.
 
 **Updating to a new release:**
 

--- a/README.md
+++ b/README.md
@@ -95,12 +95,17 @@ See [docs/download.md](docs/download.md) for the same install steps in a short d
    ```
 
    Already have Homebrew? Skip this step.
-3. Install NullPlayer:
+3. Add the NullPlayer tap (one-time configuration):
+
+   ```bash
+   brew tap ad-repo/nullplayer
+   ```
+4. Install NullPlayer:
 
    ```bash
    brew install --cask ad-repo/nullplayer/nullplayer
    ```
-4. Open NullPlayer from your Applications folder or Launchpad — no security prompt.
+5. Open NullPlayer from your Applications folder or Launchpad — no security prompt.
 
 **Updating to a new release:**
 

--- a/README.md
+++ b/README.md
@@ -83,7 +83,7 @@ See [docs/download.md](docs/download.md) for the same install steps in a short d
 
 ### Install with Homebrew (recommended — no security warnings)
 
-Homebrew is a free package manager for macOS. This is the smoothest way to install NullPlayer: Homebrew removes the Gatekeeper quarantine flag automatically, so you never see the "app is damaged" warning, and updates are a single command.
+[Homebrew](https://brew.sh/) is a free package manager for macOS. This is the smoothest way to install NullPlayer: Homebrew removes the Gatekeeper quarantine flag automatically, so you never see the "app is damaged" warning, and updates are a single command.
 
 **New to Homebrew? Here's the whole thing, start to finish:**
 

--- a/README.md
+++ b/README.md
@@ -72,6 +72,53 @@ Requires macOS 14 Sonoma or newer.
 
 See [docs/download.md](docs/download.md) for the same install steps in a short download-only page.
 
+> **Tip:** Installing with Homebrew (next section) clears the macOS quarantine flag for you, so you skip the "app is damaged" security warning entirely.
+
+### Install with Homebrew (recommended — no security warnings)
+
+Homebrew is a free package manager for macOS. This is the smoothest way to install NullPlayer: Homebrew removes the Gatekeeper quarantine flag automatically, so you never see the "app is damaged" warning, and updates are a single command.
+
+**New to Homebrew? Here's the whole thing, start to finish:**
+
+1. Open **Terminal** — press `Cmd + Space`, type `Terminal`, and press Return.
+2. Install Homebrew by pasting this line and pressing Return. It asks for your Mac login password (the cursor stays still while you type — that's normal) and takes a few minutes:
+
+   ```bash
+   /bin/bash -c "$(curl -fsSL https://raw.githubusercontent.com/Homebrew/install/HEAD/install.sh)"
+   ```
+
+   Already have Homebrew? Skip this step.
+3. Install NullPlayer:
+
+   ```bash
+   brew install --cask ad-repo/nullplayer/nullplayer
+   ```
+4. Open NullPlayer from your Applications folder or Launchpad — no security prompt.
+
+**Updating to a new release:**
+
+```bash
+brew update
+brew upgrade --cask ad-repo/nullplayer/nullplayer
+```
+
+<details>
+<summary>Homebrew power-user notes</summary>
+
+Verify the tap is serving the latest version:
+
+```bash
+brew livecheck --cask ad-repo/nullplayer/nullplayer
+```
+
+`brew uninstall --cask --zap nullplayer` removes app data under `~/Library/Application Support/NullPlayer` and the app's preferences/caches, but **does not** remove Keychain entries for Plex/Subsonic/Jellyfin/Emby tokens. To clear those:
+
+```bash
+security delete-generic-password -s com.nullplayer.app
+```
+
+</details>
+
 ### Fixing "App is damaged" or "macOS cannot verify that this app is free from malware" Error
 
 NullPlayer releases are currently ad-hoc signed, not Developer ID notarized. Because of that, macOS Gatekeeper may block the app on first launch.
@@ -90,33 +137,6 @@ xattr -cr /Applications/NullPlayer.app
 4. Click **Open** in the confirmation dialog.
 
 After either option, NullPlayer will open normally.
-
-### Advanced: Homebrew
-
-Terminal users can install NullPlayer through the personal Homebrew tap:
-
-```bash
-brew install --cask ad-repo/nullplayer/nullplayer
-```
-
-To upgrade to a new release:
-
-```bash
-brew update
-brew upgrade --cask ad-repo/nullplayer/nullplayer
-```
-
-To verify the tap is picking up the latest version:
-
-```bash
-brew livecheck --cask ad-repo/nullplayer/nullplayer
-```
-
-The Homebrew cask strips the quarantine attribute on install because the app is currently ad-hoc signed. `brew uninstall --cask --zap nullplayer` removes app data under `~/Library/Application Support/NullPlayer` and the app's preferences/caches, but **does not** remove Keychain entries for Plex/Subsonic/Jellyfin/Emby tokens. To clear those:
-
-```bash
-security delete-generic-password -s com.nullplayer.app
-```
 
 ### Optional command-line launcher
 

--- a/docs/development-workflow.md
+++ b/docs/development-workflow.md
@@ -76,14 +76,19 @@ NullPlayer releases use the plain `X.Y.Z` tag format, matching `CFBundleShortVer
 
 ### GitHub Release
 
-The preferred release helper builds the DMG, creates or updates the GitHub release, and uploads both the immutable versioned asset and the stable human-friendly asset:
+The preferred release helper builds the DMG, creates or updates the GitHub release, and uploads both the immutable versioned asset and the stable human-friendly asset. It must be run from a clean, up-to-date `main` checkout so the DMG, release tag, and source archive all describe the same commit.
 
 1. Bump `CFBundleShortVersionString` (and `CFBundleVersion` if needed) in `Sources/NullPlayer/Resources/Info.plist`.
 2. Update `CHANGELOG.md` with a matching `## X.Y.Z` section.
-3. Run:
+3. Commit, merge to `main`, and push.
+4. Pull the final release commit and run the helper from `main`:
    ```bash
+   git switch main
+   git pull --ff-only origin main
    ./scripts/create_release.sh
    ```
+
+The helper fails before building if the checkout is not `main`, has uncommitted changes, is behind/ahead of `origin/main`, or if the release tag already exists on a different commit.
 
 The helper uses `.github/release_template.md`, extracts the matching changelog section, and publishes these assets:
 

--- a/docs/development-workflow.md
+++ b/docs/development-workflow.md
@@ -52,9 +52,10 @@ The terminal file shows `exit_code: 0` after the build script completes, but new
 
 Output:
 - `dist/NullPlayer.app` — Application bundle
-- `dist/NullPlayer-X.Y.dmg` — Distributable DMG with Applications symlink
+- `dist/NullPlayer-X.Y.Z.dmg` — Immutable, versioned DMG for archives, checksums, and Homebrew
+- `dist/NullPlayer.dmg` — Stable-name copy for human-facing download links
 
-The script builds a release binary, creates the app bundle, copies VLCKit.framework and libprojectM-4.dylib, fixes rpaths, and creates a DMG. The final summary prints the DMG's SHA256 — copy this value into the Homebrew cask on each release.
+The script builds a release binary, creates the app bundle, copies VLCKit.framework and libprojectM-4.dylib, fixes rpaths, creates the versioned DMG, and copies it to the stable `NullPlayer.dmg` filename. The final summary prints the versioned DMG's SHA256 — copy this value into the Homebrew cask on each release.
 
 ### Mac App Store
 
@@ -69,21 +70,49 @@ Output:
 
 Requires environment variables (`MAS_APP_IDENTITY`, `MAS_INSTALLER_IDENTITY`, `MAS_PROVISION_PROFILE`). See `docs/mas-build-guide.md` for detailed setup and submission instructions.
 
-## Release flow (Homebrew cask)
+## Release Flow
 
-NullPlayer is distributed via a personal tap at `ad-repo/homebrew-nullplayer` (`Casks/nullplayer.rb`). For each release:
+NullPlayer releases use the plain `X.Y.Z` tag format, matching `CFBundleShortVersionString` exactly. Do not prefix release tags with `v`.
+
+### GitHub Release
+
+The preferred release helper builds the DMG, creates or updates the GitHub release, and uploads both the immutable versioned asset and the stable human-friendly asset:
 
 1. Bump `CFBundleShortVersionString` (and `CFBundleVersion` if needed) in `Sources/NullPlayer/Resources/Info.plist`.
-2. Run `./scripts/build_dmg.sh`. Note the printed `SHA256`.
-3. Publish the DMG:
+2. Update `CHANGELOG.md` with a matching `## X.Y.Z` section.
+3. Run:
    ```bash
-   gh release create vX.Y.Z dist/NullPlayer-X.Y.Z.dmg
+   ./scripts/create_release.sh
    ```
-4. In the `ad-repo/homebrew-nullplayer` repo, update `Casks/nullplayer.rb`:
+
+The helper uses `.github/release_template.md`, extracts the matching changelog section, and publishes these assets:
+
+- `NullPlayer-X.Y.Z.dmg` — use for Homebrew and archived release references
+- `NullPlayer.dmg` — use for download pages and `releases/latest/download/NullPlayer.dmg`
+
+Useful helper options:
+
+```bash
+./scripts/create_release.sh --dry-run     # Build notes and assets, but do not call GitHub
+./scripts/create_release.sh --skip-build  # Reuse an existing dist/NullPlayer-X.Y.Z.dmg
+./scripts/create_release.sh --draft       # Create/update the release as a draft
+./scripts/create_release.sh --prerelease  # Mark the release as a prerelease
+./scripts/create_release.sh --replace-versioned  # Re-upload the versioned DMG on an existing release
+```
+
+When updating an existing release, the helper always refreshes `NullPlayer.dmg` but leaves `NullPlayer-X.Y.Z.dmg` unchanged unless `--replace-versioned` is passed. This protects Homebrew users because the cask checksum is tied to the versioned asset.
+
+### Homebrew Cask
+
+NullPlayer is distributed via a personal tap at `ad-repo/homebrew-nullplayer` (`Casks/nullplayer.rb`). After the GitHub release:
+
+1. Note the SHA256 printed by `./scripts/build_dmg.sh` for `dist/NullPlayer-X.Y.Z.dmg`.
+2. In the `ad-repo/homebrew-nullplayer` repo, update `Casks/nullplayer.rb`:
    - Bump `version "X.Y.Z"`.
-   - Replace `sha256 "..."` with the value from step 2.
+   - Replace `sha256 "..."` with the value from step 1.
+   - Keep the cask URL pointed at the versioned DMG, not `NullPlayer.dmg`.
    - Commit and push.
-5. Verify locally:
+3. Verify locally:
    ```bash
    brew update
    brew install --cask ad-repo/nullplayer/nullplayer

--- a/docs/development-workflow.md
+++ b/docs/development-workflow.md
@@ -90,6 +90,8 @@ The helper uses `.github/release_template.md`, extracts the matching changelog s
 - `NullPlayer-X.Y.Z.dmg` — use for Homebrew and archived release references
 - `NullPlayer.dmg` — use for download pages and `releases/latest/download/NullPlayer.dmg`
 
+After publishing the release, the helper also updates the Homebrew cask (see below) so `brew upgrade` picks up the new version — no separate step is needed for a normal release.
+
 Useful helper options:
 
 ```bash
@@ -98,13 +100,18 @@ Useful helper options:
 ./scripts/create_release.sh --draft       # Create/update the release as a draft
 ./scripts/create_release.sh --prerelease  # Mark the release as a prerelease
 ./scripts/create_release.sh --replace-versioned  # Re-upload the versioned DMG on an existing release
+./scripts/create_release.sh --skip-tap    # Publish the release but do not touch the Homebrew cask
 ```
 
 When updating an existing release, the helper always refreshes `NullPlayer.dmg` but leaves `NullPlayer-X.Y.Z.dmg` unchanged unless `--replace-versioned` is passed. This protects Homebrew users because the cask checksum is tied to the versioned asset.
 
 ### Homebrew Cask
 
-NullPlayer is distributed via a personal tap at `ad-repo/homebrew-nullplayer` (`Casks/nullplayer.rb`). After the GitHub release:
+NullPlayer is distributed via a personal tap at `ad-repo/homebrew-nullplayer` (`Casks/nullplayer.rb`). `create_release.sh` updates this cask automatically once the release is published: it hashes the versioned DMG it just uploaded and edits `version` and `sha256` in the cask via the GitHub API (the tap is a separate repo and is **not** cloned locally). The cask `url` is templated on `#{version}` and is left untouched.
+
+The automatic update runs only when the versioned asset actually changed — a fresh release, a first upload, or an explicit `--replace-versioned` — and never for `--draft`/`--prerelease` builds, whose download URL is not live yet. Pass `--skip-tap` to publish the release without touching the cask.
+
+To update the cask by hand (e.g. after `--skip-tap`, or if the automatic update fails):
 
 1. Note the SHA256 printed by `./scripts/build_dmg.sh` for `dist/NullPlayer-X.Y.Z.dmg`.
 2. In the `ad-repo/homebrew-nullplayer` repo, update `Casks/nullplayer.rb`:

--- a/docs/development-workflow.md
+++ b/docs/development-workflow.md
@@ -126,7 +126,7 @@ To update the cask by hand (e.g. after `--skip-tap`, or if the automatic update 
    brew livecheck --cask ad-repo/nullplayer/nullplayer
    ```
 
-The cask runs `xattr -cr` in `postflight` to clear the quarantine bit, because the DMG is currently ad-hoc signed only. Once Developer ID notarization is added to `build_dmg.sh`, that block can be removed.
+The cask runs `xattr -cr` in `postflight` to clear the quarantine bit, because the DMG is ad-hoc signed only (there is no paid Apple Developer ID / notarization, and none is planned). Direct-DMG users have to run `xattr -cr /Applications/NullPlayer.app` themselves — that is why the install docs treat it as a required step, not optional troubleshooting.
 
 ## Versioning
 

--- a/docs/download.md
+++ b/docs/download.md
@@ -46,12 +46,17 @@ New to Homebrew? Here is the whole thing, start to finish:
    ```
 
    Already have Homebrew? Skip this step.
-3. Install NullPlayer:
+3. Add the NullPlayer tap (one-time configuration):
+
+   ```bash
+   brew tap ad-repo/nullplayer
+   ```
+4. Install NullPlayer:
 
    ```bash
    brew install --cask ad-repo/nullplayer/nullplayer
    ```
-4. Open NullPlayer from your Applications folder or Launchpad. No security prompt.
+5. Open NullPlayer from your Applications folder or Launchpad. No security prompt.
 
 Update to a new release any time with:
 

--- a/docs/download.md
+++ b/docs/download.md
@@ -12,7 +12,39 @@ Requires macOS 14 Sonoma or newer.
 2. Drag `NullPlayer.app` to Applications.
 3. Open NullPlayer from Applications.
 
+> **Tip:** Installing with Homebrew (next section) clears the macOS quarantine flag for you, so you skip the "app is damaged" warning entirely.
+
+## Install with Homebrew (recommended — no security warnings)
+
+Homebrew is a free package manager for macOS. This is the smoothest way to install NullPlayer: Homebrew removes the Gatekeeper quarantine flag automatically, so you never see the "app is damaged" warning, and updates are a single command.
+
+New to Homebrew? Here is the whole thing, start to finish:
+
+1. Open **Terminal** — press `Cmd + Space`, type `Terminal`, and press Return.
+2. Install Homebrew by pasting this line and pressing Return. It asks for your Mac login password (the cursor stays still while you type — that is normal) and takes a few minutes:
+
+   ```bash
+   /bin/bash -c "$(curl -fsSL https://raw.githubusercontent.com/Homebrew/install/HEAD/install.sh)"
+   ```
+
+   Already have Homebrew? Skip this step.
+3. Install NullPlayer:
+
+   ```bash
+   brew install --cask ad-repo/nullplayer/nullplayer
+   ```
+4. Open NullPlayer from your Applications folder or Launchpad. No security prompt.
+
+Update to a new release any time with:
+
+```bash
+brew update
+brew upgrade --cask ad-repo/nullplayer/nullplayer
+```
+
 ## If macOS Blocks the App
+
+(Only applies if you downloaded the DMG directly instead of using Homebrew.)
 
 NullPlayer releases are currently ad-hoc signed, not Developer ID notarized. Because of that, macOS Gatekeeper may say the app is damaged or cannot verify that it is free from malware.
 
@@ -28,18 +60,3 @@ Or use System Settings:
 2. Open System Settings -> Privacy & Security.
 3. Click Open Anyway next to the NullPlayer message.
 4. Click Open in the confirmation dialog.
-
-## Advanced: Homebrew
-
-Terminal users can install with Homebrew:
-
-```bash
-brew install --cask ad-repo/nullplayer/nullplayer
-```
-
-To upgrade later:
-
-```bash
-brew update
-brew upgrade --cask ad-repo/nullplayer/nullplayer
-```

--- a/docs/download.md
+++ b/docs/download.md
@@ -8,15 +8,33 @@ Requires macOS 14 Sonoma or newer.
 
 ## Install
 
+NullPlayer is not signed with an Apple Developer ID — that requires a paid Apple developer account, which this project does not have and has no plans to buy. Because of that, **macOS will block the app on first launch** with an "app is damaged" or "cannot verify that it is free from malware" message. This is expected. Clearing the quarantine flag is a required install step — run it every time you install or update via the DMG:
+
 1. Open `NullPlayer.dmg`.
 2. Drag `NullPlayer.app` to Applications.
-3. Open NullPlayer from Applications.
+3. Clear the quarantine flag so macOS will open the app. Open **Terminal** (`Cmd + Space`, type `Terminal`, press Return) and run:
 
-> **Tip:** Installing with Homebrew (next section) clears the macOS quarantine flag for you, so you skip the "app is damaged" warning entirely.
+   ```bash
+   xattr -cr /Applications/NullPlayer.app
+   ```
+4. Open NullPlayer from Applications.
+
+> **Tip:** Don't want to run a Terminal command every time you update? Install with Homebrew (next section) instead — the cask clears the quarantine flag for you automatically, so the app just opens.
+
+### Opening it without the Terminal
+
+If you'd rather not run the `xattr` command, clear the block through System Settings instead:
+
+1. Drag `NullPlayer.app` to Applications and double-click it once. macOS will refuse to open it — that's expected.
+2. Open System Settings -> Privacy & Security.
+3. Click Open Anyway next to the NullPlayer message.
+4. Click Open in the confirmation dialog.
+
+After this NullPlayer opens normally.
 
 ## Install with Homebrew (recommended — no security warnings)
 
-Homebrew is a free package manager for macOS. This is the smoothest way to install NullPlayer: Homebrew removes the Gatekeeper quarantine flag automatically, so you never see the "app is damaged" warning, and updates are a single command.
+Homebrew is a free package manager for macOS. This is the smoothest way to install NullPlayer: Homebrew removes the Gatekeeper quarantine flag automatically, so the app just opens with no security warning and no `xattr` command, and updates are a single command.
 
 New to Homebrew? Here is the whole thing, start to finish:
 
@@ -41,22 +59,3 @@ Update to a new release any time with:
 brew update
 brew upgrade --cask ad-repo/nullplayer/nullplayer
 ```
-
-## If macOS Blocks the App
-
-(Only applies if you downloaded the DMG directly instead of using Homebrew.)
-
-NullPlayer releases are currently ad-hoc signed, not Developer ID notarized. Because of that, macOS Gatekeeper may say the app is damaged or cannot verify that it is free from malware.
-
-To allow the app from Terminal:
-
-```bash
-xattr -cr /Applications/NullPlayer.app
-```
-
-Or use System Settings:
-
-1. Try to open NullPlayer once.
-2. Open System Settings -> Privacy & Security.
-3. Click Open Anyway next to the NullPlayer message.
-4. Click Open in the confirmation dialog.

--- a/docs/download.md
+++ b/docs/download.md
@@ -34,7 +34,7 @@ After this NullPlayer opens normally.
 
 ## Install with Homebrew (recommended — no security warnings)
 
-Homebrew is a free package manager for macOS. This is the smoothest way to install NullPlayer: Homebrew removes the Gatekeeper quarantine flag automatically, so the app just opens with no security warning and no `xattr` command, and updates are a single command.
+[Homebrew](https://brew.sh/) is a free package manager for macOS. This is the smoothest way to install NullPlayer: Homebrew removes the Gatekeeper quarantine flag automatically, so the app just opens with no security warning and no `xattr` command, and updates are a single command.
 
 New to Homebrew? Here is the whole thing, start to finish:
 

--- a/docs/download.md
+++ b/docs/download.md
@@ -1,0 +1,45 @@
+# Download NullPlayer
+
+Download the latest NullPlayer release for macOS:
+
+https://github.com/ad-repo/nullplayer/releases/latest/download/NullPlayer.dmg
+
+Requires macOS 14 Sonoma or newer.
+
+## Install
+
+1. Open `NullPlayer.dmg`.
+2. Drag `NullPlayer.app` to Applications.
+3. Open NullPlayer from Applications.
+
+## If macOS Blocks the App
+
+NullPlayer releases are currently ad-hoc signed, not Developer ID notarized. Because of that, macOS Gatekeeper may say the app is damaged or cannot verify that it is free from malware.
+
+To allow the app from Terminal:
+
+```bash
+xattr -cr /Applications/NullPlayer.app
+```
+
+Or use System Settings:
+
+1. Try to open NullPlayer once.
+2. Open System Settings -> Privacy & Security.
+3. Click Open Anyway next to the NullPlayer message.
+4. Click Open in the confirmation dialog.
+
+## Advanced: Homebrew
+
+Terminal users can install with Homebrew:
+
+```bash
+brew install --cask ad-repo/nullplayer/nullplayer
+```
+
+To upgrade later:
+
+```bash
+brew update
+brew upgrade --cask ad-repo/nullplayer/nullplayer
+```

--- a/docs/download.md
+++ b/docs/download.md
@@ -46,17 +46,25 @@ New to Homebrew? Here is the whole thing, start to finish:
    ```
 
    Already have Homebrew? Skip this step.
-3. Add the NullPlayer tap (one-time configuration):
+3. Add Homebrew to your shell so the `brew` command is found. The installer finishes by printing a **Next steps** section — run the two commands it lists. On Apple Silicon Macs (M1/M2/M3/M4) they are:
+
+   ```bash
+   echo 'eval "$(/opt/homebrew/bin/brew shellenv)"' >> ~/.zprofile
+   eval "$(/opt/homebrew/bin/brew shellenv)"
+   ```
+
+   On older Intel Macs, replace `/opt/homebrew` with `/usr/local`. If `brew` already worked before you started, skip this step.
+4. Add the NullPlayer tap (one-time configuration):
 
    ```bash
    brew tap ad-repo/nullplayer
    ```
-4. Install NullPlayer:
+5. Install NullPlayer:
 
    ```bash
    brew install --cask ad-repo/nullplayer/nullplayer
    ```
-5. Open NullPlayer from your Applications folder or Launchpad. No security prompt.
+6. Open NullPlayer from your Applications folder or Launchpad. No security prompt.
 
 Update to a new release any time with:
 

--- a/scripts/build_dmg.sh
+++ b/scripts/build_dmg.sh
@@ -93,6 +93,8 @@ log_info "Creating DMG..."
 
 DMG_NAME="$APP_NAME-$VERSION.dmg"
 DMG_PATH="$DIST_DIR/$DMG_NAME"
+STABLE_DMG_NAME="$APP_NAME.dmg"
+STABLE_DMG_PATH="$DIST_DIR/$STABLE_DMG_NAME"
 STAGING_DIR="$DIST_DIR/dmg_staging"
 
 # Create staging directory
@@ -135,6 +137,11 @@ rm -rf "$STAGING_DIR"
 
 log_success "DMG created at $DMG_PATH"
 
+# Keep an immutable, versioned DMG for checksums/Homebrew and a stable filename
+# for human-facing download links such as GitHub Releases' latest/download URL.
+cp "$DMG_PATH" "$STABLE_DMG_PATH"
+log_success "Stable DMG copy created at $STABLE_DMG_PATH"
+
 # Summary
 echo ""
 echo "======================================"
@@ -142,6 +149,7 @@ log_success "Build complete!"
 echo ""
 echo "  App Bundle: $APP_BUNDLE"
 echo "  DMG File:   $DMG_PATH"
+echo "  Stable DMG: $STABLE_DMG_PATH"
 echo "  Size:       $(du -h "$DMG_PATH" | cut -f1)"
 echo "  SHA256:     $(shasum -a 256 "$DMG_PATH" | awk '{print $1}')"
 echo "======================================"

--- a/scripts/create_release.sh
+++ b/scripts/create_release.sh
@@ -1,0 +1,160 @@
+#!/bin/bash
+# Create or update a GitHub release with human-friendly download assets.
+#
+# Usage: ./scripts/create_release.sh [--skip-build] [--draft] [--prerelease] [--dry-run] [--replace-versioned]
+
+set -eo pipefail
+
+RED='\033[0;31m'
+GREEN='\033[0;32m'
+YELLOW='\033[1;33m'
+BLUE='\033[0;34m'
+NC='\033[0m'
+
+log_info() { echo -e "${BLUE}ℹ${NC} $1"; }
+log_success() { echo -e "${GREEN}✓${NC} $1"; }
+log_warning() { echo -e "${YELLOW}⚠${NC} $1"; }
+log_error() { echo -e "${RED}✗${NC} $1" >&2; }
+
+cd "$(dirname "$0")/.."
+REPO_ROOT=$(pwd)
+
+INFO_PLIST="$REPO_ROOT/Sources/NullPlayer/Resources/Info.plist"
+RELEASE_TEMPLATE="$REPO_ROOT/.github/release_template.md"
+CHANGELOG="$REPO_ROOT/CHANGELOG.md"
+DIST_DIR="$REPO_ROOT/dist"
+
+VERSION=$(/usr/libexec/PlistBuddy -c "Print CFBundleShortVersionString" "$INFO_PLIST")
+TAG="$VERSION"
+VERSIONED_DMG="$DIST_DIR/NullPlayer-$VERSION.dmg"
+STABLE_DMG="$DIST_DIR/NullPlayer.dmg"
+NOTES_FILE=$(mktemp "${TMPDIR:-/tmp}/nullplayer-release-$VERSION.XXXXXX")
+CHANGELOG_FILE=$(mktemp "${TMPDIR:-/tmp}/nullplayer-changelog-$VERSION.XXXXXX")
+
+SKIP_BUILD=false
+DRY_RUN=false
+REPLACE_VERSIONED=false
+RELEASE_FLAGS=()
+
+cleanup() {
+    rm -f "$NOTES_FILE" "$CHANGELOG_FILE"
+}
+trap cleanup EXIT
+
+for arg in "$@"; do
+    case "$arg" in
+        --skip-build)
+            SKIP_BUILD=true
+            ;;
+        --draft)
+            RELEASE_FLAGS+=(--draft)
+            ;;
+        --prerelease)
+            RELEASE_FLAGS+=(--prerelease)
+            ;;
+        --dry-run)
+            DRY_RUN=true
+            ;;
+        --replace-versioned)
+            REPLACE_VERSIONED=true
+            ;;
+        *)
+            log_error "Unknown argument: $arg"
+            exit 1
+            ;;
+    esac
+done
+
+if [[ ! -f "$RELEASE_TEMPLATE" ]]; then
+    log_error "Missing release template: $RELEASE_TEMPLATE"
+    exit 1
+fi
+
+if [[ "$SKIP_BUILD" == true ]]; then
+    log_info "Using existing DMG build"
+    if [[ ! -f "$VERSIONED_DMG" ]]; then
+        log_error "Missing versioned DMG: $VERSIONED_DMG"
+        exit 1
+    fi
+    cp "$VERSIONED_DMG" "$STABLE_DMG"
+else
+    log_info "Building release DMG"
+    ./scripts/build_dmg.sh
+fi
+
+if [[ ! -f "$VERSIONED_DMG" || ! -f "$STABLE_DMG" ]]; then
+    log_error "Expected release assets were not created"
+    exit 1
+fi
+
+awk -v version="$VERSION" '
+    $0 == "## " version { found = 1; next }
+    found && /^## / { exit }
+    found { print }
+' "$CHANGELOG" | sed '/./,$!d' > "$CHANGELOG_FILE"
+
+if [[ ! -s "$CHANGELOG_FILE" ]]; then
+    log_warning "No CHANGELOG.md section found for $VERSION; release notes will use a placeholder"
+    echo "- Release notes pending." > "$CHANGELOG_FILE"
+fi
+
+awk -v changelog_file="$CHANGELOG_FILE" '
+    $0 == "{{CHANGELOG}}" {
+        while ((getline line < changelog_file) > 0) {
+            print line
+        }
+        close(changelog_file)
+        next
+    }
+    { print }
+' "$RELEASE_TEMPLATE" > "$NOTES_FILE"
+
+log_info "Release tag: $TAG"
+log_info "Versioned asset: $VERSIONED_DMG"
+log_info "Stable asset: $STABLE_DMG"
+log_info "Release notes: $NOTES_FILE"
+
+if [[ "$DRY_RUN" == true ]]; then
+    log_info "Dry run requested; not calling GitHub"
+    echo ""
+    cat "$NOTES_FILE"
+    exit 0
+fi
+
+if ! command -v gh >/dev/null 2>&1; then
+    log_error "GitHub CLI not found. Install gh or create the release manually."
+    exit 1
+fi
+
+release_asset_exists() {
+    local tag="$1"
+    local asset_name="$2"
+
+    gh release view "$tag" --json assets --jq '.assets[].name' | grep -Fxq "$asset_name"
+}
+
+if gh release view "$TAG" >/dev/null 2>&1; then
+    log_info "Updating existing GitHub release $TAG"
+    gh release edit "$TAG" --title "$VERSION" --notes-file "$NOTES_FILE" "${RELEASE_FLAGS[@]}"
+
+    gh release upload "$TAG" "$STABLE_DMG#Download for macOS" --clobber
+
+    if [[ "$REPLACE_VERSIONED" == true ]]; then
+        log_warning "Replacing versioned release asset; update Homebrew if the SHA256 changed"
+        gh release upload "$TAG" "$VERSIONED_DMG#Versioned archive / Homebrew" --clobber
+    elif release_asset_exists "$TAG" "NullPlayer-$VERSION.dmg"; then
+        log_info "Versioned asset already exists; leaving it unchanged"
+    else
+        gh release upload "$TAG" "$VERSIONED_DMG#Versioned archive / Homebrew"
+    fi
+else
+    log_info "Creating GitHub release $TAG"
+    gh release create "$TAG" \
+        "$STABLE_DMG#Download for macOS" \
+        "$VERSIONED_DMG#Versioned archive / Homebrew" \
+        --title "$VERSION" \
+        --notes-file "$NOTES_FILE" \
+        "${RELEASE_FLAGS[@]}"
+fi
+
+log_success "Release $TAG is ready"

--- a/scripts/create_release.sh
+++ b/scripts/create_release.sh
@@ -1,7 +1,7 @@
 #!/bin/bash
 # Create or update a GitHub release with human-friendly download assets.
 #
-# Usage: ./scripts/create_release.sh [--skip-build] [--draft] [--prerelease] [--dry-run] [--replace-versioned]
+# Usage: ./scripts/create_release.sh [--skip-build] [--draft] [--prerelease] [--dry-run] [--replace-versioned] [--skip-tap]
 
 set -eo pipefail
 
@@ -24,6 +24,10 @@ RELEASE_TEMPLATE="$REPO_ROOT/.github/release_template.md"
 CHANGELOG="$REPO_ROOT/CHANGELOG.md"
 DIST_DIR="$REPO_ROOT/dist"
 
+# Homebrew tap (a separate repo, not cloned locally — edited via the GitHub API).
+TAP_REPO="ad-repo/homebrew-nullplayer"
+CASK_PATH="Casks/nullplayer.rb"
+
 VERSION=$(/usr/libexec/PlistBuddy -c "Print CFBundleShortVersionString" "$INFO_PLIST")
 TAG="$VERSION"
 VERSIONED_DMG="$DIST_DIR/NullPlayer-$VERSION.dmg"
@@ -34,6 +38,9 @@ CHANGELOG_FILE=$(mktemp "${TMPDIR:-/tmp}/nullplayer-changelog-$VERSION.XXXXXX")
 SKIP_BUILD=false
 DRY_RUN=false
 REPLACE_VERSIONED=false
+SKIP_TAP=false
+DRAFT_OR_PRERELEASE=false
+VERSIONED_PUBLISHED=false
 RELEASE_FLAGS=()
 
 cleanup() {
@@ -48,15 +55,20 @@ for arg in "$@"; do
             ;;
         --draft)
             RELEASE_FLAGS+=(--draft)
+            DRAFT_OR_PRERELEASE=true
             ;;
         --prerelease)
             RELEASE_FLAGS+=(--prerelease)
+            DRAFT_OR_PRERELEASE=true
             ;;
         --dry-run)
             DRY_RUN=true
             ;;
         --replace-versioned)
             REPLACE_VERSIONED=true
+            ;;
+        --skip-tap)
+            SKIP_TAP=true
             ;;
         *)
             log_error "Unknown argument: $arg"
@@ -140,12 +152,14 @@ if gh release view "$TAG" >/dev/null 2>&1; then
     gh release upload "$TAG" "$STABLE_DMG#Download for macOS" --clobber
 
     if [[ "$REPLACE_VERSIONED" == true ]]; then
-        log_warning "Replacing versioned release asset; update Homebrew if the SHA256 changed"
+        log_warning "Replacing versioned release asset; the Homebrew cask SHA256 may change"
         gh release upload "$TAG" "$VERSIONED_DMG#Versioned archive / Homebrew" --clobber
+        VERSIONED_PUBLISHED=true
     elif release_asset_exists "$TAG" "NullPlayer-$VERSION.dmg"; then
         log_info "Versioned asset already exists; leaving it unchanged"
     else
         gh release upload "$TAG" "$VERSIONED_DMG#Versioned archive / Homebrew"
+        VERSIONED_PUBLISHED=true
     fi
 else
     log_info "Creating GitHub release $TAG"
@@ -155,6 +169,65 @@ else
         --title "$VERSION" \
         --notes-file "$NOTES_FILE" \
         "${RELEASE_FLAGS[@]}"
+    VERSIONED_PUBLISHED=true
 fi
 
 log_success "Release $TAG is ready"
+
+# Point the Homebrew tap at the versioned DMG we just published. Only run when
+# the versioned asset actually changed (a full release, a fresh upload, or an
+# explicit --replace-versioned) so brew users on an untouched asset aren't
+# disturbed, and never for drafts/prereleases whose download URL isn't live yet.
+update_homebrew_tap() {
+    local sha old_content blob_sha new_content commit_url cask_file
+    cask_file=$(mktemp "${TMPDIR:-/tmp}/nullplayer-cask-$VERSION.XXXXXX")
+
+    log_info "Updating Homebrew cask $CASK_PATH in $TAP_REPO"
+
+    sha=$(shasum -a 256 "$VERSIONED_DMG" | awk '{print $1}')
+
+    if ! old_content=$(gh api "repos/$TAP_REPO/contents/$CASK_PATH" -q .content | base64 -d); then
+        log_error "Could not read $CASK_PATH from $TAP_REPO; update the cask manually"
+        rm -f "$cask_file"
+        return 1
+    fi
+    blob_sha=$(gh api "repos/$TAP_REPO/contents/$CASK_PATH" -q .sha)
+
+    printf '%s\n' "$old_content" > "$cask_file"
+
+    # Only version and sha256 change; the cask url is templated on #{version}.
+    sed -i '' -E "s/version \"[^\"]*\"/version \"$VERSION\"/" "$cask_file"
+    sed -i '' -E "s/sha256 \"[^\"]*\"/sha256 \"$sha\"/" "$cask_file"
+
+    if ! grep -q "version \"$VERSION\"" "$cask_file" || ! grep -q "sha256 \"$sha\"" "$cask_file"; then
+        log_error "Could not rewrite version/sha256 in $CASK_PATH; leaving the tap untouched"
+        rm -f "$cask_file"
+        return 1
+    fi
+
+    new_content=$(cat "$cask_file")
+    if [[ "$new_content" == "$old_content" ]]; then
+        log_info "Homebrew cask already at $VERSION with a matching sha256; nothing to update"
+        rm -f "$cask_file"
+        return 0
+    fi
+
+    commit_url=$(gh api -X PUT "repos/$TAP_REPO/contents/$CASK_PATH" \
+        -f message="Update NullPlayer to $VERSION" \
+        -f content="$(base64 -i "$cask_file")" \
+        -f sha="$blob_sha" -q '.commit.html_url')
+
+    rm -f "$cask_file"
+    log_success "Homebrew cask updated: $commit_url"
+    log_info "brew upgrade --cask ad-repo/nullplayer/nullplayer now pulls $VERSION"
+}
+
+if [[ "$SKIP_TAP" == true ]]; then
+    log_info "Skipping Homebrew tap update (--skip-tap)"
+elif [[ "$DRAFT_OR_PRERELEASE" == true ]]; then
+    log_info "Draft/prerelease build; leaving the Homebrew cask on the current release"
+elif [[ "$VERSIONED_PUBLISHED" != true ]]; then
+    log_info "Versioned asset unchanged; leaving the Homebrew cask as-is"
+else
+    update_homebrew_tap
+fi

--- a/scripts/create_release.sh
+++ b/scripts/create_release.sh
@@ -186,12 +186,19 @@ update_homebrew_tap() {
 
     sha=$(shasum -a 256 "$VERSIONED_DMG" | awk '{print $1}')
 
-    if ! old_content=$(gh api "repos/$TAP_REPO/contents/$CASK_PATH" -q .content | base64 -d); then
+    # Fetch the blob sha and content from one API response. Two separate calls
+    # could race a concurrent edit to the tap and PUT a newer sha with older
+    # content, silently clobbering the intervening change. gsub flattens the
+    # base64 (GitHub wraps it in newlines) so it reads back as a single line.
+    local cask_meta content_b64
+    if ! cask_meta=$(gh api "repos/$TAP_REPO/contents/$CASK_PATH" --jq '.sha, (.content | gsub("\n"; ""))'); then
         log_error "Could not read $CASK_PATH from $TAP_REPO; update the cask manually"
         rm -f "$cask_file"
         return 1
     fi
-    blob_sha=$(gh api "repos/$TAP_REPO/contents/$CASK_PATH" -q .sha)
+    blob_sha=${cask_meta%%$'\n'*}
+    content_b64=${cask_meta#*$'\n'}
+    old_content=$(base64 -d <<<"$content_b64")
 
     printf '%s\n' "$old_content" > "$cask_file"
 

--- a/scripts/create_release.sh
+++ b/scripts/create_release.sh
@@ -42,6 +42,7 @@ SKIP_TAP=false
 DRAFT_OR_PRERELEASE=false
 VERSIONED_PUBLISHED=false
 RELEASE_FLAGS=()
+RELEASE_TARGET=""
 
 cleanup() {
     rm -f "$NOTES_FILE" "$CHANGELOG_FILE"
@@ -77,10 +78,59 @@ for arg in "$@"; do
     esac
 done
 
+require_release_source() {
+    local current_branch local_head remote_main remote_tag_sha status_output
+
+    if ! git rev-parse --is-inside-work-tree >/dev/null 2>&1; then
+        log_error "Release must be run from the NullPlayer git checkout"
+        exit 1
+    fi
+
+    current_branch=$(git branch --show-current)
+    if [[ "$current_branch" != "main" ]]; then
+        log_error "Release must be run from main, not '$current_branch'"
+        log_error "Run: git switch main && git pull --ff-only origin main"
+        exit 1
+    fi
+
+    status_output=$(git status --porcelain)
+    if [[ -n "$status_output" ]]; then
+        log_error "Release checkout has uncommitted changes"
+        log_error "Commit or stash them, then run from a clean main checkout"
+        exit 1
+    fi
+
+    log_info "Checking origin/main"
+    git fetch --quiet origin main:refs/remotes/origin/main
+
+    local_head=$(git rev-parse HEAD)
+    remote_main=$(git rev-parse origin/main)
+    if [[ "$local_head" != "$remote_main" ]]; then
+        log_error "Local main is not up to date with origin/main"
+        log_error "Run: git pull --ff-only origin main"
+        exit 1
+    fi
+
+    remote_tag_sha=$(git ls-remote origin "refs/tags/$TAG^{}" | awk '{print $1}' | head -n 1)
+    if [[ -z "$remote_tag_sha" ]]; then
+        remote_tag_sha=$(git ls-remote origin "refs/tags/$TAG" | awk '{print $1}' | head -n 1)
+    fi
+    if [[ -n "$remote_tag_sha" && "$remote_tag_sha" != "$local_head" ]]; then
+        log_error "Remote tag $TAG already points at $remote_tag_sha, not current main $local_head"
+        log_error "Refusing to publish assets that would not match the release tag"
+        exit 1
+    fi
+
+    RELEASE_TARGET="$local_head"
+    log_info "Release source: main@$RELEASE_TARGET"
+}
+
 if [[ ! -f "$RELEASE_TEMPLATE" ]]; then
     log_error "Missing release template: $RELEASE_TEMPLATE"
     exit 1
 fi
+
+require_release_source
 
 if [[ "$SKIP_BUILD" == true ]]; then
     log_info "Using existing DMG build"
@@ -167,6 +217,7 @@ else
         "$STABLE_DMG#Download for macOS" \
         "$VERSIONED_DMG#Versioned archive / Homebrew" \
         --title "$VERSION" \
+        --target "$RELEASE_TARGET" \
         --notes-file "$NOTES_FILE" \
         "${RELEASE_FLAGS[@]}"
     VERSIONED_PUBLISHED=true


### PR DESCRIPTION
## Summary
- reframe Homebrew as the **recommended, warning-free** install path with a full beginner walkthrough (open Terminal → install Homebrew → install the cask); moved above the "app is damaged" section in README and docs/download.md, no longer labeled "Advanced"
- add stable NullPlayer.dmg generation alongside the versioned release DMG
- add a release helper (`scripts/create_release.sh`) and template that put direct download/install instructions first
- **the release helper now updates the Homebrew cask automatically** — after publishing it hashes the uploaded versioned DMG and rewrites `version` + `sha256` in the separate `ad-repo/homebrew-nullplayer` tap via the GitHub API, so `brew upgrade` picks up the release with no manual step
- rewrite install docs so direct DMG download and Homebrew are both first-class, and document immutable versioned assets for Homebrew vs stable assets for human-facing download links

## Cask auto-update guards
- runs only when the versioned asset actually changed (fresh release, first upload, or `--replace-versioned`)
- skipped for `--draft` / `--prerelease` (their download URL isn't live yet) and via `--skip-tap`
- bails **before** pushing if the version/sha256 rewrite fails or the cask is already current (no empty commit)
- requires `gh` authed with write access to `ad-repo/homebrew-nullplayer`

## Validation
- bash -n scripts/build_dmg.sh
- bash -n scripts/create_release.sh
- shellcheck scripts/create_release.sh (clean)
- ./scripts/create_release.sh --skip-build --dry-run

## Notes
- shellcheck on scripts/build_dmg.sh still reports existing unused-global/source-following warnings around values shared with scripts/lib/assemble_app.sh; this PR leaves that broader cleanup alone.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Updated macOS installation/download guidance (macOS 14 Sonoma+), including quarantine clearing and “Open Anyway” steps.
  * Expanded Homebrew install/update instructions and clarified ad-hoc signing and Keychain token persistence/cleanup.
  * Added dedicated download and development/distribution documentation for versioned vs stable DMG files.
* **Chores**
  * Improved release workflow automation: generates release notes from the changelog, builds/copies DMGs, uploads stable/versioned assets, and updates the Homebrew cask as needed.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->