### PR TITLE
Add edition-agnostic capability seam for UI modes

### DIFF
--- a/Sources/NullPlayer/App/AppCapabilities.swift
+++ b/Sources/NullPlayer/App/AppCapabilities.swift
@@ -1,0 +1,33 @@
+import Foundation
+
+/// A feature that a product *edition* may choose not to support.
+///
+/// The full (default) edition supports everything. A downstream edition can
+/// narrow the set by building with the `EDITION_CUSTOM` compilation condition
+/// and supplying an `EditionPolicy` type (see `AppCapabilities.supports`).
+///
+/// Add cases here for any capability an edition might want to turn off. Keep
+/// the cases named after the *feature*, not after any particular edition — this
+/// enum is edition-agnostic on purpose.
+enum AppFeature {
+    case classicMode
+    case modernMode
+    case metalMode
+}
+
+/// Edition-agnostic capability seam.
+///
+/// This is the *only* place the app asks "does this edition support X?". The
+/// default build answers "yes" to everything, so introducing the seam is inert
+/// for the full edition. A downstream edition activates its own policy purely by
+/// defining `EDITION_CUSTOM` and adding an `EditionPolicy` — upstream never needs
+/// to know which edition that is.
+enum AppCapabilities {
+    static func supports(_ feature: AppFeature) -> Bool {
+        #if EDITION_CUSTOM
+        return EditionPolicy.supports(feature)
+        #else
+        return true
+        #endif
+    }
+}

--- a/Sources/NullPlayer/App/ContextMenuBuilder.swift
+++ b/Sources/NullPlayer/App/ContextMenuBuilder.swift
@@ -625,7 +625,7 @@ class ContextMenuBuilder {
         // Active indicator on the submenu item
         if activeMode == .classic { classicItem.state = .on }
         classicItem.submenu = classicMenu
-        uiMenu.addItem(classicItem)
+        if AppCapabilities.supports(.classicMode) { uiMenu.addItem(classicItem) }
 
         // --- Modern submenu ---
         let modernItem = NSMenuItem(title: "Modern", action: nil, keyEquivalent: "")
@@ -682,7 +682,7 @@ class ContextMenuBuilder {
 
         if activeMode == .modern { modernItem.state = .on }
         modernItem.submenu = modernMenu
-        uiMenu.addItem(modernItem)
+        if AppCapabilities.supports(.modernMode) { uiMenu.addItem(modernItem) }
 
         // --- Metal submenu ---
         let metalItem = NSMenuItem(title: "Metal", action: nil, keyEquivalent: "")
@@ -733,8 +733,8 @@ class ContextMenuBuilder {
 
         if activeMode == .metal { metalItem.state = .on }
         metalItem.submenu = metalMenu
-        uiMenu.addItem(metalItem)
-        
+        if AppCapabilities.supports(.metalMode) { uiMenu.addItem(metalItem) }
+
         return uiMenu
     }
     
@@ -4020,18 +4020,21 @@ class MenuActions: NSObject {
     // MARK: - UI Mode Switching
     
     @objc func setClassicMode() {
+        guard AppCapabilities.supports(.classicMode) else { return }
         let wm = WindowManager.shared
         guard wm.uiMode != .classic else { return }
         wm.reloadUI(to: .classic)
     }
 
     @objc func setModernMode() {
+        guard AppCapabilities.supports(.modernMode) else { return }
         let wm = WindowManager.shared
         guard wm.uiMode != .modern else { return }
         wm.reloadUI(to: .modern)
     }
 
     @objc func setMetalMode() {
+        guard AppCapabilities.supports(.metalMode) else { return }
         let wm = WindowManager.shared
         guard wm.uiMode != .metal else { return }
         wm.reloadUI(to: .metal)


### PR DESCRIPTION
## What

Introduces `AppCapabilities.supports(_:)` — a single, edition-agnostic seam for asking whether the current product *edition* supports a given feature. Wires the UI-mode switcher (Classic/Modern/Metal) and the `set*Mode` actions through it as the first consumers, guarded at both the menu and action layers.

## Why

Enables a downstream edition to ship a narrower feature set **without editing shared code**. The downstream build defines `EDITION_CUSTOM` and supplies an `EditionPolicy`; upstream never needs to know which edition that is. This keeps the divergence out of hot files like `ContextMenuBuilder`, so upstream↔downstream merges stay cheap.

## Inert for this repo

The default build (no `EDITION_CUSTOM`) answers "yes" to everything, so nullplayer's behavior is unchanged — every UI mode still appears exactly as before. Verified with a clean `swift build`.

## Merge note

Please **merge without squashing** (merge-commit or rebase). A downstream consumer already has this exact commit in its history; preserving the SHA keeps its future `git merge upstream/main` frictionless. A squash creates a new SHA with identical content, which still merges but is less clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added support for edition-based feature availability.
  * UI mode options now appear only when supported by the current edition.
  * Prevented switching to unavailable Classic, Modern, or Metal modes.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->