### PR TITLE
Fix CLI Sonos casting, album-art rendering, and log noise

### DIFF
--- a/README.md
+++ b/README.md
@@ -291,6 +291,10 @@ nullplayer --cli --source radio --station "Heart 80s UK"
 # Outputs and casting
 nullplayer --cli --source local --artist "Augustus Pablo" --output "MacBook Pro Speakers"
 nullplayer --cli --source plex --playlist "Recently Added" --cast "Living Room" --cast-type sonos
+
+# Sonos multi-room: the first name is the group coordinator, the rest are grouped onto it
+nullplayer --cli --source plex --playlist "Recently Added" --cast "Living Room,Kitchen,Office" --cast-type sonos
+# (equivalent to --cast "Living Room" --sonos-rooms "Kitchen,Office")
 ```
 
 ### Volume control

--- a/README.md
+++ b/README.md
@@ -336,6 +336,31 @@ nullplayer --cli --source radio --station "Radio Paradise: Mellow Mix" --tuning-
 | `m` | Toggle mute |
 | `i` | Show track info |
 
+### Terminal display
+
+During playback the CLI shows album art in the terminal. The render mode is auto-detected from the terminal's color support and can be forced:
+
+- default: color half-block art on color-capable terminals (truecolor or 256-color), otherwise a monochrome character-ramp
+- `--color-art`: force color art
+- `--ascii-art`: force the monochrome character-ramp — use this if your terminal reports color but renders the art as flat blocks
+- `--no-art`: disable album art
+
+```bash
+nullplayer --cli --source local --artist "Rush" --ascii-art
+```
+
+If a terminal misreports its color support (some shell profiles `export COLORTERM=truecolor` globally, making every terminal claim color it can't paint), set a per-terminal default in that terminal's shell profile instead of passing a flag each time:
+
+```sh
+export NULLPLAYER_ART=ascii   # or: color, auto (default). Flags still override.
+```
+
+Framework log output is suppressed by default so the session stays clean. Pass `--verbose` to keep it for debugging:
+
+```bash
+nullplayer --cli --source plex --playlist "All Music" --cast "Living Room" --cast-type sonos --verbose
+```
+
 See `nullplayer --cli --help` for the full flag reference. If you have not installed the launcher yet, the underlying app binary is still available at `NullPlayer.app/Contents/MacOS/NullPlayer`.
 
 ## Development

--- a/Sources/NullPlayer/App/main.swift
+++ b/Sources/NullPlayer/App/main.swift
@@ -7,6 +7,10 @@ if args.contains("--cli") && args.contains("--ui-testing") {
 }
 
 if args.contains("--cli") {
+    // Silence the app's pervasive NSLog output before anything can log, keeping the
+    // CLI's own messages (via cliStderr) visible. --verbose keeps logs for debugging.
+    suppressFrameworkLoggingForCLI(verbose: args.contains("--verbose"))
+
     let app = NSApplication.shared
     app.setActivationPolicy(.accessory)   // no Dock icon, no menu bar
     let cliDelegate = CLIMode()

--- a/Sources/NullPlayer/CLI/CLIDisplay.swift
+++ b/Sources/NullPlayer/CLI/CLIDisplay.swift
@@ -172,13 +172,19 @@ class CLIDisplay {
             --tuning-offset-cents <n>   Direct tuning offset in cents
             --cast <device>             Cast to device
             --cast-type <type>          Filter: sonos, chromecast, dlna
-            --sonos-rooms <rooms>       Multi-room (comma-separated)
+            --sonos-rooms <rooms>       Group rooms (comma-separated) to --cast device
             --folder <name>             Radio folder: all, favorites, top-rated,
                                         unrated, recent, channels, genres, regions,
                                         genre, channel, region
             --channel <name>            Radio channel (with --folder channel)
             --region <name>             Radio region (with --folder region)
-            --no-art                    Disable ASCII album art
+            --verbose                   Keep framework log output (suppressed by default)
+            --no-art                    Disable album art
+            --color-art                 Force color art (truecolor/256-color)
+            --ascii-art                 Force monochrome character-ramp art
+                                        (default auto-detects terminal color support;
+                                        set NULLPLAYER_ART=ascii|color|auto to pin a
+                                        per-terminal default)
             --json                      JSON output for queries
 
         KEYBOARD CONTROLS (during playback):
@@ -204,14 +210,66 @@ class CLIDisplay {
 
     // MARK: - ASCII Art
 
-    func printAsciiArt(_ image: NSImage) {
+    /// Luminance ramp, darkest → brightest, for the no-color (mono) path.
+    /// Assumes a dark terminal background so denser glyphs read as brighter pixels.
+    private static let asciiRamp = Array(" .:-=+*#%@")
+
+    enum ColorMode { case truecolor, ansi256, mono }
+
+    /// Best-effort detection of the terminal's color capability from the environment.
+    /// Purely declarative (env-based) — it reports what the terminal *claims*, which
+    /// a color-disabled profile can still misrepresent; hence the explicit overrides.
+    /// Only returns a color mode on a positive signal, so ambiguous terminals fall
+    /// back to the always-safe monochrome ramp.
+    static func detectColorMode() -> ColorMode {
+        // Not a real terminal (piped/redirected) → color codes would be garbage.
+        guard isatty(fileno(stdout)) != 0 else { return .mono }
+        let env = ProcessInfo.processInfo.environment
+        let colorterm = env["COLORTERM"]?.lowercased() ?? ""
+        if colorterm.contains("truecolor") || colorterm.contains("24bit") { return .truecolor }
+        let term = env["TERM"]?.lowercased() ?? ""
+        if term.contains("truecolor") || term.contains("direct") { return .truecolor }
+        if term.contains("256color") { return .ansi256 }
+        return .mono
+    }
+
+    /// Render album art to the terminal.
+    ///
+    /// By default the mode is auto-detected (`detectColorMode`): a color-capable
+    /// terminal gets truecolor/256 half-block art, everything else gets a monochrome
+    /// luminance→character ramp that renders anywhere. The overrides exist because
+    /// detection is declarative and a terminal can misreport its color support.
+    /// Precedence: explicit flags > `NULLPLAYER_ART` env var > auto-detection.
+    /// - Parameters:
+    ///   - forceColor: force the color half-block path (`--color-art`).
+    ///   - forceAscii: force the monochrome ramp (`--ascii-art`), for terminals that
+    ///     claim color but don't actually render it.
+    func printAsciiArt(_ image: NSImage, forceColor: Bool = false, forceAscii: Bool = false) {
+        let detected = Self.detectColorMode()
+        let asciiMode: Bool
+        if forceAscii {
+            asciiMode = true
+        } else if forceColor {
+            asciiMode = false
+        } else {
+            // Per-terminal default override. Detection is env-based and can't see through
+            // a terminal that misreports color support (e.g. `export COLORTERM=truecolor`
+            // in a shell profile makes every terminal claim truecolor even when it renders
+            // monochrome). NULLPLAYER_ART lets such a terminal pin `ascii` in its profile
+            // without passing a flag every time. Unset/"auto"/unrecognized → auto-detect.
+            switch ProcessInfo.processInfo.environment["NULLPLAYER_ART"]?.lowercased() {
+            case "ascii", "mono": asciiMode = true
+            case "color":         asciiMode = false
+            default:              asciiMode = (detected == .mono)
+            }
+        }
         let artWidth = 60  // characters wide
-        // Terminal characters are ~2:1 tall:wide. Each half-block char (▀) covers
-        // 2 pixel rows, so one character cell ≈ 1 square pixel visually.
-        // To produce a square image: artWidth cols × (artWidth/2) rows of chars,
-        // sampled from an artWidth×artWidth pixel grid.
+        // Terminal characters are ~2:1 tall:wide. In color mode each half-block char
+        // (▀) covers 2 pixel rows, so a square image needs artWidth×artWidth pixels
+        // (→ artWidth/2 output rows). In ascii mode each char covers 1 pixel, so a
+        // square image needs artWidth × (artWidth/2) pixels (one char per pixel).
         let pixelWidth = artWidth
-        let pixelHeight = artWidth  // artWidth/2 output rows × 2 pixel-rows each
+        let pixelHeight = asciiMode ? artWidth / 2 : artWidth
 
         // cgImage(forProposedRect:) returns nil in headless processes (no display context).
         // tiffRepresentation rasterizes at native size without needing a screen.
@@ -248,6 +306,39 @@ class CLIDisplay {
         context.interpolationQuality = .high
         context.draw(cgImage, in: CGRect(x: 0, y: 0, width: pixelWidth, height: pixelHeight))
 
+        // No-color path: map each pixel's luminance to a ramp glyph. Works on any
+        // terminal because it carries the image in the characters themselves, not
+        // in color codes. CGContext origin is bottom-left (memory row 0 = image top).
+        if asciiMode {
+            var lines: [String] = []
+            for row in 0..<pixelHeight {
+                var line = ""
+                for x in 0..<pixelWidth {
+                    let idx = row * bytesPerRow + x * bytesPerPixel
+                    let r = Double(pixelData[idx])
+                    let g = Double(pixelData[idx + 1])
+                    let b = Double(pixelData[idx + 2])
+                    // Rec. 601 luma → ramp index.
+                    let luma = 0.299 * r + 0.587 * g + 0.114 * b
+                    let rampIdx = min(Self.asciiRamp.count - 1,
+                                      Int(luma / 255.0 * Double(Self.asciiRamp.count - 1)))
+                    line.append(Self.asciiRamp[rampIdx])
+                }
+                lines.append(line)
+            }
+            fputs("\r\u{1B}[K\n", stdout)
+            for line in lines { print(line) }
+            print("")
+            fflush(stdout)
+            return
+        }
+
+        // Color half-block path. Every cell is the same ▀ glyph — the picture is
+        // carried entirely by the per-cell color codes. Use truecolor only when it
+        // was positively detected; otherwise emit the xterm 256-color palette (which
+        // is what a forceColor request on an unknown terminal falls back to).
+        let useTrueColor = (detected == .truecolor)
+
         // Build ASCII art using half-block characters.
         // Each output row combines two pixel rows:
         //   top pixel → foreground color (▀ upper half block)
@@ -267,8 +358,15 @@ class CLIDisplay {
                 let br = pixelData[botIdx]
                 let bg = pixelData[botIdx + 1]
                 let bb = pixelData[botIdx + 2]
-                // True color: \e[38;2;R;G;Bm (fg) \e[48;2;R;G;Bm (bg)
-                line += "\u{1B}[38;2;\(tr);\(tg);\(tb);48;2;\(br);\(bg);\(bb)m▀"
+                if useTrueColor {
+                    // True color: \e[38;2;R;G;Bm (fg) \e[48;2;R;G;Bm (bg)
+                    line += "\u{1B}[38;2;\(tr);\(tg);\(tb);48;2;\(br);\(bg);\(bb)m▀"
+                } else {
+                    // 256-color fallback: \e[38;5;{n}m (fg) \e[48;5;{n}m (bg)
+                    let fgIdx = Self.ansi256Index(r: tr, g: tg, b: tb)
+                    let bgIdx = Self.ansi256Index(r: br, g: bg, b: bb)
+                    line += "\u{1B}[38;5;\(fgIdx);48;5;\(bgIdx)m▀"
+                }
             }
             line += "\u{1B}[0m"  // reset
             lines.append(line)
@@ -286,6 +384,40 @@ class CLIDisplay {
     }
 
     // MARK: - Helpers
+
+    /// Map an 8-bit RGB color to the nearest xterm 256-color palette index.
+    /// Considers both the 6×6×6 color cube (16–231) and the grayscale ramp
+    /// (232–255), returning whichever candidate is closer to the source color.
+    private static func ansi256Index(r: UInt8, g: UInt8, b: UInt8) -> Int {
+        let ri = Int(r), gi = Int(g), bi = Int(b)
+
+        // Nearest color-cube component using xterm's non-linear steps.
+        let steps = [0, 95, 135, 175, 215, 255]
+        func cubeIndex(_ v: Int) -> Int {
+            var best = 0, bestDist = Int.max
+            for (i, s) in steps.enumerated() {
+                let d = abs(s - v)
+                if d < bestDist { bestDist = d; best = i }
+            }
+            return best
+        }
+        let cr = cubeIndex(ri), cg = cubeIndex(gi), cb = cubeIndex(bi)
+        let cubeColor = (steps[cr], steps[cg], steps[cb])
+        let cubeCode = 16 + 36 * cr + 6 * cg + cb
+
+        // Nearest grayscale-ramp entry (codes 232–255 → values 8, 18, …, 238).
+        let gray = (ri + gi + bi) / 3
+        let grayIdx = max(0, min(23, (gray - 8) / 10))
+        let grayValue = 8 + grayIdx * 10
+        let grayCode = 232 + grayIdx
+
+        // Pick whichever candidate is closer (squared RGB distance).
+        func dist(_ c: (Int, Int, Int)) -> Int {
+            let dr = c.0 - ri, dg = c.1 - gi, db = c.2 - bi
+            return dr * dr + dg * dg + db * db
+        }
+        return dist(cubeColor) <= dist((grayValue, grayValue, grayValue)) ? cubeCode : grayCode
+    }
 
     private func formatTime(_ time: TimeInterval) -> String {
         let mins = Int(time) / 60

--- a/Sources/NullPlayer/CLI/CLIDisplay.swift
+++ b/Sources/NullPlayer/CLI/CLIDisplay.swift
@@ -170,9 +170,11 @@ class CLIDisplay {
             --tuning <off|Hz>           Reference Tuning target Hz
             --tuning-source <Hz>        Source reference Hz (default: 440)
             --tuning-offset-cents <n>   Direct tuning offset in cents
-            --cast <device>             Cast to device
+            --cast <device[,rooms…]>    Cast to device. For Sonos, a comma-separated
+                                        list groups the extra rooms onto the first
             --cast-type <type>          Filter: sonos, chromecast, dlna
-            --sonos-rooms <rooms>       Group rooms (comma-separated) to --cast device
+            --sonos-rooms <rooms>       Extra Sonos rooms to group (comma-separated;
+                                        merged with any rooms listed in --cast)
             --folder <name>             Radio folder: all, favorites, top-rated,
                                         unrated, recent, channels, genres, regions,
                                         genre, channel, region

--- a/Sources/NullPlayer/CLI/CLIMode.swift
+++ b/Sources/NullPlayer/CLI/CLIMode.swift
@@ -46,6 +46,11 @@ struct CLIOptions {
     var repeatAll = false
     var repeatOne = false
     var art = true
+    // Album art rendering. Default (both false) auto-detects the terminal's color
+    // support and picks color or a monochrome ramp accordingly. The flags force it.
+    var artColor = false   // --color-art: force color half-block art
+    var artAscii = false   // --ascii-art: force monochrome character ramp
+    var verbose = false    // --verbose: keep framework NSLog output (handled in main.swift)
     var volume: Int?
 
     // Casting
@@ -87,6 +92,9 @@ struct CLIOptions {
             case "--repeat-all": opts.repeatAll = true
             case "--repeat-one": opts.repeatOne = true
             case "--no-art": opts.art = false
+            case "--color-art": opts.artColor = true
+            case "--ascii-art": opts.artAscii = true
+            case "--verbose": opts.verbose = true
             case "--list-sources": opts.listSources = true
             case "--list-libraries": opts.listLibraries = true
             case "--list-artists": opts.listArtists = true
@@ -111,7 +119,7 @@ struct CLIOptions {
                     case "--genre": opts.genre = value
                     case "--decade":
                         guard let intVal = Int(value) else {
-                            fputs("Error: --decade requires an integer value (e.g. 1970)\n", stderr)
+                            fputs("Error: --decade requires an integer value (e.g. 1970)\n", cliStderr)
                             exit(1)
                         }
                         opts.decade = intVal
@@ -124,7 +132,7 @@ struct CLIOptions {
                     case "--region": opts.region = value
                     case "--volume":
                         guard let intVal = Int(value) else {
-                            fputs("Error: --volume requires an integer value (0-100)\n", stderr)
+                            fputs("Error: --volume requires an integer value (0-100)\n", cliStderr)
                             exit(1)
                         }
                         opts.volume = intVal
@@ -137,17 +145,17 @@ struct CLIOptions {
                     case "--tuning-source": opts.tuningSource = value
                     case "--tuning-offset-cents":
                         guard let d = Double(value) else {
-                            fputs("Error: --tuning-offset-cents requires a number\n", stderr)
+                            fputs("Error: --tuning-offset-cents requires a number\n", cliStderr)
                             exit(1)
                         }
                         opts.tuningOffsetCents = d
                     default:
-                        fputs("Error: Unknown flag '\(arg)'\n", stderr)
+                        fputs("Error: Unknown flag '\(arg)'\n", cliStderr)
                         exit(1)
                     }
                     i += 1 // skip value
                 } else if arg.hasPrefix("--") {
-                    fputs("Error: Flag '\(arg)' requires a value\n", stderr)
+                    fputs("Error: Flag '\(arg)' requires a value\n", cliStderr)
                     exit(1)
                 }
             }
@@ -199,7 +207,7 @@ class CLIMode: NSObject, NSApplicationDelegate {
 
         // Validate mutually exclusive flags
         if opts.repeatAll && opts.repeatOne {
-            fputs("Error: --repeat-all and --repeat-one are mutually exclusive\n", stderr)
+            fputs("Error: --repeat-all and --repeat-one are mutually exclusive\n", cliStderr)
             exit(1)
         }
 
@@ -210,7 +218,7 @@ class CLIMode: NSObject, NSApplicationDelegate {
                     try await CLIQueryHandler.handle(opts)
                     exit(0)
                 } catch {
-                    fputs("Error: \(error.localizedDescription.redactingSensitiveURLQueryItems)\n", stderr)
+                    fputs("Error: \(error.localizedDescription.redactingSensitiveURLQueryItems)\n", cliStderr)
                     exit(1)
                 }
             }
@@ -229,7 +237,7 @@ class CLIMode: NSObject, NSApplicationDelegate {
                 switch result {
                 case .tracks(let tracks):
                     if tracks.isEmpty {
-                        fputs("Error: No tracks found for the given criteria.\n", stderr)
+                        fputs("Error: No tracks found for the given criteria.\n", cliStderr)
                         exit(1)
                     }
                     cliPlayer.play(tracks: tracks)
@@ -242,7 +250,7 @@ class CLIMode: NSObject, NSApplicationDelegate {
                 self.keyboard = kb
                 kb.start()
             } catch {
-                fputs("Error: \(error.localizedDescription.redactingSensitiveURLQueryItems)\n", stderr)
+                fputs("Error: \(error.localizedDescription.redactingSensitiveURLQueryItems)\n", cliStderr)
                 exit(1)
             }
         }

--- a/Sources/NullPlayer/CLI/CLIPlayer.swift
+++ b/Sources/NullPlayer/CLI/CLIPlayer.swift
@@ -126,12 +126,12 @@ class CLIPlayer: AudioEngineDelegate {
         // Casting
         if let castName = options.cast {
             Task { @MainActor in
-                await setupCasting(deviceName: castName)
+                await setupCasting(castValue: castName)
             }
         }
     }
 
-    private func setupCasting(deviceName: String) async {
+    private func setupCasting(castValue: String) async {
         // Wait for AudioEngine to have a current track loaded before casting
         let trackDeadline = Date().addingTimeInterval(5)
         while audioEngine.currentTrack == nil && Date() < trackDeadline {
@@ -141,6 +141,16 @@ class CLIPlayer: AudioEngineDelegate {
             fputs("Error: No track loaded for casting\n", cliStderr)
             return
         }
+
+        // --cast accepts a comma-separated list: the first entry is the device we cast
+        // to (the Sonos group coordinator); any remaining entries are Sonos rooms to
+        // group onto it, merged with --sonos-rooms. Grouping is Sonos-only.
+        let castComponents = castValue
+            .split(separator: ",")
+            .map { $0.trimmingCharacters(in: .whitespaces) }
+            .filter { !$0.isEmpty }
+        let deviceName = castComponents.first ?? castValue.trimmingCharacters(in: .whitespaces)
+        let inlineRooms = Array(castComponents.dropFirst())
 
         // Resolve and validate cast type once up front
         let typeFilter: CastDeviceType?
@@ -192,9 +202,24 @@ class CLIPlayer: AudioEngineDelegate {
             castSessionActive = true
             try await CastManager.shared.castCurrentTrack(to: device)
 
-            // Sonos multi-room
-            if let roomsStr = options.sonosRooms {
-                let roomNames = roomsStr.split(separator: ",").map { $0.trimmingCharacters(in: .whitespaces) }
+            // Rooms to group: inline (from --cast "A,B,C") plus --sonos-rooms.
+            let explicitRooms = options.sonosRooms?
+                .split(separator: ",")
+                .map { $0.trimmingCharacters(in: .whitespaces) } ?? []
+            // Dedupe case-insensitively and drop the coordinator itself.
+            var seen = Set([deviceName.lowercased()])
+            var roomNames: [String] = []
+            for room in inlineRooms + explicitRooms where !room.isEmpty {
+                if seen.insert(room.lowercased()).inserted {
+                    roomNames.append(room)
+                }
+            }
+
+            if !roomNames.isEmpty {
+                guard device.type == .sonos else {
+                    fputs("Warning: multi-room grouping is only supported for Sonos; ignoring \(roomNames.joined(separator: ", "))\n", cliStderr)
+                    return
+                }
                 let sonosDevices = CastManager.shared.discoveredDevices.filter { $0.type == .sonos }
                 let coordinatorUDN = device.id
 

--- a/Sources/NullPlayer/CLI/CLIPlayer.swift
+++ b/Sources/NullPlayer/CLI/CLIPlayer.swift
@@ -6,6 +6,7 @@ class CLIPlayer: AudioEngineDelegate {
     let display = CLIDisplay()
     private var previousVolume: Float = 0.5
     private var lastArtworkKey: String?
+    private var lastTrackInfoKey: String?
 
     init(options: CLIOptions) {
         self.options = options
@@ -41,7 +42,7 @@ class CLIPlayer: AudioEngineDelegate {
         // Precedence: --tuning-offset-cents → --tuning off → --tuning <Hz> → persisted state.
         if let cents = options.tuningOffsetCents {
             guard cents.isFinite else {
-                fputs("Error: --tuning-offset-cents must be a finite number\n", stderr)
+                fputs("Error: --tuning-offset-cents must be a finite number\n", cliStderr)
                 exit(1)
             }
             audioEngine.setTuningOffsetCents(cents, persist: false)
@@ -52,7 +53,7 @@ class CLIPlayer: AudioEngineDelegate {
                 let sourceHz: Double
                 if let src = options.tuningSource {
                     guard let parsed = Double(src), parsed.isFinite, parsed > 0 else {
-                        fputs("Error: --tuning-source requires a positive number (Hz)\n", stderr)
+                        fputs("Error: --tuning-source requires a positive number (Hz)\n", cliStderr)
                         exit(1)
                     }
                     sourceHz = parsed
@@ -61,7 +62,7 @@ class CLIPlayer: AudioEngineDelegate {
                 }
                 audioEngine.setTuningPreset(.custom(source: sourceHz, target: targetHz), persist: false)
             } else {
-                fputs("Error: --tuning requires 'off' or a positive number in Hz (e.g. 432)\n", stderr)
+                fputs("Error: --tuning requires 'off' or a positive number in Hz (e.g. 432)\n", cliStderr)
                 exit(1)
             }
         }
@@ -78,7 +79,7 @@ class CLIPlayer: AudioEngineDelegate {
                 audioEngine.setEQEnabled(true)
             } else {
                 let names = EQPreset.allPresets.map { $0.name }.joined(separator: ", ")
-                fputs("Error: Unknown EQ preset '\(eqName)'. Available: \(names)\n", stderr)
+                fputs("Error: Unknown EQ preset '\(eqName)'. Available: \(names)\n", cliStderr)
                 exit(1)
             }
         }
@@ -91,7 +92,7 @@ class CLIPlayer: AudioEngineDelegate {
                 audioEngine.setOutputDevice(device.id)
             } else {
                 let names = AudioOutputManager.shared.outputDevices.map { $0.name }.joined(separator: ", ")
-                fputs("Error: Unknown output device '\(outputName)'. Available: \(names)\n", stderr)
+                fputs("Error: Unknown output device '\(outputName)'. Available: \(names)\n", cliStderr)
                 exit(1)
             }
         }
@@ -99,6 +100,13 @@ class CLIPlayer: AudioEngineDelegate {
 
     private var currentPlaylist: [Track] = []
     private var hasStartedPlaying = false
+
+    /// Set once we commit to casting. During the cast handoff the local engine is
+    /// deliberately stopped (`stopLocalForCasting`) and emits `.stopped` even though
+    /// audio is now playing on the cast device (the engine re-enters `.playing` once
+    /// the device reports status). Without this flag the CLI would mistake that
+    /// handoff `.stopped` for end-of-playlist and quit exactly when casting begins.
+    private var castSessionActive = false
 
     /// Set when the streaming player enters an error state. The engine surfaces
     /// both error-induced and natural end-of-playlist stops as `.stopped`, so this
@@ -110,7 +118,7 @@ class CLIPlayer: AudioEngineDelegate {
         currentPlaylist = tracks
         audioEngine.loadTracks(tracks)
         audioEngine.play()
-        display.printTrackInfo(tracks.first)
+        printTrackInfoIfChanged(tracks.first)
         if options.art, let first = tracks.first {
             showArtworkIfChanged(for: first)
         }
@@ -130,40 +138,58 @@ class CLIPlayer: AudioEngineDelegate {
             try? await Task.sleep(nanoseconds: 100_000_000)
         }
         guard audioEngine.currentTrack != nil else {
-            fputs("Error: No track loaded for casting\n", stderr)
+            fputs("Error: No track loaded for casting\n", cliStderr)
             return
         }
 
-        CastManager.shared.startDiscovery()
+        // Resolve and validate cast type once up front
+        let typeFilter: CastDeviceType?
+        if let castType = options.castType {
+            switch castType.lowercased() {
+            case "sonos": typeFilter = .sonos
+            case "chromecast": typeFilter = .chromecast
+            case "dlna": typeFilter = .dlnaTV
+            default:
+                fputs("Error: Unknown cast type '\(castType)'. Use: sonos, chromecast, dlna\n", cliStderr)
+                return
+            }
+        } else {
+            typeFilter = nil
+        }
 
-        // Poll for devices with 10s timeout
-        let deadline = Date().addingTimeInterval(10)
-        while CastManager.shared.discoveredDevices.isEmpty && Date() < deadline {
+        CastManager.shared.startDiscovery()
+        fputs("Discovering cast devices…\n", cliStderr)
+
+        // Poll for matching device with 15s timeout
+        let deadline = Date().addingTimeInterval(15)
+        var device: CastDevice?
+
+        while Date() < deadline {
+            let allDevices = CastManager.shared.discoveredDevices
+            let filteredDevices = typeFilter.map { type in allDevices.filter { $0.type == type } } ?? allDevices
+
+            if let match = filteredDevices.first(where: {
+                $0.name.caseInsensitiveCompare(deviceName) == .orderedSame
+            }) {
+                device = match
+                break
+            }
+
             try? await Task.sleep(nanoseconds: 500_000_000)
         }
 
-        // Filter by cast type if specified
-        var devices = CastManager.shared.discoveredDevices
-        if let castType = options.castType {
-            switch castType.lowercased() {
-            case "sonos": devices = devices.filter { $0.type == .sonos }
-            case "chromecast": devices = devices.filter { $0.type == .chromecast }
-            case "dlna": devices = devices.filter { $0.type == .dlnaTV }
-            default:
-                fputs("Error: Unknown cast type '\(castType)'. Use: sonos, chromecast, dlna\n", stderr)
-                return
-            }
-        }
-
-        guard let device = devices.first(where: {
-            $0.name.caseInsensitiveCompare(deviceName) == .orderedSame
-        }) else {
-            let available = devices.map { "\($0.name) (\($0.type))" }.joined(separator: ", ")
-            fputs("Error: Cast device '\(deviceName)' not found. Available: \(available)\n", stderr)
+        guard let device else {
+            let allDevices = CastManager.shared.discoveredDevices
+            let filteredDevices = typeFilter.map { type in allDevices.filter { $0.type == type } } ?? allDevices
+            let available = filteredDevices.map { "\($0.name) (\($0.type))" }.joined(separator: ", ")
+            fputs("Error: Cast device '\(deviceName)' not found. Available: \(available)\n", cliStderr)
             return
         }
 
         do {
+            // Commit to casting before the handoff. castCurrentTrack triggers
+            // stopLocalForCasting, whose `.stopped` must not exit the CLI (see flag docs).
+            castSessionActive = true
             try await CastManager.shared.castCurrentTrack(to: device)
 
             // Sonos multi-room
@@ -181,12 +207,12 @@ class CLIPlayer: AudioEngineDelegate {
                             coordinatorUDN: coordinatorUDN
                         )
                     } else {
-                        fputs("Warning: Sonos room '\(roomName)' not found\n", stderr)
+                        fputs("Warning: Sonos room '\(roomName)' not found\n", cliStderr)
                     }
                 }
             }
         } catch {
-            fputs("Error: Cast failed: \(error.localizedDescription.redactingSensitiveURLQueryItems)\n", stderr)
+            fputs("Error: Cast failed: \(error.localizedDescription.redactingSensitiveURLQueryItems)\n", cliStderr)
         }
     }
 
@@ -297,6 +323,14 @@ class CLIPlayer: AudioEngineDelegate {
     }
 
     func audioEngineDidChangeState(_ state: PlaybackState) {
+        // While a cast session owns playback, the local engine is intentionally
+        // stopped for the handoff and re-enters .playing once the device reports
+        // status. Never treat a local .stopped as end-of-playlist here — audio is
+        // playing on the cast device, and exiting/restarting would kill or fight it.
+        if state == .stopped && castSessionActive {
+            return
+        }
+
         // An error-induced stop (e.g. seek into EOF, network drop, dead server)
         // surfaces as .stopped just like a natural end-of-playlist. Don't treat it
         // as completion: skip both the repeat-all restart (which would hammer a
@@ -340,10 +374,23 @@ class CLIPlayer: AudioEngineDelegate {
     }
 
     func audioEngineDidChangeTrack(_ track: Track?) {
-        display.printTrackInfo(track)
+        printTrackInfoIfChanged(track)
         if options.art, let track {
             showArtworkIfChanged(for: track)
         }
+    }
+
+    /// Print the "Now Playing" block only when the track actually changes. The
+    /// track-change delegate fires several times for the same track during load and
+    /// stream-format detection (and `play()` prints once up front), so a plain print
+    /// would repeat the same block 4–5×. The `i` key calls `display.printTrackInfo`
+    /// directly and is intentionally not deduped — it's an explicit on-demand reprint.
+    private func printTrackInfoIfChanged(_ track: Track?) {
+        guard let track else { return }
+        let key = "\(track.artist ?? "")|\(track.title ?? "")|\(track.album ?? "")"
+        guard key != lastTrackInfoKey else { return }
+        lastTrackInfoKey = key
+        display.printTrackInfo(track)
     }
 
     private func showArtworkIfChanged(for track: Track) {
@@ -377,7 +424,9 @@ class CLIPlayer: AudioEngineDelegate {
             }
             NSLog("[CLIArt] got image %@ x %@, rendering ASCII art", "\(image.size.width)", "\(image.size.height)")
             await MainActor.run {
-                self.display.printAsciiArt(image)
+                self.display.printAsciiArt(image,
+                                           forceColor: self.options.artColor,
+                                           forceAscii: self.options.artAscii)
             }
         }
     }
@@ -391,6 +440,6 @@ class CLIPlayer: AudioEngineDelegate {
     }
 
     func audioEngineDidFailToLoadTrack(_ track: Track, error: Error) {
-        fputs("Error loading '\(track.title)': \(error.localizedDescription.redactingSensitiveURLQueryItems)\n", stderr)
+        fputs("Error loading '\(track.title)': \(error.localizedDescription.redactingSensitiveURLQueryItems)\n", cliStderr)
     }
 }

--- a/Sources/NullPlayer/CLI/CLIPlayer.swift
+++ b/Sources/NullPlayer/CLI/CLIPlayer.swift
@@ -106,6 +106,10 @@ class CLIPlayer: AudioEngineDelegate {
     /// audio is now playing on the cast device (the engine re-enters `.playing` once
     /// the device reports status). Without this flag the CLI would mistake that
     /// handoff `.stopped` for end-of-playlist and quit exactly when casting begins.
+    /// It stays set for the life of a successful cast (auto-advance between cast
+    /// tracks can emit `.stopped`, so a one-shot would exit mid-playlist), and is
+    /// cleared if cast setup throws — otherwise a failed cast would swallow every
+    /// future `.stopped` and hang the CLI at natural end (see the catch in setupCasting).
     private var castSessionActive = false
 
     /// Set when the streaming player enters an error state. The engine surfaces
@@ -196,48 +200,66 @@ class CLIPlayer: AudioEngineDelegate {
             return
         }
 
+        // Commit to casting before the handoff. castCurrentTrack triggers
+        // stopLocalForCasting, whose `.stopped` must not exit the CLI (see flag docs).
+        castSessionActive = true
         do {
-            // Commit to casting before the handoff. castCurrentTrack triggers
-            // stopLocalForCasting, whose `.stopped` must not exit the CLI (see flag docs).
-            castSessionActive = true
             try await CastManager.shared.castCurrentTrack(to: device)
-
-            // Rooms to group: inline (from --cast "A,B,C") plus --sonos-rooms.
-            let explicitRooms = options.sonosRooms?
-                .split(separator: ",")
-                .map { $0.trimmingCharacters(in: .whitespaces) } ?? []
-            // Dedupe case-insensitively and drop the coordinator itself.
-            var seen = Set([deviceName.lowercased()])
-            var roomNames: [String] = []
-            for room in inlineRooms + explicitRooms where !room.isEmpty {
-                if seen.insert(room.lowercased()).inserted {
-                    roomNames.append(room)
-                }
-            }
-
-            if !roomNames.isEmpty {
-                guard device.type == .sonos else {
-                    fputs("Warning: multi-room grouping is only supported for Sonos; ignoring \(roomNames.joined(separator: ", "))\n", cliStderr)
-                    return
-                }
-                let sonosDevices = CastManager.shared.discoveredDevices.filter { $0.type == .sonos }
-                let coordinatorUDN = device.id
-
-                for roomName in roomNames {
-                    if let room = sonosDevices.first(where: {
-                        $0.name.caseInsensitiveCompare(roomName) == .orderedSame
-                    }) {
-                        try await CastManager.shared.joinSonosToGroup(
-                            zoneUDN: room.id,
-                            coordinatorUDN: coordinatorUDN
-                        )
-                    } else {
-                        fputs("Warning: Sonos room '\(roomName)' not found\n", cliStderr)
-                    }
-                }
-            }
         } catch {
+            // Cast setup failed — undo the handoff guard so normal stop handling
+            // resumes. Left set, the guard would swallow every future .stopped and the
+            // CLI would hang at natural end instead of exiting/repeating. If local
+            // playback was already stopped for the (failed) handoff there is nothing
+            // left to play, so exit with an error; otherwise (e.g. an all-Sonos-
+            // incompatible playlist that threw before local playback was touched) let
+            // local playback continue and exit naturally at its end.
+            castSessionActive = false
             fputs("Error: Cast failed: \(error.localizedDescription.redactingSensitiveURLQueryItems)\n", cliStderr)
+            if audioEngine.state != .playing {
+                metadataTimer?.invalidate()
+                CLIKeyboard.restoreTerminal()
+                exit(1)
+            }
+            return
+        }
+
+        // Cast is now active. Grouping is best-effort: a room that fails to join must
+        // not tear down the working cast, so failures here are per-room warnings only
+        // (they do NOT clear castSessionActive).
+        let explicitRooms = options.sonosRooms?
+            .split(separator: ",")
+            .map { $0.trimmingCharacters(in: .whitespaces) } ?? []
+        // Dedupe case-insensitively and drop the coordinator itself.
+        var seen = Set([deviceName.lowercased()])
+        var roomNames: [String] = []
+        for room in inlineRooms + explicitRooms where !room.isEmpty {
+            if seen.insert(room.lowercased()).inserted {
+                roomNames.append(room)
+            }
+        }
+
+        guard !roomNames.isEmpty else { return }
+        guard device.type == .sonos else {
+            fputs("Warning: multi-room grouping is only supported for Sonos; ignoring \(roomNames.joined(separator: ", "))\n", cliStderr)
+            return
+        }
+        let sonosDevices = CastManager.shared.discoveredDevices.filter { $0.type == .sonos }
+        let coordinatorUDN = device.id
+        for roomName in roomNames {
+            guard let room = sonosDevices.first(where: {
+                $0.name.caseInsensitiveCompare(roomName) == .orderedSame
+            }) else {
+                fputs("Warning: Sonos room '\(roomName)' not found\n", cliStderr)
+                continue
+            }
+            do {
+                try await CastManager.shared.joinSonosToGroup(
+                    zoneUDN: room.id,
+                    coordinatorUDN: coordinatorUDN
+                )
+            } catch {
+                fputs("Warning: failed to group '\(roomName)': \(error.localizedDescription.redactingSensitiveURLQueryItems)\n", cliStderr)
+            }
         }
     }
 

--- a/Sources/NullPlayer/CLI/CLIQueryHandler.swift
+++ b/Sources/NullPlayer/CLI/CLIQueryHandler.swift
@@ -167,7 +167,7 @@ struct CLIQueryHandler {
                 )
             }
         default:
-            fputs("Error: --list-libraries not supported for source '\(source)'\n", stderr)
+            fputs("Error: --list-libraries not supported for source '\(source)'\n", cliStderr)
         }
     }
 
@@ -314,7 +314,7 @@ struct CLIQueryHandler {
                 print("\n\(names.count) artist(s)")
             }
         default:
-            fputs("Error: --list-artists not supported for source '\(source)'\n", stderr)
+            fputs("Error: --list-artists not supported for source '\(source)'\n", cliStderr)
         }
     }
 
@@ -332,12 +332,12 @@ struct CLIQueryHandler {
             }
         case "plex":
             guard let artistName = artist else {
-                fputs("Error: --list-albums for plex requires --artist <name>\n", stderr)
+                fputs("Error: --list-albums for plex requires --artist <name>\n", cliStderr)
                 return
             }
             let artists = try await PlexManager.shared.fetchArtists()
             guard let plexArtist = artists.first(where: { $0.title.caseInsensitiveCompare(artistName) == .orderedSame }) else {
-                fputs("Error: Artist '\(artistName)' not found on Plex\n", stderr)
+                fputs("Error: Artist '\(artistName)' not found on Plex\n", cliStderr)
                 return
             }
             let albums = try await PlexManager.shared.fetchAlbums(forArtist: plexArtist)
@@ -349,12 +349,12 @@ struct CLIQueryHandler {
             }
         case "subsonic":
             guard let artistName = artist else {
-                fputs("Error: --list-albums for subsonic requires --artist <name>\n", stderr)
+                fputs("Error: --list-albums for subsonic requires --artist <name>\n", cliStderr)
                 return
             }
             let artists = try await SubsonicManager.shared.fetchArtists()
             guard let a = artists.first(where: { $0.name.caseInsensitiveCompare(artistName) == .orderedSame }) else {
-                fputs("Error: Artist '\(artistName)' not found on Subsonic\n", stderr)
+                fputs("Error: Artist '\(artistName)' not found on Subsonic\n", cliStderr)
                 return
             }
             let albums = try await SubsonicManager.shared.fetchAlbums(forArtist: a)
@@ -366,12 +366,12 @@ struct CLIQueryHandler {
             }
         case "jellyfin":
             guard let artistName = artist else {
-                fputs("Error: --list-albums for jellyfin requires --artist <name>\n", stderr)
+                fputs("Error: --list-albums for jellyfin requires --artist <name>\n", cliStderr)
                 return
             }
             let artists = try await JellyfinManager.shared.fetchArtists()
             guard let a = artists.first(where: { $0.name.caseInsensitiveCompare(artistName) == .orderedSame }) else {
-                fputs("Error: Artist '\(artistName)' not found on Jellyfin\n", stderr)
+                fputs("Error: Artist '\(artistName)' not found on Jellyfin\n", cliStderr)
                 return
             }
             let albums = try await JellyfinManager.shared.fetchAlbums(forArtist: a)
@@ -383,12 +383,12 @@ struct CLIQueryHandler {
             }
         case "emby":
             guard let artistName = artist else {
-                fputs("Error: --list-albums for emby requires --artist <name>\n", stderr)
+                fputs("Error: --list-albums for emby requires --artist <name>\n", cliStderr)
                 return
             }
             let artists = try await EmbyManager.shared.fetchArtists()
             guard let a = artists.first(where: { $0.name.caseInsensitiveCompare(artistName) == .orderedSame }) else {
-                fputs("Error: Artist '\(artistName)' not found on Emby\n", stderr)
+                fputs("Error: Artist '\(artistName)' not found on Emby\n", cliStderr)
                 return
             }
             let albums = try await EmbyManager.shared.fetchAlbums(forArtist: a)
@@ -399,7 +399,7 @@ struct CLIQueryHandler {
                 print("\n\(names.count) album(s)")
             }
         default:
-            fputs("Error: --list-albums not supported for source '\(source)'\n", stderr)
+            fputs("Error: --list-albums not supported for source '\(source)'\n", cliStderr)
         }
     }
 
@@ -418,13 +418,13 @@ struct CLIQueryHandler {
             }
         case "plex":
             guard let artistName = artist else {
-                fputs("Error: --list-tracks for plex requires --artist <name>\n", stderr)
+                fputs("Error: --list-tracks for plex requires --artist <name>\n", cliStderr)
                 return
             }
             let mgr = PlexManager.shared
             let artists = try await mgr.fetchArtists()
             guard let a = artists.first(where: { $0.title.caseInsensitiveCompare(artistName) == .orderedSame }) else {
-                fputs("Error: Artist '\(artistName)' not found on Plex\n", stderr)
+                fputs("Error: Artist '\(artistName)' not found on Plex\n", cliStderr)
                 return
             }
             let albums = try await mgr.fetchAlbums(forArtist: a)
@@ -442,7 +442,7 @@ struct CLIQueryHandler {
             }
         case "subsonic", "jellyfin", "emby":
             guard let artistName = artist else {
-                fputs("Error: --list-tracks for \(source) requires --artist <name>\n", stderr)
+                fputs("Error: --list-tracks for \(source) requires --artist <name>\n", cliStderr)
                 return
             }
             var opts = CLIOptions()
@@ -457,7 +457,7 @@ struct CLIQueryHandler {
                 print("\n\(names.count) track(s)")
             }
         default:
-            fputs("Error: --list-tracks not supported for source '\(source)'\n", stderr)
+            fputs("Error: --list-tracks not supported for source '\(source)'\n", cliStderr)
         }
     }
 
@@ -506,7 +506,7 @@ struct CLIQueryHandler {
             }
             return
         default:
-            fputs("Error: --search not supported for source '\(source)'\n", stderr)
+            fputs("Error: --search not supported for source '\(source)'\n", cliStderr)
             return
         }
 
@@ -535,7 +535,7 @@ struct CLIQueryHandler {
             let playlists = try await EmbyManager.shared.fetchPlaylists()
             names = playlists.map { $0.name }
         default:
-            fputs("Error: --list-playlists not supported for source '\(source)'\n", stderr)
+            fputs("Error: --list-playlists not supported for source '\(source)'\n", cliStderr)
             return
         }
 

--- a/Sources/NullPlayer/CLI/CLISourceResolver.swift
+++ b/Sources/NullPlayer/CLI/CLISourceResolver.swift
@@ -107,7 +107,7 @@ struct CLISourceResolver {
         case "radio":
             break // Always available
         default:
-            fputs("Error: Unknown source '\(source)'. Use: local, plex, subsonic, jellyfin, emby, radio\n", stderr)
+            fputs("Error: Unknown source '\(source)'. Use: local, plex, subsonic, jellyfin, emby, radio\n", cliStderr)
             exit(1)
         }
     }

--- a/Sources/NullPlayer/CLI/CLIStderr.swift
+++ b/Sources/NullPlayer/CLI/CLIStderr.swift
@@ -1,0 +1,32 @@
+import Foundation
+
+/// Handle the CLI uses for its own diagnostics (errors, status). Starts as the real
+/// `stderr` and stays pointed at the terminal even after `suppressFrameworkLoggingForCLI`
+/// redirects fd 2 to /dev/null to silence the app's pervasive `NSLog` output.
+var cliStderr: UnsafeMutablePointer<FILE> = stderr
+
+/// Silence framework logging noise in CLI mode.
+///
+/// The app calls `NSLog` in ~80 files; that output goes to fd 2 (stderr) and floods
+/// a headless session endlessly. Redirect fd 2 to /dev/null so those writes vanish,
+/// but first dup the real stderr and expose it via `cliStderr` so the CLI's own
+/// messages still reach the terminal. No-op when `verbose` is set, so logs remain
+/// available for debugging.
+func suppressFrameworkLoggingForCLI(verbose: Bool) {
+    guard !verbose else { return }
+
+    // Preserve the real stderr for CLI diagnostics before repointing fd 2.
+    let saved = dup(STDERR_FILENO)
+    guard saved >= 0 else { return }
+
+    if let devnull = fopen("/dev/null", "w") {
+        dup2(fileno(devnull), STDERR_FILENO)
+        fclose(devnull)
+    }
+
+    if let handle = fdopen(saved, "w") {
+        cliStderr = handle
+    } else {
+        close(saved)
+    }
+}

--- a/Sources/NullPlayer/Casting/CastManager.swift
+++ b/Sources/NullPlayer/Casting/CastManager.swift
@@ -948,8 +948,10 @@ class CastManager {
                 }
 
                 // Close the video player only when this audio cast superseded a video cast.
-                NSLog("CastManager: cast() audio — closing video player if video cast was superseded")
-                WindowManager.shared.closeVideoPlayerForCastTransition(wasVideoCast: supersededVideoCast)
+                if !AudioEngine.isHeadless {
+                    NSLog("CastManager: cast() audio — closing video player if video cast was superseded")
+                    WindowManager.shared.closeVideoPlayerForCastTransition(wasVideoCast: supersededVideoCast)
+                }
             }
             NotificationCenter.default.post(name: Self.sessionDidChangeNotification, object: nil)
             NotificationCenter.default.post(name: Self.playbackStateDidChangeNotification, object: nil)

--- a/Sources/NullPlayer/Casting/CastManager.swift
+++ b/Sources/NullPlayer/Casting/CastManager.swift
@@ -1179,7 +1179,7 @@ class CastManager {
             // operation. Recursing into castNewTrack() from here would enqueue a task
             // behind the current inflight task and deadlock the cast handoff.
             if session.device.type == .sonos {
-                let engine = WindowManager.shared.audioEngine
+                let engine = self.resolvedAudioEngine
                 var requestedTrackRejected = false
 
                 while true {
@@ -1970,7 +1970,7 @@ class CastManager {
                 WindowManager.shared.mainWindowController?.clearVideoTrackInfo()
             }
             
-            WindowManager.shared.audioEngine.stopCastPlayback(resumeLocally: false)
+            self.resolvedAudioEngine.stopCastPlayback(resumeLocally: false)
             NotificationCenter.default.post(name: Self.sessionDidChangeNotification, object: nil)
             NotificationCenter.default.post(name: Self.playbackStateDidChangeNotification, object: nil)
         }
@@ -2086,7 +2086,7 @@ class CastManager {
                 self.isVideoCastPlaying = false
             } else {
                 // Reset time to 0 but keep cast session active
-                WindowManager.shared.audioEngine.resetCastTime()
+                self.resolvedAudioEngine.resetCastTime()
             }
             NotificationCenter.default.post(name: Self.playbackStateDidChangeNotification, object: nil)
         }
@@ -2113,7 +2113,7 @@ class CastManager {
                 self.activeSession?.isPlaying = false
                 self.isVideoCastPlaying = false
             } else {
-                WindowManager.shared.audioEngine.pauseCastPlayback()
+                self.resolvedAudioEngine.pauseCastPlayback()
             }
         }
     }
@@ -2135,7 +2135,7 @@ class CastManager {
                 self.activeSession?.isPlaying = true
                 self.isVideoCastPlaying = true
             } else {
-                WindowManager.shared.audioEngine.resumeCastPlayback()
+                self.resolvedAudioEngine.resumeCastPlayback()
             }
         }
     }
@@ -2239,7 +2239,7 @@ class CastManager {
                         return
                     }
                     // Ignore poll failures once we're no longer routing audio to a cast (post-stop races).
-                    guard WindowManager.shared.audioEngine.isAudioCastRoutingActive else { return }
+                    guard self.resolvedAudioEngine.isAudioCastRoutingActive else { return }
                     consecutiveSonosPollFailures += 1
                     NSLog("CastManager: Sonos poll failed (%d consecutive) — %@",
                           consecutiveSonosPollFailures, self.activeSession?.device.name ?? "nil")
@@ -2266,7 +2266,7 @@ class CastManager {
                     return
                 }
                 consecutiveSonosPollFailures = 0
-                let engine = WindowManager.shared.audioEngine
+                let engine = self.resolvedAudioEngine
                 guard engine.isAudioCastRoutingActive else {
                     NSLog("CastManager: Sonos poll result ignored — audio cast routing inactive")
                     return
@@ -2370,7 +2370,7 @@ class CastManager {
                 if result.state == "STOPPED" || result.state == "NO_MEDIA_PRESENT" {
                     NSLog("CastManager: Sonos stopped during sleep")
                     await MainActor.run {
-                        WindowManager.shared.audioEngine.pauseCastPlayback()
+                        self.resolvedAudioEngine.pauseCastPlayback()
                         NotificationCenter.default.post(name: Self.playbackStateDidChangeNotification, object: nil)
                     }
                 }

--- a/skills/cli/SKILL.md
+++ b/skills/cli/SKILL.md
@@ -447,7 +447,7 @@ RadioManager.cliAudioEngine = audioEngine
 CastManager.cliAudioEngine = audioEngine
 ```
 
-All `WindowManager.shared.audioEngine` references in the cast/radio path use `resolvedAudioEngine` instead.
+All `WindowManager.shared.audioEngine` references in the cast/radio path use `resolvedAudioEngine` instead — **including the cast-control, status-poll, and teardown paths**, not just the initial cast handoff. This covers `stopCastPlayback` (natural cast end), `resetCastTime`, `pauseCastPlayback`/`resumeCastPlayback`, the `isAudioCastRoutingActive` poll guards, the Sonos poll-result engine, the Sonos advance-on-unsupported-format branch in `castNewTrack`, and the post-sleep-wake Sonos check. If any of these hit `WindowManager.shared.audioEngine` directly, cast end/pause/resume/status updates never reach the CLI-owned engine and the attached `--cli` session sits with stale state (e.g. a Chromecast cast ends but the CLI still thinks it's casting). The **only** intended `WindowManager.shared.audioEngine` reference is the fallback inside `resolvedAudioEngine` itself.
 
 ## `currentMetadataTitle`
 

--- a/skills/cli/SKILL.md
+++ b/skills/cli/SKILL.md
@@ -83,16 +83,17 @@ Avoid vague phrasing like "CLI browser" when the real value is orchestration acr
 | `CLIMode.swift` | `NSApplicationDelegate` for CLI mode; `CLIOptions` struct with arg parsing; signal handling |
 | `CLIPlayer.swift` | Headless playback controller; owns `AudioEngine`; implements `AudioEngineDelegate` |
 | `CLIKeyboard.swift` | Raw terminal input via `tcsetattr`; ANSI escape sequence handling on background queue |
-| `CLIDisplay.swift` | Terminal output: progress bar, status lines, ASCII art, `--json` formatting |
-| `CLIArtwork.swift` | Artwork loading from local/Plex/Subsonic/Jellyfin/Emby; ASCII art rendering |
+| `CLIDisplay.swift` | Terminal output: progress bar, status lines, album art, `--json` formatting; terminal color detection |
+| `CLIArtwork.swift` | Artwork loading from local/Plex/Subsonic/Jellyfin/Emby |
 | `CLISourceResolver.swift` | Resolves all flags to `[Track]` or `.radioStation`; `CLISourceError` enum |
 | `CLIQueryHandler.swift` | Handles `--list-*` and `--search` queries; prints results then calls `exit()` |
+| `CLIStderr.swift` | `cliStderr` handle + `suppressFrameworkLoggingForCLI(verbose:)` — silences `NSLog` noise while keeping CLI messages visible |
 
 ### Modified Files
 
 | File | Change |
 |------|--------|
-| `App/main.swift` | Branch on `--cli` flag; `--cli`+`--ui-testing` mutual exclusion |
+| `App/main.swift` | Branch on `--cli` flag; `--cli`+`--ui-testing` mutual exclusion; calls `suppressFrameworkLoggingForCLI(verbose:)` before `app.run()` |
 | `Audio/AudioEngine.swift` | `static var isHeadless = false`; guards on all 10 `WindowManager.shared` video references |
 | `Radio/RadioManager.swift` | `static weak var cliAudioEngine`; `resolvedAudioEngine`; `currentMetadataTitle`; 4 `play(station:)` replacements |
 | `Casting/CastManager.swift` | `static weak var cliAudioEngine`; `resolvedAudioEngine`; replacements in `castCurrentTrack`, `castNewTrack`, `pauseLocalPlayback`, Chromecast status handler |
@@ -115,9 +116,14 @@ Avoid vague phrasing like "CLI browser" when the real value is orchestration acr
 | `--shuffle` | Enable shuffle mode |
 | `--repeat-all` | Repeat entire playlist (CLIPlayer-managed; restarts on `.stopped`) |
 | `--repeat-one` | Repeat current track (`AudioEngine.repeatEnabled = true`) |
-| `--no-art` | Disable ASCII album art (art is shown by default; 256-color half-block) |
+| `--no-art` | Disable album art entirely (art is shown by default) |
+| `--color-art` | Force color half-block art (truecolor/256) |
+| `--ascii-art` | Force monochrome character-ramp art |
+| `--verbose` | Keep framework `NSLog` output (suppressed by default) |
 
 `--repeat-all` and `--repeat-one` are mutually exclusive; validated at startup.
+
+Art rendering and log suppression each have their own section below.
 
 ### Query Commands (print and exit)
 
@@ -314,6 +320,78 @@ This pairs with the connectivity fix: `checkConnectivity` now `await`s the backg
 - `CLIMode.applicationDidFinishLaunching` spawns `Task { @MainActor in ... }` for all async resolution
 
 ---
+
+## Album Art Rendering
+
+`CLIDisplay.printAsciiArt(_:forceColor:forceAscii:)` renders album art three ways. The
+mode is **auto-detected by default** and can be forced by flags.
+
+`CLIDisplay.detectColorMode()` → `.truecolor` / `.ansi256` / `.mono`, purely from the
+environment (declarative — it reports what the terminal *claims*):
+
+- Not a TTY (`isatty(fileno(stdout)) == 0`, i.e. piped/redirected) → `.mono`
+- `COLORTERM` contains `truecolor`/`24bit` → `.truecolor`
+- `TERM` contains `truecolor`/`direct` → `.truecolor`
+- `TERM` contains `256color` → `.ansi256`
+- otherwise (no positive color signal) → `.mono`
+
+Rendering per mode:
+
+- **Color** (`.truecolor`/`.ansi256`): every cell is a `▀` half-block; the image is carried
+  entirely by per-cell color codes (`\e[38;2;…` truecolor or `\e[38;5;…` 256-color via
+  `ansi256Index(r:g:b:)`, which picks the nearest of the 6×6×6 cube or the grayscale ramp).
+  Samples a 60×60 pixel grid → 30 char rows (2 pixels per row).
+- **Mono** (`.mono`): a luminance→character ramp (` .:-=+*#%@`, `asciiRamp`) using **no color
+  codes at all** — the only thing that renders on terminals that ignore ANSI color (where the
+  color path collapses to a flat wall of `▀`). Samples 60×30 (one char per pixel). Assumes a
+  **dark background** (denser glyph = brighter pixel); on a light background it reads inverted.
+
+Mode precedence (in `printAsciiArt`): `forceAscii` (`--ascii-art`) → mono; else `forceColor`
+(`--color-art`) → color (truecolor if detected, else 256); else the `NULLPLAYER_ART` env var
+(`ascii`/`mono` → mono, `color` → color, unset/`auto`/unrecognized → auto-detect). `--no-art`
+(in `CLIOptions.art`) short-circuits before any of this and skips art entirely.
+
+**Why the overrides exist:** detection is env-based and a terminal can misreport — most
+commonly `export COLORTERM=truecolor` in a shell profile makes *every* terminal claim
+truecolor even when it renders monochrome, so auto-detect picks color and the art collapses to
+blocks. `--ascii-art` is the per-invocation escape hatch; `NULLPLAYER_ART=ascii` is the
+per-terminal one (pin it in that terminal's shell profile so the default renders ascii with no
+flag). There is no runtime way to know a terminal actually renders monochrome short of an
+escape-sequence round-trip (OSC 4 / DA query with a timed stdin read), which is fragile across
+tmux/ssh and not done.
+
+## Log Suppression
+
+The app calls `NSLog` in ~80 files; that output goes to **stderr** and floods a headless
+session endlessly. `CLIStderr.swift` handles this:
+
+- `suppressFrameworkLoggingForCLI(verbose:)` — called from `main.swift` in the `--cli` branch
+  **before `app.run()`** (so it's active before any `NSLog` fires). It `dup`s the real stderr,
+  redirects fd 2 to `/dev/null` (swallowing all `NSLog`), and exposes the saved terminal
+  stderr as the global `cliStderr`.
+- **All CLI diagnostics write to `cliStderr`, not `stderr`** — every `fputs(…, cliStderr)` in
+  `CLIMode`/`CLIPlayer`/`CLIQueryHandler`/`CLISourceResolver`. This is a hard rule: a bare
+  `fputs(…, stderr)` in CLI code would be silently swallowed by the redirect. (The one
+  exception is `main.swift`'s pre-redirect `--cli`+`--ui-testing` error, which runs before the
+  redirect and correctly uses `stderr`.)
+- `--verbose` sets `CLIOptions.verbose` and makes `suppressFrameworkLoggingForCLI` a no-op, so
+  framework logs return for debugging. `main.swift` reads it directly via
+  `args.contains("--verbose")` (before options are parsed).
+
+## Casting Keep-Alive
+
+When `--cast` hands off to a device, `CastManager` calls `AudioEngine.stopLocalForCasting()`,
+which sets local `state = .stopped`. Without guarding, `CLIPlayer.audioEngineDidChangeState`
+treats that as end-of-playlist (`hasStartedPlaying && !repeatAll`) and calls `exit(0)` — the
+CLI would quit the instant the cast starts.
+
+`CLIPlayer` guards this with `castSessionActive`, set `true` right before
+`CastManager.shared.castCurrentTrack(to:)`. While set, a local `.stopped` is ignored (no exit,
+no repeat-all restart) — audio is on the cast device, and the engine re-enters `.playing` from
+`updateCastPosition` once the device reports status. The flag can't rely on
+`CastManager.isCasting` at the handoff instant: `stopLocalForCasting` runs *before*
+`upnpManager.connect`, so `activeSession` is still nil and `isCasting` is false when the
+`.stopped` fires. Once set, the CLI never auto-exits on `.stopped`; the user quits with `q`.
 
 ## Exit Codes
 

--- a/skills/cli/SKILL.md
+++ b/skills/cli/SKILL.md
@@ -162,9 +162,9 @@ Art rendering and log suppression each have their own section below.
 | `--channel <name>` | string | Radio channel (with `--folder channel`) |
 | `--region <name>` | string | Radio region (with `--folder region`) |
 | `--volume <0-100>` | int | Initial volume (divided by 100 for `AudioEngine.volume`) |
-| `--cast <device>` | string | Cast to named device (case-insensitive match) |
+| `--cast <device[,rooms…]>` | string | Cast to named device (case-insensitive match). Comma-separated: the **first** entry is the cast target / Sonos group coordinator; remaining entries are Sonos rooms grouped onto it (merged with `--sonos-rooms`, deduped, coordinator dropped). Grouping is Sonos-only — a non-Sonos target with extra rooms warns and ignores them. |
 | `--cast-type <type>` | string | `sonos`, `chromecast`, `dlna` (UPnP/DLNA target filter) |
-| `--sonos-rooms <rooms>` | string | Comma-separated Sonos room names for multi-room |
+| `--sonos-rooms <rooms>` | string | Extra comma-separated Sonos room names to group, merged with any rooms in `--cast` |
 | `--eq <preset>` | string | EQ preset name (case-insensitive; from `EQPreset.allPresets`) |
 | `--output <device>` | string | Audio output device name (case-insensitive) |
 | `--tuning <off\|Hz>` | string | Reference Tuning: `off`, or target reference frequency in Hz (e.g. `432`). Enables pitch shift for local output only (local files and HTTP streams) — not casting. Session-only override. |

--- a/skills/cli/SKILL.md
+++ b/skills/cli/SKILL.md
@@ -391,7 +391,17 @@ no repeat-all restart) — audio is on the cast device, and the engine re-enters
 `updateCastPosition` once the device reports status. The flag can't rely on
 `CastManager.isCasting` at the handoff instant: `stopLocalForCasting` runs *before*
 `upnpManager.connect`, so `activeSession` is still nil and `isCasting` is false when the
-`.stopped` fires. Once set, the CLI never auto-exits on `.stopped`; the user quits with `q`.
+`.stopped` fires.
+
+It's a **session** flag, not a one-shot: it stays set for the life of a successful cast so the
+CLI doesn't auto-exit on the `.stopped` events cast auto-advance can emit between tracks (a
+one-shot cleared after the first `.stopped` would exit mid-playlist). The user quits with `q`.
+
+**Failure must clear it.** If `castCurrentTrack` throws (e.g. an all-Sonos-incompatible
+playlist), the `catch` sets `castSessionActive = false` — otherwise the guard would swallow
+every future `.stopped` and hang the CLI at natural end. It then exits (code 1) if local
+playback is no longer running (it was stopped for the failed handoff), or lets local playback
+continue to its natural end if the throw happened before local playback was touched.
 
 ## Exit Codes
 


### PR DESCRIPTION
## Summary

CLI-mode fixes that surfaced while debugging Sonos casting. All changes are scoped to `--cli` and do not affect the GUI.

### Casting no longer quits the CLI
A cast handoff calls `AudioEngine.stopLocalForCasting()`, which sets local `state = .stopped`. `CLIPlayer` treated that as end-of-playlist (`hasStartedPlaying && !repeatAll`) and called `exit(0)` — killing the CLI exactly when the Sonos cast took over. Guarded with a `castSessionActive` flag; the local `.stopped` during a cast is now ignored, and the engine re-enters `.playing` from cast status polling. `CastManager.cast()` also skips `WindowManager` teardown when headless.

### Comma-separated `--cast` for Sonos grouping
`--cast "A,B,C"` now casts to A (the group coordinator) and groups B and C onto it for Sonos, merged with any `--sonos-rooms` (deduped, coordinator dropped). Previously the whole comma string was matched as one device name and failed with `Cast device 'A,B,C' not found`. Non-Sonos targets with extra rooms warn and ignore them (grouping is Sonos-only). Equivalent forms:
- `--cast "Living Room,Kitchen,Office" --cast-type sonos`
- `--cast "Living Room" --sonos-rooms "Kitchen,Office" --cast-type sonos`

### Album art renders on any terminal
- Mode is **auto-detected**: truecolor (`COLORTERM`), else 256-color, else a monochrome luminance→character ramp that renders with no color codes.
- `--color-art` / `--ascii-art` force a mode.
- `NULLPLAYER_ART=ascii|color|auto` pins a per-terminal default — for terminals that misreport color support (e.g. a global `export COLORTERM=truecolor` making every terminal claim color it can't paint).
- Precedence: flag > `NULLPLAYER_ART` > auto-detect.

### Framework log noise suppressed
The app's ~80 `NSLog` call sites flooded headless sessions. New `CLIStderr.swift` redirects fd 2 to `/dev/null` while preserving a `cliStderr` handle for the CLI's own messages (all CLI diagnostics now write there). `--verbose` keeps logs for debugging.

### "Now Playing" no longer repeats
The block printed 4–5× per track because the track-change delegate fires repeatedly during load/format detection. Deduped on a `lastTrackInfoKey`, mirroring the existing artwork dedup. The `i` key still reprints on demand.

## Files
- New: `CLI/CLIStderr.swift`
- `CLI/CLIPlayer.swift`, `CLI/CLIDisplay.swift`, `CLI/CLIMode.swift`, `App/main.swift`, `Casting/CastManager.swift`, and CLI stderr reroutes in `CLIQueryHandler`/`CLISourceResolver`
- Docs: `skills/cli/SKILL.md`, `README.md`

## Testing
- `swift build` clean
- Manual: verified log suppression (`--list-eq` clean vs `--verbose`), CLI errors still print, `--ascii-art` renders on a monochrome terminal, casting stays alive through the Sonos handoff
- Not verified live: actual Sonos multi-room `joinSonosToGroup` handoff (no devices in the build environment) — device resolution/dedupe is exercised, worth a real run

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added color, ASCII, and disabled album-art display modes with automatic terminal detection.
  - Added `--verbose` to show framework logs; normal CLI output is now less noisy.
  - Expanded casting support for comma-separated devices and Sonos multi-room groups.
  - Improved cast handoff reliability and reduced duplicate “Now Playing” messages.

- **Documentation**
  - Updated CLI help and guides with casting, artwork, logging, and terminal display details.


<!-- end of auto-generated comment: release notes by coderabbit.ai -->