### PR TITLE
Fix CLI crash/exit on streaming seek-to-EOF and error stops

### DIFF
--- a/Sources/NullPlayer/Audio/AudioEngine.swift
+++ b/Sources/NullPlayer/Audio/AudioEngine.swift
@@ -73,6 +73,16 @@ protocol AudioEngineDelegate: AnyObject {
     func audioEngineDidUpdateSpectrum(_ levels: [Float])
     func audioEngineDidChangePlaylist()
     func audioEngineDidFailToLoadTrack(_ track: Track, error: Error)
+    /// Fired when the streaming player enters an error state, immediately before
+    /// `state` is set to `.stopped`. Lets observers distinguish an error-induced
+    /// stop from a natural end-of-playlist stop (both surface as `.stopped`).
+    func audioEngineDidEncounterPlaybackError()
+}
+
+extension AudioEngineDelegate {
+    // Default no-op: only observers that care about error-vs-natural stops
+    // (e.g. the headless CLI) need to implement this.
+    func audioEngineDidEncounterPlaybackError() {}
 }
 
 /// Core audio engine using AVAudioEngine for playback and DSP
@@ -2561,6 +2571,16 @@ class AudioEngine {
         // Use 1.0s buffer for streaming (seeking too close to EOF can crash the player)
         // Use 0.5s buffer for local files
         let eofBuffer: TimeInterval = isStreamingPlayback ? 1.0 : 0.5
+
+        // Seeking into the final EOF region of a fully-buffered stream drives the
+        // AudioStreaming player into an error state (which stops playback). When a
+        // forward seek reaches the end of a streaming track, let the track finish
+        // playing instead of issuing a doomed seek — it will advance naturally.
+        if isStreamingPlayback && time >= currentDuration - eofBuffer && time > currentTime {
+            NSLog("AudioEngine: Ignoring forward streaming seek into EOF region (%.2f/%.2f) - letting track finish", time, currentDuration)
+            return
+        }
+
         let seekTime = max(0, min(time, currentDuration - eofBuffer))
         
         if isStreamingPlayback {
@@ -6162,6 +6182,10 @@ extension AudioEngine: StreamingAudioPlayerDelegate {
         case .error:
             NSLog("AudioEngine: Streaming player entered error state")
             streamingPlaybackConfirmed = false
+            // Signal the error BEFORE flipping to .stopped so observers can tell
+            // this apart from a natural end-of-playlist stop (the didSet on `state`
+            // fires audioEngineDidChangeState(.stopped) synchronously below).
+            delegate?.audioEngineDidEncounterPlaybackError()
             self.state = .stopped
             isSeekingStreaming = false
             // Cancel any pending seeks and reset work items

--- a/Sources/NullPlayer/CLI/CLIPlayer.swift
+++ b/Sources/NullPlayer/CLI/CLIPlayer.swift
@@ -100,6 +100,12 @@ class CLIPlayer: AudioEngineDelegate {
     private var currentPlaylist: [Track] = []
     private var hasStartedPlaying = false
 
+    /// Set when the streaming player enters an error state. The engine surfaces
+    /// both error-induced and natural end-of-playlist stops as `.stopped`, so this
+    /// flag lets us tell them apart and avoid quitting (or restart-looping) on an
+    /// error such as a mid-stream network drop.
+    private var lastStopWasError = false
+
     func play(tracks: [Track]) {
         currentPlaylist = tracks
         audioEngine.loadTracks(tracks)
@@ -286,7 +292,23 @@ class CLIPlayer: AudioEngineDelegate {
 
     // MARK: - AudioEngineDelegate
 
+    func audioEngineDidEncounterPlaybackError() {
+        lastStopWasError = true
+    }
+
     func audioEngineDidChangeState(_ state: PlaybackState) {
+        // An error-induced stop (e.g. seek into EOF, network drop, dead server)
+        // surfaces as .stopped just like a natural end-of-playlist. Don't treat it
+        // as completion: skip both the repeat-all restart (which would hammer a
+        // failing stream in a tight loop) and the exit. Stay alive so the user can
+        // press > to skip or q to quit.
+        if state == .stopped && lastStopWasError {
+            lastStopWasError = false
+            display.printState(state)
+            display.printAboveProgress("Playback error — press > to skip or q to quit")
+            return
+        }
+
         // Implement repeat-all: when playlist ends (state == .stopped),
         // reload and restart from the beginning
         if state == .stopped && options.repeatAll && !currentPlaylist.isEmpty {
@@ -296,6 +318,7 @@ class CLIPlayer: AudioEngineDelegate {
         }
         if state == .playing {
             hasStartedPlaying = true
+            lastStopWasError = false  // Recovered — a later stop is a real one
         }
         display.printState(state)
         // Exit when playback finishes naturally and there is nothing left to play


### PR DESCRIPTION
## Problem

In headless CLI mode, hitting **seek-forward at the end of a streaming (Plex) track crashed out** — the process exited. Root cause: seeking into the final EOF region of a fully-buffered stream drives the AudioStreaming player into an `.error` state, which `AudioEngine` maps to `.stopped`. The CLI treats *any* `.stopped` after playback started as end-of-playlist and calls `exit(0)`.

This also meant **any** streaming error (mid-stream network drop, dead server) silently killed the CLI — and under `--repeat-all` would tight-loop restarting a failing stream.

## Fixes

**1. Don't issue doomed EOF seeks** (`AudioEngine.seek`)
A forward streaming seek that lands within the EOF buffer is ignored; the track plays out and advances naturally. Backward and mid-track seeks are unaffected.

**2. Distinguish error stops from natural completion**
- New `AudioEngineDelegate.audioEngineDidEncounterPlaybackError()` with a **default no-op** (GUI `AppDelegate` unchanged), fired from the `.error` handler *before* the `.stopped` transition.
- `CLIPlayer` uses it to skip both the `exit(0)` and the `--repeat-all` restart on error stops, staying alive so the user can press `>` to skip or `q` to quit.

| Scenario | Before | After |
|----------|--------|-------|
| Seek → EOF | crash/exit | seek ignored, track finishes |
| Network drop mid-stream | silent `exit(0)` | stays alive, prompts skip/quit |
| Dead server + `--repeat-all` | infinite restart loop | stops looping, prompts |
| Last track finishes normally | exits | exits (unchanged) |

## Testing

`swift build` passes. Manual QA recommended: in CLI mode, mash seek-forward at the end of a Plex FLAC, and pull the network mid-track — confirm the CLI no longer exits.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Streaming playback now reports when an error occurs, giving clearer feedback instead of treating it like a normal stop.
* **Bug Fixes**
  * Improved seeking near the end of streamed tracks so playback finishes naturally instead of triggering an unexpected stop.
  * The command-line player now better distinguishes playback errors from reaching the end of a track, showing a clearer prompt for what to do next.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->