### PR TITLE
Retire deprecated double-size toggle

### DIFF
--- a/Sources/NullPlayer/App/ContextMenuBuilder.swift
+++ b/Sources/NullPlayer/App/ContextMenuBuilder.swift
@@ -4749,13 +4749,6 @@ class MenuActions: NSObject {
         WindowManager.shared.toggleCompactWindow()
     }
 
-    @objc func toggleDoubleSize() {
-        // Live toggle in both modern and classic UI — applyDoubleSize() rescales every
-        // window in place (classic windows self-scale their skin rendering from their bounds),
-        // so no restart is needed.
-        WindowManager.shared.isDoubleSize.toggle()
-    }
-
     @objc func setUIScaleLevel(_ sender: NSMenuItem) {
         guard let rawValue = sender.representedObject as? String,
               let level = UIScaleLevel(storedRawValue: rawValue) else { return }

--- a/Sources/NullPlayer/App/WindowManager.swift
+++ b/Sources/NullPlayer/App/WindowManager.swift
@@ -228,8 +228,7 @@ class WindowManager {
 
     /// Back-compat shim for callers that only need to know whether the UI is at a non-default size.
     var isDoubleSize: Bool {
-        get { uiScaleLevel != .p100 }
-        set { uiScaleLevel = newValue ? .p150 : .p100 }
+        uiScaleLevel != .p100
     }
 
     /// Classic UI size multiplier driven by the UI Size menu.


### PR DESCRIPTION
## Summary

Follow-up cleanup to #342 (UI Size percentage options). #342 replaced the boolean double-size toggle with discrete `UIScaleLevel` scale levels, but the removal of the now-dead double-size code path was left uncommitted and didn't land with it. This finishes that:

- Remove the dead `toggleDoubleSize()` menu action from `ContextMenuBuilder` (nothing references it — sizing is driven by `setUIScaleLevel(_:)`).
- Make `WindowManager.isDoubleSize` a read-only back-compat shim (`uiScaleLevel != .p100`), dropping the setter that mapped a bool onto `.p150`/`.p100`.

`AppStateManager` still reads `isDoubleSize` (getter) for legacy state migration, which continues to work; its own `AppState.isDoubleSize` stored property is unaffected.

## Testing

`swift build` passes on top of current `main`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)