### PR TITLE
Expand non-affiliation disclaimer to full Winamp Group family

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,10 @@
 - **CLI server queries no longer return empty results at launch** — headless `--cli` queries and playback against Plex, Jellyfin, and Emby (`--list-artists`, `--list-albums`, `--list-tracks`, `--artist`, `--search`, `--radio`, etc.) now wait for the background server connection before running, instead of racing it and silently returning nothing (which surfaced as "artist not found" / "0 artist(s)"). When the restored current library is a non-music section — a Plex Movies/TV library, or a Jellyfin/Emby "Playlists", "Video", "Movies", or "TV shows" view — the CLI now auto-selects a music library for every music operation (queries, `--search`, and server `--radio`), or prints the available music libraries and asks you to pick one with `--library` instead of returning empty. `--search` also honors an explicit `--library`. `--list-sources` shows configured Subsonic/Navidrome, Jellyfin, and Emby servers as **Connected** instead of momentarily "Not configured", and now returns promptly because the CLI waits only for the connection, not for the full background library preload.
 - **Play button no longer rewinds the clock during local playback** — pressing ▶ while a local file was already playing snapped the progress bar and the elapsed-time display backward (by a fraction of a second, or all the way to the start), making the track look like it ended early even though the audio kept playing uninterrupted. The play button now preserves the true playback position on a redundant press. Streaming and cast playback were never affected.
 
+### Documentation
+
+- **Non-affiliation disclaimer now names the full Winamp Group** — the README disclaimer previously listed only Winamp, Nullsoft, and Radionomy Group. It now enumerates the entire Winamp Group SA family — Winamp Group SA, Llama Group (former name), Jamendo, Hotmix, Bridger, and SHOUTcast — alongside the existing Sonos and Plex mentions, and clarifies the project is "not affiliated with, endorsed by, or connected to" those parties.
+
 ## 0.27.0
 
 ### New Features

--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 ## A throwback open-source music player for macOS written in Swift, with a first-class headless CLI for automation, multi-source playback, and casting across Sonos, Chromecast, UPnP/DLNA, local media servers, and internet radio.
 
-## This is a 100% clean room hobby project is not affiliated with Winamp, Nullsoft, Sonos, Plex, Radionomy Group or anyone else.
+## This is a 100% clean room hobby project and is not affiliated with, endorsed by, or connected to Winamp, Nullsoft, Winamp Group SA, Llama Group, Radionomy Group, Jamendo, Hotmix, Bridger, SHOUTcast, Sonos, Plex, or anyone else.
 
 ## **If you enjoy NullPlayer, please ⭐ star ⭐ the project on GitHub!**
 


### PR DESCRIPTION
## Summary

The README non-affiliation disclaimer previously named only **Winamp, Nullsoft, and Radionomy Group**. Winamp Group SA (formerly Llama Group, formerly Radionomy Group) also owns several sibling brands that were not covered. This expands the disclaimer to the full Winamp Group family and tightens the wording.

### Before
> This is a 100% clean room hobby project is not affiliated with Winamp, Nullsoft, Sonos, Plex, Radionomy Group or anyone else.

### After
> This is a 100% clean room hobby project and is not affiliated with, endorsed by, or connected to Winamp, Nullsoft, Winamp Group SA, Llama Group, Radionomy Group, Jamendo, Hotmix, Bridger, SHOUTcast, Sonos, Plex, or anyone else.

## Changes
- **Added the full Winamp Group family**: Winamp Group SA (current parent name), Llama Group (former name), Jamendo, Hotmix, Bridger, and SHOUTcast.
- **Kept** existing Winamp, Nullsoft, Radionomy Group, Sonos, and Plex mentions.
- **Fixed grammar** ("project is not affiliated" → "project and is not affiliated") and strengthened to "not affiliated with, endorsed by, or connected to."
- Added a CHANGELOG entry under Unreleased → Documentation.

## Notes
- The in-app About box (`AppDelegate.swift`) just says "This is a clean room project" with no company list, so nothing to sync there.
- SHOUTcast's ownership has changed over the years, but it originated at Nullsoft and the README advertises Shoutcast radio support, so including it is the safe call.

## Sources
- https://winamp-group.com/fr/financial-information/winamp-group-announces-the-filing-of-a-u.s.-lawsuit-against-suno/
- https://www.businesswire.com/news/home/20251020592923/en/Llama-Group-Officially-Becomes-Winamp-Group-SA

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Gh6kPucGcJmSemXd9oFkvU