### PR TITLE
Fix center-stack docking drift

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,7 @@
 
 ### Bug Fixes
 
+- **Center-stack windows keep docking below the main window after detaches** — opening Spectrum, Flow, PeppyMeter, Audio Analysis, EQ, Playlist, or Waveform now ignores visible center-stack windows that were detached and moved aside. New stack windows again dock directly under the main window or fill real gaps in the docked stack instead of drifting downward below floating windows.
 - **Audio Analyzer and Flow windows drag consistently from their faces** — in both classic and modern UI, clicking and dragging the body of the Audio Analyzer or Flow window now moves the window just like Spectrum and the other center-stack windows. Close buttons, Flow's double-click download/upload toggle, right-click menus, and interactive controls on other windows keep their existing behavior.
 - **Large NAS-hosted local files seek smoothly** — local tracks on network-mounted volumes are now staged to a temp file based on available disk space instead of a hard 300 MB cap, so very large files avoid SMB/NFS reads during playback and seeking. NullPlayer also cleans up its staged playback temp files on launch after a crash or force-quit.
 - **Docked side windows resize to the current center stack** — reopening a docked Library/browser or Visualizations window now recomputes its height from the current main/EQ/playlist/spectrum/waveform/audio-analysis/PeppyMeter stack instead of replaying a stale remembered height. Detached side windows still reopen at the exact position and size where you left them.

--- a/Sources/NullPlayer/App/WindowManager.swift
+++ b/Sources/NullPlayer/App/WindowManager.swift
@@ -839,15 +839,11 @@ class WindowManager {
         let newHeight = window.frame.size.height
         let newWidth = window.frame.size.width
         
-        // Collect all visible stack windows except the one being positioned
+        // Detached windows moved aside should not affect where new stack windows open.
         var visibleWindows: [NSWindow] = [mainWindow]
-        if let w = equalizerWindowController?.window, w.isVisible, w !== window { visibleWindows.append(w) }
-        if let w = playlistWindowController?.window, w.isVisible, w !== window { visibleWindows.append(w) }
-        if let w = spectrumWindowController?.window, w.isVisible, w !== window { visibleWindows.append(w) }
-        if let w = audioAnalysisWindowController?.window, w.isVisible, w !== window { visibleWindows.append(w) }
-        if let w = peppyMeterWindowController?.window, w.isVisible, w !== window { visibleWindows.append(w) }
-        if let w = networkMonitorWindowController?.window, w.isVisible, w !== window { visibleWindows.append(w) }
-        if let w = waveformWindowController?.window, w.isVisible, w !== window { visibleWindows.append(w) }
+        for win in dockedCenterStackWindowsBelowMain(mainFrame: mainFrame) where win !== window {
+            visibleWindows.append(win)
+        }
         
         // Sort top-to-bottom (highest minY first, since macOS Y increases upward)
         visibleWindows.sort { $0.frame.minY > $1.frame.minY }

--- a/skills/ui-guide/SKILL.md
+++ b/skills/ui-guide/SKILL.md
@@ -202,6 +202,10 @@ Main, EQ, Playlist, Spectrum, Waveform, Audio Analysis, PeppyMeter, and Flow all
 - Width is normalized to the main stack
 - Height is window-specific: Flow is single-height; PeppyMeter uses a 1.75x landscape height
 - Saved frames are restored through `WindowManager` rather than ad hoc per-window logic
+- Opening a center-stack window must calculate gaps from windows actually docked below main, not
+  every visible stack-capable window. Use `dockedCenterStackWindowsBelowMain(mainFrame:)` (vertical
+  adjacency within `dockThreshold` plus horizontal overlap) so detached windows moved aside do not
+  make new windows drift downward below the floating stack.
 - Modern and classic implementations should expose a provider protocol in `App/` so `WindowManager` can manage both without mode-specific branching outside window creation
 - Modern dockable windows must not create a second visual border by adding their own outer content gutter or rounded inner panel around the main content. Use the shared auxiliary chrome inset (`ModernSkinElements.*BorderWidth`) as the only window border. If content needs internal breathing room, apply it inside the renderer/content layout, not by shrinking the whole chrome content rect. Flow and PeppyMeter are explicit regression examples: extra content padding made their modern windows look like they had heavy borders, while Metal already used the correct thin-edge treatment.
 


### PR DESCRIPTION
## Summary
- Use the existing docked-below-main traversal when positioning center-stack windows
- Ignore detached visible center-stack windows so new windows dock under main or fill real stack gaps
- Update changelog and UI guide skill with the docking rule

Refs #176392

## Testing
- swift build
- swift test

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Center-stack windows now dock correctly beneath the main window after being detached or moved aside.
  - Newly opened windows no longer drift downward because of floating windows.

- **Documentation**
  - Updated docking behavior documentation to clarify how window placement and vertical gaps are determined.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->