### PR TITLE
Fix audio-tap notification deadlock on rapid track loads

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,7 @@
 
 - **Classic 16-color skins and themed EQ art render correctly** — packed 1-bit/4-bit BMP rows now use the BMP bit stride instead of treating every pixel as a byte, fixing scrambled transport buttons, numbers, and playlist art in skins such as `ascii.wsz`. The classic EQ also draws its slider tracks and graph curve from each skin's `eqmain.bmp`, so non-default skins such as `Purple_Glow.wsz` no longer fall back to hardcoded green/yellow/red art.
 - **Docked PeppyMeter and Flow windows no longer show a thin seam under the main window** — dragging the PeppyMeter or Flow window to dock it below the main window could leave a roughly 1-pixel line where the desktop showed through the join, most visible on standard-resolution (non-Retina) displays. Classic skins left a sub-pixel gap between the two window frames, and modern translucent skins exposed a strip of window background at the shared edge. Both now dock flush with no gap, matching the seamless docking that Metal skins already had.
+- **App no longer freezes when Play is pressed rapidly with a VU or Audio Analysis window open** — quickly re-triggering track loads while the PeppyMeter/VU meter or the Audio Analysis Scope/Octave panes were open could deadlock the app. Those windows subscribed to realtime audio-tap notifications with main-thread delivery, which blocked the audio tap thread while the main thread was tearing the tap down during a track load. The affected windows now receive tap updates without blocking the audio thread.
 
 ## 0.28.1
 

--- a/Sources/NullPlayer/PeppyMeter/PeppyMeterLevelModel.swift
+++ b/Sources/NullPlayer/PeppyMeter/PeppyMeterLevelModel.swift
@@ -42,14 +42,20 @@ final class PeppyMeterLevelModel {
         guard !running else { return }
         running = true
         WindowManager.shared.audioEngine.addStereoConsumer(consumerId)
+        // Receive on the posting thread (`queue: nil`) and hop to main ourselves. Registering
+        // with `queue: .main` makes NotificationCenter deliver synchronously (addOperation +
+        // waitUntilFinished), which blocks the real-time audio tap thread on the main queue and
+        // deadlocks against tap teardown (removeTap during rapid track loads).
         observer = NotificationCenter.default.addObserver(
-            forName: .audioStereoPCMDataUpdated, object: nil, queue: .main
-        ) { [weak self] note in
-            guard let self else { return }
+            forName: .audioStereoPCMDataUpdated, object: nil, queue: nil
+        ) { note in
             let left = note.userInfo?["left"] as? [Float] ?? []
             let right = note.userInfo?["right"] as? [Float] ?? []
-            self.targetLeft = PeppyMeterLevels.volume(fromDBFS: Double(AudioAnalysisDSP.rmsDBFS(left)), floor: self.floorDB)
-            self.targetRight = PeppyMeterLevels.volume(fromDBFS: Double(AudioAnalysisDSP.rmsDBFS(right)), floor: self.floorDB)
+            DispatchQueue.main.async { [weak self] in
+                guard let self else { return }
+                self.targetLeft = PeppyMeterLevels.volume(fromDBFS: Double(AudioAnalysisDSP.rmsDBFS(left)), floor: self.floorDB)
+                self.targetRight = PeppyMeterLevels.volume(fromDBFS: Double(AudioAnalysisDSP.rmsDBFS(right)), floor: self.floorDB)
+            }
         }
         let t = Timer(timeInterval: 1.0 / 60.0, repeats: true) { [weak self] _ in self?.tick() }
         RunLoop.main.add(t, forMode: .common)

--- a/Sources/NullPlayer/Windows/AudioAnalysis/OctavePaneView.swift
+++ b/Sources/NullPlayer/Windows/AudioAnalysis/OctavePaneView.swift
@@ -39,18 +39,23 @@ class OctaveCanvasView: NSView {
         layer?.backgroundColor = NSColor.black.cgColor
 
         // Observe magnitudes updates from the audio engine
+        // Receive on the posting thread (`queue: nil`) and hop to main ourselves. `queue: .main`
+        // makes NotificationCenter deliver synchronously and blocks the real-time audio tap
+        // thread on the main queue, deadlocking against tap teardown during rapid track loads.
         magnitudesObserver = NotificationCenter.default.addObserver(
             forName: .audioFFTMagnitudesUpdated,
             object: nil,
-            queue: .main
-        ) { [weak self] notification in
+            queue: nil
+        ) { notification in
             guard let userInfo = notification.userInfo,
                   let magnitudes = userInfo["magnitudes"] as? [Float],
                   let sampleRate = userInfo["sampleRate"] as? Double,
                   let fftSize = userInfo["fftSize"] as? Int else { return }
 
-            self?.updateWithMagnitudes(magnitudes, sampleRate: sampleRate, fftSize: fftSize)
-            self?.needsDisplay = true
+            DispatchQueue.main.async { [weak self] in
+                self?.updateWithMagnitudes(magnitudes, sampleRate: sampleRate, fftSize: fftSize)
+                self?.needsDisplay = true
+            }
         }
     }
 

--- a/Sources/NullPlayer/Windows/AudioAnalysis/ScopePaneView.swift
+++ b/Sources/NullPlayer/Windows/AudioAnalysis/ScopePaneView.swift
@@ -44,14 +44,19 @@ class ScopeCanvasView: NSView {
         layer?.backgroundColor = NSColor.black.cgColor
 
         // Observe PCM data updates from the audio engine
+        // Receive on the posting thread (`queue: nil`) and hop to main ourselves. `queue: .main`
+        // makes NotificationCenter deliver synchronously and blocks the real-time audio tap
+        // thread on the main queue, deadlocking against tap teardown during rapid track loads.
         pcmObserver = NotificationCenter.default.addObserver(
             forName: .audioPCMDataUpdated,
             object: nil,
-            queue: .main
-        ) { [weak self] notification in
+            queue: nil
+        ) { notification in
             guard let userInfo = notification.userInfo,
                   let pcm = userInfo["pcm"] as? [Float] else { return }
-            self?.ingest(pcm)
+            DispatchQueue.main.async { [weak self] in
+                self?.ingest(pcm)
+            }
         }
     }
 

--- a/skills/audio-system/SKILL.md
+++ b/skills/audio-system/SKILL.md
@@ -364,6 +364,40 @@ consumer set so it costs nothing when unused:
 identical payload shape.** A consumer listening to only one path silently misses the other engine — the
 `stereoNeeded`/`magnitudesNeeded` mirror flags bridge engine → streaming the same way `spectrumNeeded` does.
 
+### Consuming tap notifications safely — never observe on `queue: .main` ⚠️
+
+`.audioPCMDataUpdated`, `.audioStereoPCMDataUpdated`, `.audioFFTMagnitudesUpdated`, and
+`.audioWaveform576DataUpdated` are posted **directly from the realtime audio tap thread** (see
+`AudioEngine.processAudioBuffer`; `.audioSpectrumDataUpdated` is the exception — it is dispatched to
+main at the source). `NotificationCenter` delivers a `queue:`-based observer **synchronously**: it
+enqueues an `NSOperation` on that queue and calls `waitUntilFinished`. So an observer registered with
+`queue: .main` blocks the audio tap thread on the main queue.
+
+That deadlocks against tap teardown: `AudioEngine.commitLoadedLocalTrack` calls
+`mixerNode.removeTap(onBus:)` on the **main thread**, which waits on the AVFoundation RealtimeMessenger
+lock the tap thread holds while it is blocked posting to main. Rapid track loads (e.g. spamming Play)
+make teardown coincide with a tap callback and hang the app.
+
+**Correct pattern for any window/view consuming these tap notifications** — register with `queue: nil`
+(runs synchronously on the posting thread, no `OperationQueue` wait) and hop to main yourself:
+
+```swift
+observer = NotificationCenter.default.addObserver(
+    forName: .audioPCMDataUpdated, object: nil, queue: nil   // NOT .main
+) { note in
+    guard let pcm = note.userInfo?["pcm"] as? [Float] else { return }
+    DispatchQueue.main.async { [weak self] in
+        self?.ingest(pcm)   // UI / mutable state touched only on main
+    }
+}
+```
+
+This is poster-agnostic, so it covers both the `AudioEngine` and `StreamingAudioPlayer` posting paths.
+Reference implementations: `BaseWaveformView`, `PeppyMeterLevelModel`, `ScopePaneView`, `OctavePaneView`.
+Views needing lowest latency (e.g. `ProjectMView`, `SpectrumAnalyzerView`) instead do their work
+directly on the posting thread with their own locking — also `queue: nil`, just no main hop. Either way,
+**never `queue: .main`** for a tap-posted notification.
+
 ## BPM Detection
 
 Real-time BPM detection using **aubio** library (`libaubio.5.dylib`):


### PR DESCRIPTION
## Problem

Pressing **Play** rapidly with a **VU meter (PeppyMeter)** or **Audio Analysis (Scope/Octave)** window open could freeze the app. A `sample` of the hung process showed a mutual deadlock:

- **Main thread** — `commitLoadedLocalTrack` → `mixerNode.removeTap(onBus:)` → blocked on the AVFoundation RealtimeMessenger lock.
- **Audio tap thread** — `processAudioBuffer` → `NotificationCenter.post(.audioStereoPCMDataUpdated)` → blocked in `NSOperation waitUntilFinished`, holding that same lock.

## Root cause

Three UI observers subscribed to notifications posted **directly from the realtime audio tap thread** using `queue: .main`. `NotificationCenter` delivers `queue:`-based observers synchronously (`addOperation` + `waitUntilFinished`), so each post blocked the tap thread on the main queue. When the main thread simultaneously tore down the tap during a track load, the two threads waited on each other. Rapid track loads just make teardown coincide with a tap callback.

## Fix

Switch the affected observers to `queue: nil` and hop to main via `DispatchQueue.main.async`, matching the existing pattern in `BaseWaveformView` (which already carried a comment describing this exact deadlock). The fix is poster-agnostic, so it also covers the `StreamingAudioPlayer` posting paths.

| Observer | Notification |
|---|---|
| `PeppyMeterLevelModel` | `.audioStereoPCMDataUpdated` (the one that fired) |
| `ScopePaneView` | `.audioPCMDataUpdated` |
| `OctavePaneView` | `.audioFFTMagnitudesUpdated` |

Spectrum-fed observers (`SpectrumView`, `ModernSpectrumView`, `SpectrogramPaneView`) were already safe — the spectrum notification is dispatched to main at the source, so `queue: .main` delivery is inline. Both ProjectM windows already use `queue: nil`.

## Also included

- **Changelog** entry under Unreleased → Bug Fixes.
- **audio-system skill** — documents the deadlock-safe observer pattern so new windows consuming realtime tap notifications don't reintroduce it.

## Testing

- `swift build` passes.
- Suggested manual QA: open the VU meter and Audio Analysis window, then spam Play on a playlist to confirm no hang.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed an issue where the app could freeze when Play was pressed rapidly while the VU meter or Audio Analysis windows were open.
  * Improved responsiveness and stability when updating audio visualizations during playback and track loading.

* **Documentation**
  * Added guidance for safely handling realtime audio updates to help prevent future hangs.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->