### PR TITLE
Fix video rendering in bottom-left corner until resize

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@
 
 ### Bug Fixes
 
+- **Video now fills the player window immediately instead of the bottom-left corner** — launching a video (most noticeably a just-ripped local clip) could render it into a small patch in the bottom-left of the window until the window was manually resized, which snapped it to fill. VLCKit sizes its video-output subview to the drawable at insertion time, and for instant-starting local files that happened before the window had laid out. The video host now forces VLCKit's output to fill on insertion and on every resize, so playback fills the window from the first frame.
 - **Ripping and YouTube downloads to a NAS no longer fail with "Bad file descriptor"** — ripping a URL, or downloading from the YouTube source, directly to a network-mounted folder (SMB/AFP) could fail with *Bad file descriptor* and similar errors, while the same operation to a local folder worked. yt-dlp streams to a `.part` file, `fsync`s it, and renames it into place, and video rips then transcode with ffmpeg `+faststart`; network filesystems reject those random-access/rename patterns. The download and transcode now run in a local staging folder, and only the finished file (plus any `.cue`) is moved to the destination as a single sequential copy, which network volumes handle reliably.
 
 ## 0.28.2

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,7 +8,6 @@
 
 ### Bug Fixes
 
-- **Video now fills the player window immediately instead of the bottom-left corner** — launching a video (most noticeably a just-ripped local clip) could render it into a small patch in the bottom-left of the window until the window was manually resized, which snapped it to fill. VLCKit sizes its video-output subview to the drawable at insertion time, and for instant-starting local files that happened before the window had laid out. The video host now forces VLCKit's output to fill on insertion and on every resize, so playback fills the window from the first frame.
 - **Ripping and YouTube downloads to a NAS no longer fail with "Bad file descriptor"** — ripping a URL, or downloading from the YouTube source, directly to a network-mounted folder (SMB/AFP) could fail with *Bad file descriptor* and similar errors, while the same operation to a local folder worked. yt-dlp streams to a `.part` file, `fsync`s it, and renames it into place, and video rips then transcode with ffmpeg `+faststart`; network filesystems reject those random-access/rename patterns. The download and transcode now run in a local staging folder, and only the finished file (plus any `.cue`) is moved to the destination as a single sequential copy, which network volumes handle reliably.
 
 ## 0.28.2

--- a/Sources/NullPlayer/Windows/VideoPlayer/VideoPlayerView.swift
+++ b/Sources/NullPlayer/Windows/VideoPlayer/VideoPlayerView.swift
@@ -11,13 +11,39 @@ private struct VideoTrackInfo {
     let name: String
 }
 
+/// Host view for VLCKit's video output.
+///
+/// VLCKit inserts its own rendering subview into whatever NSView is assigned as
+/// the player's `drawable`, and it sizes that subview to the host's bounds *at
+/// insertion time*. For instant-starting local files (e.g. a freshly ripped
+/// clip) that insertion can happen before the window has been laid out, leaving
+/// the video pinned to the bottom-left corner at a stale size until a manual
+/// resize nudges it. Streamed sources avoid this only because their first-frame
+/// delay lets layout settle first. Forcing every subview to fill the host on
+/// insertion and on every resize keeps the video output matched to the host
+/// regardless of when VLCKit attaches it.
+private final class VLCVideoHostView: NSView {
+    override func didAddSubview(_ subview: NSView) {
+        super.didAddSubview(subview)
+        subview.autoresizingMask = [.width, .height]
+        subview.frame = bounds
+    }
+
+    override func setFrameSize(_ newSize: NSSize) {
+        super.setFrameSize(newSize)
+        for subview in subviews {
+            subview.frame = bounds
+        }
+    }
+}
+
 /// Video player view using VLCKit (libVLC), skinned title bar, and controls
 class VideoPlayerView: NSView {
 
     // MARK: - Properties
 
     private var mediaPlayer: VLCMediaPlayer?
-    private var playerHostView: NSView!
+    private var playerHostView: VLCVideoHostView!
     private var loadingIndicator: NSProgressIndicator?
     private var currentTitle: String = ""
     private var currentURL: URL?
@@ -159,7 +185,7 @@ class VideoPlayerView: NSView {
         let controlBarHeight: CGFloat = 40
         
         // Create a host view for the player layer - fills entire view
-        playerHostView = NSView(frame: bounds)
+        playerHostView = VLCVideoHostView(frame: bounds)
         playerHostView.wantsLayer = true
         playerHostView.layer?.backgroundColor = NSColor.black.cgColor
         playerHostView.autoresizingMask = [.width, .height]


### PR DESCRIPTION
## Problem

Launching a video — most noticeably a just-ripped local clip — could render it into a small patch in the **bottom-left corner** of the player window. Manually resizing the window snapped it to fill.

## Root cause

VLCKit inserts its own video-output subview into the view assigned as the player's `drawable` (`playerHostView`) during `play()`, and sizes that subview to the host's bounds **only at insertion time**. For instant-starting local files, that insertion happens before the window has finished laying out, so the video is pinned at a stale bottom-left size. A manual resize triggers `layout()`/autoresizing and fixes it. Streamed sources (Plex/Jellyfin/Emby) dodged the bug because their first-frame delay let layout settle first.

## Fix

Route VLCKit's drawable through a dedicated `VLCVideoHostView` that forces any inserted subview to fill the host — race-free, covering both insertion (`didAddSubview`) and every subsequent resize (`setFrameSize`), and pinning the VLC subview's autoresizing mask. This benefits **all** playback paths, not just rips.

## Testing

- `swift build` succeeds (only pre-existing deprecation warnings).
- Suggested manual QA: rip a clip → play it → confirm it fills the window from the first frame; verify Plex/Jellyfin/Emby video still fills correctly.

🤖 Generated with [Claude Code](https://claude.com/claude-code)