### PR TITLE
Fix classic window titlebar text not scaling with UI Size

### DIFF
--- a/Sources/NullPlayer/Skin/SkinRenderer.swift
+++ b/Sources/NullPlayer/Skin/SkinRenderer.swift
@@ -1647,7 +1647,7 @@ class SkinRenderer {
         }
 
         drawGenFontTitleText(title, in: context, bounds: bounds,
-                             titleHeight: titleHeight, isActive: isActive)
+                             titleHeight: titleHeight, isActive: isActive, fontScale: controlScale)
 
         drawPlaylistTitleBarControls(from: pleditImage, in: context, bounds: bounds,
                                      titleHeight: titleHeight, isActive: isActive,
@@ -1860,7 +1860,7 @@ class SkinRenderer {
         }
 
         if let title {
-            drawGenFontTitleText(title, in: context, bounds: bounds, titleHeight: titleHeight, isActive: isActive)
+            drawGenFontTitleText(title, in: context, bounds: bounds, titleHeight: titleHeight, isActive: isActive, fontScale: controlScale)
         }
 
         drawPlaylistTitleBarControls(from: pleditImage, in: context, bounds: bounds,
@@ -1988,8 +1988,10 @@ class SkinRenderer {
     /// Draw title text using GenFont from gen.png with a dark background gap
     /// Reusable across all window title bars (main, playlist, EQ, library, ProjectM, analyzer)
     /// - Parameter fontScale: Font scale factor. Use 1.0 for views that already apply context scaling
-    ///   (main window, EQ, playlist). Use Skin.scaleFactor for views that draw at actual window size
-    ///   (ProjectM, library, analyzer).
+    ///   (main window, EQ, playlist). Views that draw at actual window size (ProjectM, analyzer,
+    ///   PeppyMeter, Flow) should pass their `controlScale` (= `playlistChromeScale`) so the title
+    ///   text follows UI Size in lock-step with the title-bar buttons. The default `Skin.scaleFactor`
+    ///   is the fixed 100% value used only where no UI-Size-aware scale is available.
     private func drawGenFontTitleText(_ text: String, in context: CGContext, bounds: NSRect, titleHeight: CGFloat, isActive: Bool = true, fontScale: CGFloat = Skin.scaleFactor) {
         // Check if gen.bmp has a valid font - if not, fall back to TEXT.BMP
         if !isGenFontValid {


### PR DESCRIPTION
## Summary

- Classic windows drawn at *actual window size* (PeppyMeter, Flow, Spectrum Analyzer, Audio Analysis, Waveform, ProjectM) kept their **titlebar text at a fixed size** when **UI Size** changed, even though the window, its content, and the titlebar **buttons** all scaled. The buttons already receive the UI-Size-aware `controlScale`; the title text was drawn via `drawGenFontTitleText` with the default fixed `fontScale` (`Skin.scaleFactor`).
- Pass `controlScale` (= `playlistChromeScale` = `Skin.scaleFactor × classicScaleMultiplier`) as `fontScale` at the two title-text draw sites (`drawSpectrumAnalyzerTitleBar`, `drawProjectMWindowChromeWithTitle`), so the title text scales in lock-step with the buttons — matching how the main/EQ/playlist windows already scale via an already-transformed drawing context.
- Updated the `drawGenFontTitleText` doc comment to reflect the correct usage.

At **100% UI Size** `controlScale` equals the previous fixed value (1.25), so there is no visual change there; the text now grows at 150%/200%.

## Validation

- `swift build`
- Verified in-app: PeppyMeter titlebar text now grows with UI Size.

🤖 Generated with [Claude Code](https://claude.com/claude-code)