### PR TITLE
Fix stale bundled-skin references in README and SKINNING

### DIFF
--- a/README.md
+++ b/README.md
@@ -379,7 +379,7 @@ NullPlayer has three looks — Classic, Modern, and Metal — selectable from th
 
 ### Classic Mode
 
-Classic `.wsz` skin support. No skins are bundled -- the app starts with a native macOS appearance. To apply a skin, use **Skins > Load Skin...** to open a `.wsz` file, or place skin files in `~/Library/Application Support/NullPlayer/Skins/` and select them from the Skins menu. Official NullPlayer skin packages are available in the `dist/Skins/` directory or from [Releases](https://github.com/ad-repo/nullplayer/releases). Thousands of community-created skins can be downloaded from the **Skins > Get More Skins...** menu link.
+Classic `.wsz` skin support. The app starts with a native macOS appearance and ships with one original NullPlayer skin (Silver). To apply a skin, use **Skins > Load Skin...** to open a `.wsz` file, or place skin files in `~/Library/Application Support/NullPlayer/Skins/` and select them from the Skins menu. Thousands of community-created skins can be downloaded from the **Skins > Get More Skins...** menu link, which opens the [Winamp Skin Museum](https://skins.webamp.org).
 
 ### Modern Mode
 

--- a/SKINNING.md
+++ b/SKINNING.md
@@ -2,7 +2,7 @@
 
 This guide walks you through creating custom skins for NullPlayer's modern UI mode. You can create a skin with nothing more than a text editor -- no programming required.
 
-> **Classic Mode skins**: NullPlayer also supports classic `.wsz` skins in Classic Mode. No skins are bundled -- load a `.wsz` file via **Skins > Load Skin...** or place files in `~/Library/Application Support/NullPlayer/Skins/`. Official skin packages are available in `dist/Skins/`. Use **Skins > Get More Skins...** to find community-created skins online.
+> **Classic Mode skins**: NullPlayer also supports classic `.wsz` skins in Classic Mode. It ships with one original NullPlayer skin (Silver) -- load your own `.wsz` file via **Skins > Load Skin...** or place files in `~/Library/Application Support/NullPlayer/Skins/`. Use **Skins > Get More Skins...** to browse thousands of community-created skins at the [Winamp Skin Museum](https://skins.webamp.org/).
 
 > **Metal mode skins**: Metal uses the modern skin engine, but it is a separate skin family. User-installed metal skins live in `~/Library/Application Support/NullPlayer/MetalSkins/`, the current selection is stored under `metalSkinName`, and the built-in default is `Brushed Steel`.
 


### PR DESCRIPTION
## Summary

Corrects inaccurate skin-bundling claims in the docs.

- **README.md** and **SKINNING.md** claimed *"No skins are bundled"* and pointed users to skin packages in `dist/Skins/`. But `dist/` is gitignored/untracked, so that directory doesn't exist in a fresh clone.
- The repo actually bundles one original classic skin, `NullPlayer-Silver.wsz` (in `Sources/NullPlayer/Resources/Skins/`), alongside the 13 modern skins.
- Removed the dead `dist/Skins/` + Releases references. Users are now directed to the [Winamp Skin Museum](https://skins.webamp.org) via **Skins > Get More Skins...** — which is exactly what that menu item already opens (`ContextMenuBuilder.swift:3919`).

Docs-only change; no code affected.

🤖 Generated with [Claude Code](https://claude.com/claude-code)