### PR TITLE
Persist visualization settings and restore window geometry

### DIFF
--- a/Sources/NullPlayer/App/WindowManager.swift
+++ b/Sources/NullPlayer/App/WindowManager.swift
@@ -732,7 +732,7 @@ class WindowManager {
         if let playlistWindow = playlistWindowController?.window {
             applyCenterStackSizingConstraints(playlistWindow, kind: .playlist)
             if let frame = restoredFrame, frame != .zero {
-                playlistWindow.setFrame(normalizedCenterStackRestoredFrame(frame, kind: .playlist), display: true)
+                applyRestoredCenterStackFrame(frame, to: playlistWindow, kind: .playlist)
             } else {
                 // By design: always reset to default when showing without a saved frame.
                 // This keeps the window snapped below main whenever the user opens it fresh,
@@ -790,7 +790,7 @@ class WindowManager {
         if let eqWindow = equalizerWindowController?.window {
             applyCenterStackSizingConstraints(eqWindow, kind: .equalizer)
             if let frame = restoredFrame, frame != .zero {
-                eqWindow.setFrame(normalizedCenterStackRestoredFrame(frame, kind: .equalizer), display: true)
+                applyRestoredCenterStackFrame(frame, to: eqWindow, kind: .equalizer)
             } else {
                 if isNewWindow {
                     applyDefaultCenterStackFrameForCurrentHT(eqWindow, kind: .equalizer)
@@ -2353,7 +2353,7 @@ class WindowManager {
         if let window = spectrumWindowController?.window {
             applyCenterStackSizingConstraints(window, kind: .spectrum)
             if let frame = restoredFrame, frame != .zero {
-                window.setFrame(normalizedCenterStackRestoredFrame(frame, kind: .spectrum), display: true)
+                applyRestoredCenterStackFrame(frame, to: window, kind: .spectrum)
             } else {
                 // By design: always reset to default when showing without a saved frame.
                 // Same rationale as showPlaylist — stretch state is not persisted across toggles.
@@ -2420,7 +2420,7 @@ class WindowManager {
         if let window = audioAnalysisWindowController?.window {
             applyCenterStackSizingConstraints(window, kind: .audioAnalysis)
             if let frame = restoredFrame, frame != .zero {
-                window.setFrame(normalizedCenterStackRestoredFrame(frame, kind: .audioAnalysis), display: true)
+                applyRestoredCenterStackFrame(frame, to: window, kind: .audioAnalysis)
             } else {
                 if runningModernMode {
                     applyDefaultCenterStackFrameForCurrentHT(window, kind: .audioAnalysis)
@@ -2483,7 +2483,7 @@ class WindowManager {
         if let window = peppyMeterWindowController?.window {
             applyCenterStackSizingConstraints(window, kind: .peppyMeter)
             if let frame = restoredFrame, frame != .zero {
-                window.setFrame(normalizedCenterStackRestoredFrame(frame, kind: .peppyMeter), display: true)
+                applyRestoredCenterStackFrame(frame, to: window, kind: .peppyMeter)
             } else {
                 if runningModernMode {
                     applyDefaultCenterStackFrameForCurrentHT(window, kind: .peppyMeter)
@@ -2561,7 +2561,7 @@ class WindowManager {
         if let window = networkMonitorWindowController?.window {
             applyCenterStackSizingConstraints(window, kind: .networkMonitor)
             if let frame = restoredFrame, frame != .zero {
-                window.setFrame(normalizedCenterStackRestoredFrame(frame, kind: .networkMonitor), display: true)
+                applyRestoredCenterStackFrame(frame, to: window, kind: .networkMonitor)
             } else {
                 if runningModernMode {
                     applyDefaultCenterStackFrameForCurrentHT(window, kind: .networkMonitor)
@@ -2625,7 +2625,7 @@ class WindowManager {
             applyCenterStackSizingConstraints(window, kind: .waveform)
             if let frame = restoredFrame, frame != .zero {
                 classicController?.clearPendingFrameReset()
-                window.setFrame(normalizedCenterStackRestoredFrame(frame, kind: .waveform), display: true)
+                applyRestoredCenterStackFrame(frame, to: window, kind: .waveform)
             } else {
                 if isModernUIEnabled {
                     applyDefaultCenterStackFrameForCurrentHT(window, kind: .waveform)
@@ -3518,7 +3518,7 @@ class WindowManager {
         return bounds
     }
 
-    private enum CenterStackWindowKind {
+    enum CenterStackWindowKind {
         case equalizer
         case playlist
         case spectrum
@@ -3710,6 +3710,57 @@ class WindowManager {
         window.setFrame(frame, display: true)
     }
 
+    private func applyRestoredCenterStackFrame(_ frame: NSRect, to window: NSWindow, kind: CenterStackWindowKind) {
+        let normalizedFrame = normalizedCenterStackRestoredFrame(frame, kind: kind)
+        withProgrammaticWindowFrameChange {
+            window.setFrame(normalizedFrame, display: true)
+        }
+    }
+
+    private func modernMinimumRestoredWidth(for kind: CenterStackWindowKind) -> CGFloat {
+        switch kind {
+        case .equalizer:
+            return mainWindowController?.window?.frame.width ?? ModernSkinElements.mainWindowSize.width
+        case .playlist:
+            return ModernSkinElements.playlistMinSize.width
+        case .spectrum, .audioAnalysis, .peppyMeter, .networkMonitor:
+            return ModernSkinElements.spectrumMinSize.width
+        case .waveform:
+            return ModernSkinElements.waveformMinSize.width
+        }
+    }
+
+    static func normalizedModernCenterStackRestoredFrame(
+        _ frame: NSRect,
+        kind: CenterStackWindowKind,
+        mainWidth: CGFloat,
+        minimumWidth: CGFloat,
+        targetHeight: CGFloat,
+        peppyMeterFloor: CGFloat,
+        peppyMeterLegacyDoubleHeight: CGFloat
+    ) -> NSRect {
+        var normalized = frame
+        if kind == .equalizer {
+            normalized.size.width = mainWidth
+        } else {
+            normalized.size.width = max(minimumWidth, normalized.width)
+        }
+
+        let topY = normalized.maxY
+        switch kind {
+        case .equalizer, .networkMonitor:
+            normalized.size.height = targetHeight
+        case .playlist, .spectrum, .waveform, .audioAnalysis:
+            normalized.size.height = max(targetHeight, normalized.height)
+        case .peppyMeter:
+            normalized.size.height = abs(normalized.height - peppyMeterLegacyDoubleHeight) <= 2
+                ? peppyMeterFloor
+                : max(peppyMeterFloor, normalized.height)
+        }
+        normalized.origin.y = topY - normalized.size.height
+        return normalized
+    }
+
     private func normalizedCenterStackRestoredFrame(_ frame: NSRect, kind: CenterStackWindowKind) -> NSRect {
         guard isRunningModernUI else {
             guard kind == .peppyMeter || kind == .networkMonitor else { return frame }
@@ -3729,29 +3780,16 @@ class WindowManager {
             normalized.origin.y = topY - normalized.size.height
             return normalized
         }
-        var normalized = frame
-        if let mainWindow = mainWindowController?.window, kind != .waveform {
-            normalized.origin.x = mainWindow.frame.minX
-            normalized.size.width = mainWindow.frame.width
-        }
-
-        let topY = normalized.maxY
         let target = expectedMainHeightForCurrentHT(mainWindowController?.window)
-        switch kind {
-        case .equalizer, .spectrum, .networkMonitor:
-            normalized.size.height = target
-        case .playlist, .waveform, .audioAnalysis:
-            // Accept legacy compact saved frames but normalize to current full-height minimum.
-            normalized.size.height = max(target, normalized.height)
-        case .peppyMeter:
-            normalized.size.height = restoredPeppyMeterHeight(
-                saved: normalized.height,
-                floor: peppyMeterHeight(for: target),
-                legacyDoubleHeight: (target * 2).rounded()
-            )
-        }
-        normalized.origin.y = topY - normalized.size.height
-        return normalized
+        return Self.normalizedModernCenterStackRestoredFrame(
+            frame,
+            kind: kind,
+            mainWidth: mainWindowController?.window?.frame.width ?? ModernSkinElements.mainWindowSize.width,
+            minimumWidth: modernMinimumRestoredWidth(for: kind),
+            targetHeight: target,
+            peppyMeterFloor: peppyMeterHeight(for: target),
+            peppyMeterLegacyDoubleHeight: (target * 2).rounded()
+        )
     }
 
     /// Baseline center-stack height in modern UI.

--- a/Sources/NullPlayer/Visualization/ProjectMPresetCycleSettings.swift
+++ b/Sources/NullPlayer/Visualization/ProjectMPresetCycleSettings.swift
@@ -1,0 +1,39 @@
+import Foundation
+
+enum VisualizationCycleMode: String {
+    case off
+    case cycle
+    case random
+}
+
+enum ProjectMPresetCycleSettings {
+    enum DefaultsKey {
+        static let cycleMode = "projectM.cycleMode"
+        static let cycleInterval = "projectM.cycleInterval"
+    }
+
+    static let defaultMode: VisualizationCycleMode = .off
+    static let defaultInterval: TimeInterval = 30.0
+
+    static func loadMode(defaults: UserDefaults = .standard) -> VisualizationCycleMode {
+        guard let raw = defaults.string(forKey: DefaultsKey.cycleMode),
+              let mode = VisualizationCycleMode(rawValue: raw) else {
+            return defaultMode
+        }
+        return mode
+    }
+
+    static func loadInterval(defaults: UserDefaults = .standard) -> TimeInterval {
+        let stored = defaults.double(forKey: DefaultsKey.cycleInterval)
+        return stored > 0 ? stored : defaultInterval
+    }
+
+    static func save(
+        mode: VisualizationCycleMode,
+        interval: TimeInterval,
+        defaults: UserDefaults = .standard
+    ) {
+        defaults.set(mode.rawValue, forKey: DefaultsKey.cycleMode)
+        defaults.set(interval, forKey: DefaultsKey.cycleInterval)
+    }
+}

--- a/Sources/NullPlayer/Windows/ModernProjectM/ModernProjectMView.swift
+++ b/Sources/NullPlayer/Windows/ModernProjectM/ModernProjectMView.swift
@@ -42,15 +42,8 @@ class ModernProjectMView: NSView, GeissMenuTarget, TripexMenuTarget, MetMuseumMe
     /// Observer for playback state changes
     private var playbackStateObserver: NSObjectProtocol?
     
-    /// Preset cycling mode
-    enum PresetCycleMode {
-        case off       // Manual only
-        case cycle     // Sequential cycling
-        case random    // Random on timer
-    }
-    
     /// Current preset cycle mode
-    private var presetCycleMode: PresetCycleMode = .off
+    private var presetCycleMode: VisualizationCycleMode = .off
 
     /// Timer for preset cycling
     private var presetCycleTimer: Timer?
@@ -59,7 +52,7 @@ class ModernProjectMView: NSView, GeissMenuTarget, TripexMenuTarget, MetMuseumMe
     private var presetCycleInterval: TimeInterval = 30.0
 
     /// Tripex cycle state — mirrors ProjectM controls for uniform UX.
-    private var tripexCycleMode: PresetCycleMode = .cycle
+    private var tripexCycleMode: VisualizationCycleMode = .cycle
     private var tripexCycleTimer: Timer?
     private var tripexCycleInterval: TimeInterval = 30.0
 
@@ -116,6 +109,9 @@ class ModernProjectMView: NSView, GeissMenuTarget, TripexMenuTarget, MetMuseumMe
         
         // Create and add OpenGL visualization view
         setupVisualizationView()
+
+        loadProjectMPresetCycleStateFromDefaults()
+        applyProjectMPresetCycleModeIfActive()
 
         // Restore Tripex cycle state from defaults; applied if Tripex is
         // the active engine at launch (otherwise applied on engine switch).
@@ -653,15 +649,18 @@ class ModernProjectMView: NSView, GeissMenuTarget, TripexMenuTarget, MetMuseumMe
             switch presetCycleMode {
             case .off:
                 presetCycleMode = .cycle
-                startPresetCycleTimer()
+                saveProjectMPresetCycleStateToDefaults()
+                applyProjectMPresetCycleMode()
                 NSLog("ModernProjectMView: Auto-cycle enabled")
             case .cycle:
                 presetCycleMode = .random
-                startPresetCycleTimer()
+                saveProjectMPresetCycleStateToDefaults()
+                applyProjectMPresetCycleMode()
                 NSLog("ModernProjectMView: Auto-random enabled")
             case .random:
                 presetCycleMode = .off
-                stopPresetCycleTimer()
+                saveProjectMPresetCycleStateToDefaults()
+                applyProjectMPresetCycleMode()
                 NSLog("ModernProjectMView: Auto-cycle disabled")
             }
             return true
@@ -1255,6 +1254,9 @@ class ModernProjectMView: NSView, GeissMenuTarget, TripexMenuTarget, MetMuseumMe
         if type == .tripex {
             loadTripexCycleStateFromDefaults()
             applyTripexCycleMode()
+        } else if type == .projectM {
+            loadProjectMPresetCycleStateFromDefaults()
+            applyProjectMPresetCycleMode()
         }
     }
 
@@ -1335,27 +1337,54 @@ class ModernProjectMView: NSView, GeissMenuTarget, TripexMenuTarget, MetMuseumMe
     }
     
     // MARK: - Preset Cycle Mode
+
+    private func loadProjectMPresetCycleStateFromDefaults() {
+        presetCycleMode = ProjectMPresetCycleSettings.loadMode()
+        presetCycleInterval = ProjectMPresetCycleSettings.loadInterval()
+    }
+
+    private func saveProjectMPresetCycleStateToDefaults() {
+        ProjectMPresetCycleSettings.save(mode: presetCycleMode, interval: presetCycleInterval)
+    }
+
+    private func applyProjectMPresetCycleModeIfActive() {
+        guard visualizationGLView?.currentEngineType == .projectM else {
+            stopPresetCycleTimer()
+            return
+        }
+        applyProjectMPresetCycleMode()
+    }
+
+    private func applyProjectMPresetCycleMode() {
+        if presetCycleMode == .off {
+            stopPresetCycleTimer()
+        } else {
+            startPresetCycleTimer()
+        }
+    }
     
     @objc private func setCycleModeOff(_ sender: Any?) {
         presetCycleMode = .off
-        stopPresetCycleTimer()
+        saveProjectMPresetCycleStateToDefaults()
+        applyProjectMPresetCycleMode()
     }
     
     @objc private func setCycleModeCycle(_ sender: Any?) {
         presetCycleMode = .cycle
-        startPresetCycleTimer()
+        saveProjectMPresetCycleStateToDefaults()
+        applyProjectMPresetCycleMode()
     }
     
     @objc private func setCycleModeRandom(_ sender: Any?) {
         presetCycleMode = .random
-        startPresetCycleTimer()
+        saveProjectMPresetCycleStateToDefaults()
+        applyProjectMPresetCycleMode()
     }
     
     @objc private func setCycleInterval(_ sender: NSMenuItem) {
         presetCycleInterval = TimeInterval(sender.tag)
-        if presetCycleMode != .off {
-            startPresetCycleTimer()  // Restart with new interval
-        }
+        saveProjectMPresetCycleStateToDefaults()
+        applyProjectMPresetCycleMode()
     }
     
     private func startPresetCycleTimer() {

--- a/Sources/NullPlayer/Windows/ProjectM/ProjectMView.swift
+++ b/Sources/NullPlayer/Windows/ProjectM/ProjectMView.swift
@@ -41,15 +41,8 @@ class ProjectMView: NSView, GeissMenuTarget, TripexMenuTarget, MetMuseumMenuTarg
     /// Observer for playback state changes
     private var playbackStateObserver: NSObjectProtocol?
     
-    /// Preset cycling mode
-    enum PresetCycleMode {
-        case off       // Manual only
-        case cycle     // Sequential cycling
-        case random    // Random on timer
-    }
-    
     /// Current preset cycle mode
-    private var presetCycleMode: PresetCycleMode = .off
+    private var presetCycleMode: VisualizationCycleMode = .off
 
     /// Timer for preset cycling
     private var presetCycleTimer: Timer?
@@ -59,7 +52,7 @@ class ProjectMView: NSView, GeissMenuTarget, TripexMenuTarget, MetMuseumMenuTarg
 
     /// Tripex cycle state — mirrors the ProjectM cycle controls for a
     /// uniform UX across visualization engines.
-    private var tripexCycleMode: PresetCycleMode = .cycle
+    private var tripexCycleMode: VisualizationCycleMode = .cycle
     private var tripexCycleTimer: Timer?
     private var tripexCycleInterval: TimeInterval = 30.0
 
@@ -99,6 +92,9 @@ class ProjectMView: NSView, GeissMenuTarget, TripexMenuTarget, MetMuseumMenuTarg
 
         // Create and add OpenGL visualization view
         setupVisualizationView()
+
+        loadProjectMPresetCycleStateFromDefaults()
+        applyProjectMPresetCycleModeIfActive()
 
         // Restore Tripex cycle state from defaults; applied if/when Tripex
         // becomes the active engine (handled in switchVisualizationEngine,
@@ -640,15 +636,18 @@ class ProjectMView: NSView, GeissMenuTarget, TripexMenuTarget, MetMuseumMenuTarg
             switch presetCycleMode {
             case .off:
                 presetCycleMode = .cycle
-                startPresetCycleTimer()
+                saveProjectMPresetCycleStateToDefaults()
+                applyProjectMPresetCycleMode()
                 NSLog("ProjectMView: Auto-cycle enabled")
             case .cycle:
                 presetCycleMode = .random
-                startPresetCycleTimer()
+                saveProjectMPresetCycleStateToDefaults()
+                applyProjectMPresetCycleMode()
                 NSLog("ProjectMView: Auto-random enabled")
             case .random:
                 presetCycleMode = .off
-                stopPresetCycleTimer()
+                saveProjectMPresetCycleStateToDefaults()
+                applyProjectMPresetCycleMode()
                 NSLog("ProjectMView: Auto-cycle disabled")
             }
             return true
@@ -1227,27 +1226,54 @@ class ProjectMView: NSView, GeissMenuTarget, TripexMenuTarget, MetMuseumMenuTarg
     }
     
     // MARK: - Preset Cycle Mode
+
+    private func loadProjectMPresetCycleStateFromDefaults() {
+        presetCycleMode = ProjectMPresetCycleSettings.loadMode()
+        presetCycleInterval = ProjectMPresetCycleSettings.loadInterval()
+    }
+
+    private func saveProjectMPresetCycleStateToDefaults() {
+        ProjectMPresetCycleSettings.save(mode: presetCycleMode, interval: presetCycleInterval)
+    }
+
+    private func applyProjectMPresetCycleModeIfActive() {
+        guard visualizationGLView?.currentEngineType == .projectM else {
+            stopPresetCycleTimer()
+            return
+        }
+        applyProjectMPresetCycleMode()
+    }
+
+    private func applyProjectMPresetCycleMode() {
+        if presetCycleMode == .off {
+            stopPresetCycleTimer()
+        } else {
+            startPresetCycleTimer()
+        }
+    }
     
     @objc private func setCycleModeOff(_ sender: Any?) {
         presetCycleMode = .off
-        stopPresetCycleTimer()
+        saveProjectMPresetCycleStateToDefaults()
+        applyProjectMPresetCycleMode()
     }
     
     @objc private func setCycleModeCycle(_ sender: Any?) {
         presetCycleMode = .cycle
-        startPresetCycleTimer()
+        saveProjectMPresetCycleStateToDefaults()
+        applyProjectMPresetCycleMode()
     }
     
     @objc private func setCycleModeRandom(_ sender: Any?) {
         presetCycleMode = .random
-        startPresetCycleTimer()
+        saveProjectMPresetCycleStateToDefaults()
+        applyProjectMPresetCycleMode()
     }
     
     @objc private func setCycleInterval(_ sender: NSMenuItem) {
         presetCycleInterval = TimeInterval(sender.tag)
-        if presetCycleMode != .off {
-            startPresetCycleTimer()  // Restart with new interval
-        }
+        saveProjectMPresetCycleStateToDefaults()
+        applyProjectMPresetCycleMode()
     }
 
     // MARK: - Visualization Engine Switching
@@ -1266,6 +1292,9 @@ class ProjectMView: NSView, GeissMenuTarget, TripexMenuTarget, MetMuseumMenuTarg
         if type == .tripex {
             loadTripexCycleStateFromDefaults()
             applyTripexCycleMode()
+        } else if type == .projectM {
+            loadProjectMPresetCycleStateFromDefaults()
+            applyProjectMPresetCycleMode()
         }
     }
 

--- a/Tests/NullPlayerAppTests/ProjectMPresetCycleSettingsTests.swift
+++ b/Tests/NullPlayerAppTests/ProjectMPresetCycleSettingsTests.swift
@@ -1,0 +1,44 @@
+import XCTest
+@testable import NullPlayer
+
+final class ProjectMPresetCycleSettingsTests: XCTestCase {
+    private var defaults: UserDefaults!
+    private var suiteName: String!
+
+    override func setUp() {
+        super.setUp()
+        suiteName = "ProjectMPresetCycleSettingsTests.\(UUID().uuidString)"
+        defaults = UserDefaults(suiteName: suiteName)
+    }
+
+    override func tearDown() {
+        defaults.removePersistentDomain(forName: suiteName)
+        defaults = nil
+        suiteName = nil
+        super.tearDown()
+    }
+
+    func testDefaultsToManualModeAndThirtySecondInterval() {
+        XCTAssertEqual(ProjectMPresetCycleSettings.loadMode(defaults: defaults), .off)
+        XCTAssertEqual(ProjectMPresetCycleSettings.loadInterval(defaults: defaults), 30.0, accuracy: 0.001)
+    }
+
+    func testPersistsAutoRandomModeAndInterval() {
+        ProjectMPresetCycleSettings.save(mode: .random, interval: 60.0, defaults: defaults)
+
+        XCTAssertEqual(ProjectMPresetCycleSettings.loadMode(defaults: defaults), .random)
+        XCTAssertEqual(ProjectMPresetCycleSettings.loadInterval(defaults: defaults), 60.0, accuracy: 0.001)
+    }
+
+    func testInvalidStoredModeFallsBackToManual() {
+        defaults.set("shuffle", forKey: ProjectMPresetCycleSettings.DefaultsKey.cycleMode)
+
+        XCTAssertEqual(ProjectMPresetCycleSettings.loadMode(defaults: defaults), .off)
+    }
+
+    func testInvalidStoredIntervalFallsBackToThirtySeconds() {
+        defaults.set(0.0, forKey: ProjectMPresetCycleSettings.DefaultsKey.cycleInterval)
+
+        XCTAssertEqual(ProjectMPresetCycleSettings.loadInterval(defaults: defaults), 30.0, accuracy: 0.001)
+    }
+}

--- a/Tests/NullPlayerAppTests/WindowRestoreGeometryTests.swift
+++ b/Tests/NullPlayerAppTests/WindowRestoreGeometryTests.swift
@@ -1,0 +1,59 @@
+import AppKit
+import XCTest
+@testable import NullPlayer
+
+final class WindowRestoreGeometryTests: XCTestCase {
+    func testModernRestorePreservesSideDockedEqualizerPosition() {
+        let savedEQFrame = NSRect(x: 375, y: 500, width: 275, height: 116)
+
+        let restored = WindowManager.normalizedModernCenterStackRestoredFrame(
+            savedEQFrame,
+            kind: .equalizer,
+            mainWidth: 275,
+            minimumWidth: 275,
+            targetHeight: 116,
+            peppyMeterFloor: 203,
+            peppyMeterLegacyDoubleHeight: 232
+        )
+
+        XCTAssertEqual(restored.minX, savedEQFrame.minX, accuracy: 0.001)
+        XCTAssertEqual(restored.width, 275, accuracy: 0.001)
+        XCTAssertEqual(restored.maxY, savedEQFrame.maxY, accuracy: 0.001)
+    }
+
+    func testModernRestorePreservesStretchablePlaylistWidthAndPosition() {
+        let savedPlaylistFrame = NSRect(x: 100, y: 384, width: 550, height: 116)
+
+        let restored = WindowManager.normalizedModernCenterStackRestoredFrame(
+            savedPlaylistFrame,
+            kind: .playlist,
+            mainWidth: 275,
+            minimumWidth: 275,
+            targetHeight: 116,
+            peppyMeterFloor: 203,
+            peppyMeterLegacyDoubleHeight: 232
+        )
+
+        XCTAssertEqual(restored.minX, savedPlaylistFrame.minX, accuracy: 0.001)
+        XCTAssertEqual(restored.width, savedPlaylistFrame.width, accuracy: 0.001)
+        XCTAssertEqual(restored.maxY, savedPlaylistFrame.maxY, accuracy: 0.001)
+    }
+
+    func testModernRestorePreservesStretchableSpectrumWidth() {
+        let savedSpectrumFrame = NSRect(x: 100, y: 268, width: 550, height: 140)
+
+        let restored = WindowManager.normalizedModernCenterStackRestoredFrame(
+            savedSpectrumFrame,
+            kind: .spectrum,
+            mainWidth: 275,
+            minimumWidth: 275,
+            targetHeight: 116,
+            peppyMeterFloor: 203,
+            peppyMeterLegacyDoubleHeight: 232
+        )
+
+        XCTAssertEqual(restored.width, savedSpectrumFrame.width, accuracy: 0.001)
+        XCTAssertEqual(restored.height, savedSpectrumFrame.height, accuracy: 0.001)
+        XCTAssertEqual(restored.maxY, savedSpectrumFrame.maxY, accuracy: 0.001)
+    }
+}

--- a/skills/projectm-milkdrop/SKILL.md
+++ b/skills/projectm-milkdrop/SKILL.md
@@ -52,6 +52,10 @@ Place `.milk` files there and use "Reload Presets" from the context menu.
 
 Auto-switching modes are disabled by default for stability — some presets may glitch during transitions.
 
+Cycle mode and interval are persistent user preferences:
+- Mode: `projectM.cycleMode` (`off`, `cycle`, `random`)
+- Interval: `projectM.cycleInterval` (seconds, default 30)
+
 ## Audio Sensitivity (PCM Gain)
 
 Amplitude of audio samples fed to the visualization engine:


### PR DESCRIPTION
## Summary
- Preserve restored modern center-stack window positions and stretch widths instead of forcing them back to the main window x/width
- Persist ProjectM visualization cycle mode and interval so Auto-Cycle/Auto-Random survive app restarts
- Add focused tests for restore geometry and ProjectM cycle settings

## Tests
- swift test --filter ProjectMPresetCycleSettingsTests
- swift test --filter WindowRestoreGeometryTests
- swift test

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * ProjectM preset cycling preferences now persist across app launches, including cycle mode and interval.
  * ProjectM restores saved cycling settings when initialized or reactivated.
  * Visualization cycling supports off, sequential, and random modes.

* **Bug Fixes**
  * Improved restoration of modern visualization window sizes and positions.
  * Preserved compatibility with legacy PeppyMeter window layouts.

* **Documentation**
  * Documented ProjectM cycling preferences and default interval.

* **Tests**
  * Added coverage for preference persistence and window geometry restoration.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->