### PR TITLE
Fix Cava colors across skin changes

### DIFF
--- a/Sources/NullPlayer/App/AppStateManager.swift
+++ b/Sources/NullPlayer/App/AppStateManager.swift
@@ -793,7 +793,7 @@ class AppStateManager {
         if !runningModernMode, let skinPath = state.customSkinPath {
             let skinURL = URL(fileURLWithPath: skinPath)
             if FileManager.default.fileExists(atPath: skinPath) {
-                wm.loadSkin(from: skinURL)
+                wm.restoreClassicSkin(from: skinURL)
             }
         }
         

--- a/Sources/NullPlayer/App/WindowManager.swift
+++ b/Sources/NullPlayer/App/WindowManager.swift
@@ -3082,6 +3082,8 @@ class WindowManager {
     }
     
     private func notifySkinChanged() {
+        CavaSettings.resetCustomColorsForSkinChange()
+
         // Notify all windows to redraw with new skin
         mainWindowController?.skinDidChange()
         playlistWindowController?.skinDidChange()

--- a/Sources/NullPlayer/App/WindowManager.swift
+++ b/Sources/NullPlayer/App/WindowManager.swift
@@ -2919,12 +2919,30 @@ class WindowManager {
     
     @discardableResult
     func loadSkin(from url: URL, userDefaults: UserDefaults = .standard) -> Bool {
+        loadClassicSkin(from: url, userDefaults: userDefaults, resetCavaCustomColors: true)
+    }
+
+    /// Restore a persisted classic skin without treating launch as an explicit skin change.
+    @discardableResult
+    func restoreClassicSkin(from url: URL, userDefaults: UserDefaults = .standard) -> Bool {
+        loadClassicSkin(from: url, userDefaults: userDefaults, resetCavaCustomColors: false)
+    }
+
+    @discardableResult
+    private func loadClassicSkin(
+        from url: URL,
+        userDefaults: UserDefaults,
+        resetCavaCustomColors: Bool
+    ) -> Bool {
         do {
             let skin = try SkinLoader.shared.load(from: url)
             currentSkin = skin
             currentSkinPath = url.path
             // Persist last used classic skin for easy reload when switching UI modes
             userDefaults.set(url.path, forKey: "lastClassicSkinPath")
+            if resetCavaCustomColors {
+                CavaSettings.resetCustomColorsForSkinChange()
+            }
             applyClassicVisualizationDefaults(notify: true)
             notifySkinChanged()
             return true
@@ -2995,6 +3013,7 @@ class WindowManager {
                 currentSkin = try SkinLoader.shared.load(from: bundledURL)
                 currentSkinPath = nil
                 UserDefaults.standard.removeObject(forKey: "lastClassicSkinPath")
+                CavaSettings.resetCustomColorsForSkinChange()
                 applyClassicVisualizationDefaults(notify: true)
                 notifySkinChanged()
                 return
@@ -3006,6 +3025,7 @@ class WindowManager {
         currentSkin = SkinLoader.shared.loadDefault()
         currentSkinPath = nil
         UserDefaults.standard.removeObject(forKey: "lastClassicSkinPath")
+        CavaSettings.resetCustomColorsForSkinChange()
         applyClassicVisualizationDefaults(notify: true)
         notifySkinChanged()
     }
@@ -3082,8 +3102,6 @@ class WindowManager {
     }
     
     private func notifySkinChanged() {
-        CavaSettings.resetCustomColorsForSkinChange()
-
         // Notify all windows to redraw with new skin
         mainWindowController?.skinDidChange()
         playlistWindowController?.skinDidChange()

--- a/Sources/NullPlayer/Cava/CavaSettings.swift
+++ b/Sources/NullPlayer/Cava/CavaSettings.swift
@@ -321,6 +321,12 @@ enum CavaSettings {
         defaults.set(customized, forKey: key(.colorsCustomized, for: scope))
     }
 
+    /// Forget user-picked gradients after an explicit skin change so the new skin's palette wins.
+    static func resetCustomColorsForSkinChange() {
+        setHasCustomColors(false, for: .cavaWindow)
+        setHasCustomColors(false, for: .mainWindow)
+    }
+
     static var hasCustomColors: Bool {
         get { hasCustomColors(for: .cavaWindow) }
         set { setHasCustomColors(newValue, for: .cavaWindow) }

--- a/Sources/NullPlayer/ModernSkin/ModernSkinEngine.swift
+++ b/Sources/NullPlayer/ModernSkin/ModernSkinEngine.swift
@@ -302,6 +302,10 @@ class ModernSkinEngine {
     private func configureSkinDependencies(preservePersistedProfiles: Bool = false) {
         guard let skin = currentSkin else { return }
 
+        if !preservePersistedProfiles {
+            CavaSettings.resetCustomColorsForSkinChange()
+        }
+
         // Stamp the render style onto the skin instance so renderers and windows derive
         // "is this metal?" from the skin they're drawing, not the global currentRenderStyle
         // (which could lag a skin swap and leak the modern darkened top-chrome band into metal).

--- a/Tests/NullPlayerAppTests/CavaSettingsTests.swift
+++ b/Tests/NullPlayerAppTests/CavaSettingsTests.swift
@@ -5,14 +5,24 @@ import XCTest
 final class CavaSettingsTests: XCTestCase {
     private var originalValues: [String: Any] = [:]
 
-    private var preferenceKeys: [String] {
-        CavaSettings.Scope.allCases.flatMap { CavaSettings.preferenceKeys(for: $0) }
+    private var protectedPreferenceKeys: [String] {
+        CavaSettings.Scope.allCases.flatMap { CavaSettings.preferenceKeys(for: $0) } + [
+            "mainWindowVisMode",
+            "modernMainWindowVisMode",
+            "spectrumQualityMode",
+            "visClassicLastProfileName.mainWindow",
+            "visClassicLastProfileName.spectrumWindow",
+            "visClassicFitToWidth.mainWindow",
+            "visClassicFitToWidth.spectrumWindow",
+            "visClassicLastProfileName",
+            "visClassicFitToWidth",
+        ]
     }
 
     override func setUp() {
         super.setUp()
         originalValues = [:]
-        for key in preferenceKeys {
+        for key in protectedPreferenceKeys {
             if let value = UserDefaults.standard.object(forKey: key) {
                 originalValues[key] = value
             }
@@ -21,7 +31,7 @@ final class CavaSettingsTests: XCTestCase {
     }
 
     override func tearDown() {
-        for key in preferenceKeys {
+        for key in protectedPreferenceKeys {
             if let value = originalValues[key] {
                 UserDefaults.standard.set(value, forKey: key)
             } else {
@@ -94,6 +104,30 @@ final class CavaSettingsTests: XCTestCase {
         XCTAssertFalse(CavaSettings.hasCustomColors(for: .mainWindow))
         XCTAssertEqual(CavaSettings.currentColorSchemeIndex(for: .cavaWindow), fireIndex)
         XCTAssertEqual(CavaSettings.currentColorSchemeIndex(for: .mainWindow), iceIndex)
+    }
+
+    func testClassicSkinRestorePreservesCustomColorsWhileExplicitLoadClearsThem() throws {
+        let skinURL = try XCTUnwrap(
+            BundleHelper.url(
+                forResource: "NullPlayer-Silver",
+                withExtension: "wsz",
+                subdirectory: "Resources/Skins"
+            )
+        )
+        let suiteName = "CavaSettingsTests.classicSkinLoad.\(UUID().uuidString)"
+        let testDefaults = try XCTUnwrap(UserDefaults(suiteName: suiteName))
+        defer { testDefaults.removePersistentDomain(forName: suiteName) }
+
+        CavaSettings.setHasCustomColors(true, for: .cavaWindow)
+        CavaSettings.setHasCustomColors(true, for: .mainWindow)
+
+        XCTAssertTrue(WindowManager.shared.restoreClassicSkin(from: skinURL, userDefaults: testDefaults))
+        XCTAssertTrue(CavaSettings.hasCustomColors(for: .cavaWindow))
+        XCTAssertTrue(CavaSettings.hasCustomColors(for: .mainWindow))
+
+        XCTAssertTrue(WindowManager.shared.loadSkin(from: skinURL, userDefaults: testDefaults))
+        XCTAssertFalse(CavaSettings.hasCustomColors(for: .cavaWindow))
+        XCTAssertFalse(CavaSettings.hasCustomColors(for: .mainWindow))
     }
 
     func testClassicStackRepairIncludesCavaAfterFlow() throws {

--- a/Tests/NullPlayerAppTests/CavaSettingsTests.swift
+++ b/Tests/NullPlayerAppTests/CavaSettingsTests.swift
@@ -75,6 +75,27 @@ final class CavaSettingsTests: XCTestCase {
         XCTAssertEqual(CavaSettings.barCount, 48)
     }
 
+    func testSkinChangeClearsCustomColorFlagsForBothScopesWithoutDeletingColors() throws {
+        let fireIndex = try XCTUnwrap(CavaSettings.colorSchemes.firstIndex { $0.name == "Fire" })
+        let iceIndex = try XCTUnwrap(CavaSettings.colorSchemes.firstIndex { $0.name == "Ice" })
+        let fire = CavaSettings.colorSchemes[fireIndex]
+        let ice = CavaSettings.colorSchemes[iceIndex]
+
+        CavaSettings.setLowGradientColor(fire.low, for: .cavaWindow)
+        CavaSettings.setHighGradientColor(fire.high, for: .cavaWindow)
+        CavaSettings.setHasCustomColors(true, for: .cavaWindow)
+        CavaSettings.setLowGradientColor(ice.low, for: .mainWindow)
+        CavaSettings.setHighGradientColor(ice.high, for: .mainWindow)
+        CavaSettings.setHasCustomColors(true, for: .mainWindow)
+
+        CavaSettings.resetCustomColorsForSkinChange()
+
+        XCTAssertFalse(CavaSettings.hasCustomColors(for: .cavaWindow))
+        XCTAssertFalse(CavaSettings.hasCustomColors(for: .mainWindow))
+        XCTAssertEqual(CavaSettings.currentColorSchemeIndex(for: .cavaWindow), fireIndex)
+        XCTAssertEqual(CavaSettings.currentColorSchemeIndex(for: .mainWindow), iceIndex)
+    }
+
     func testClassicStackRepairIncludesCavaAfterFlow() throws {
         let main = NSRect(x: 100, y: 500, width: 275, height: Skin.mainWindowSize.height)
         let rowHeight = SkinElements.SpectrumWindow.windowSize.height

--- a/skills/cava/SKILL.md
+++ b/skills/cava/SKILL.md
@@ -193,8 +193,8 @@ they choose **Match Skin** or explicitly switch/reset skins. A same-skin app rel
 - `CavaSettings.hasCustomColors` (UserDefaults) gates this. `effectiveLowColor`/`effectiveHighColor` return the user's stored colors when true, otherwise the in-memory skin default.
 - Explicit modern skin changes clear both Cava scopes from
   `ModernSkinEngine.configureSkinDependencies(preservePersistedProfiles:)` when persisted profiles are
-  not being preserved. Classic skin changes clear them from `WindowManager.notifySkinChanged()`.
-  Startup restoration does not use either reset path.
+  not being preserved. Explicit classic loads clear them from `WindowManager.loadSkin(from:)` and
+  `loadBundledDefaultSkin()`; launch restoration uses the preserving `restoreClassicSkin(from:)` path.
 - The skin default is pushed by the **skin-aware views** (they can import `Skin/`/`ModernSkin/`; `CavaSettings` can't), in `commonInit` and `skinDidChange`:
   - **Classic standalone** (`CavaView`): the "Winamp Green" preset — green, like the classic Winamp spectrum.
   - **Classic inline** (`MainWindowView`): the active skin's ordered `visColors` palette, from the one-third point to its brightest endpoint. Starting above index 0 keeps short, quiet bars visible because Cava fills each whole bar with one intensity-derived color.

--- a/skills/cava/SKILL.md
+++ b/skills/cava/SKILL.md
@@ -70,7 +70,7 @@ the standalone window.
 ## Right-Click Menu
 
 - **Mono** / **Stereo:** Toggle between single-row and mirrored layouts (double-click the window does the same)
-- **Color:** Submenu with **Match Skin** at the top, then named gradient presets (each with a low→high swatch and a checkmark on the active one). Presets include standard combos (Blue → Magenta, Fire, Ice, Vaporwave, Aurora, Ocean, Neon, …) and a metallic set (Gold, Silver, Copper, Bronze, Gunmetal). Selecting a preset sets `lowGradientColor`/`highGradientColor`, sets `hasCustomColors = true`, and persists. **Match Skin** clears `hasCustomColors` so the gradient follows the active skin again (see below).
+- **Color:** Submenu with **Match Skin** at the top, then named gradient presets (each with a low→high swatch and a checkmark on the active one). Presets include standard combos (Blue → Magenta, Fire, Ice, Vaporwave, Aurora, Ocean, Neon, …) and a metallic set (Gold, Silver, Copper, Bronze, Gunmetal). Selecting a preset sets `lowGradientColor`/`highGradientColor`, sets `hasCustomColors = true`, and persists until the next explicit skin change. **Match Skin** clears `hasCustomColors` immediately so the gradient follows the active skin again (see below).
 - **Transparent Background** (modern only): Off by default — Cava is opaque. Toggling it on drops the window background to the skin's `window.opacity` (the metal/translucent look). Not shown in classic (classic Cava is always opaque black).
 - **Bars:** Bar-count presets (16 / 24 / 32 / 48 / 64).
 - **Smoothing:** Temporal smoothing / latency (`noiseReduction`): Snappy (0.50) · Balanced (0.65, default) · Smooth (0.80) · Very Smooth (0.90). Lower = more real-time but livelier; higher = smoother but laggier.
@@ -188,8 +188,13 @@ The 60 Hz timer redraws only if the ordered bar signature changed. Closing, orde
 `ModernCavaView` draws its background via `renderer.drawWindowBackground(..., backgroundOpacity:)`. Passing `renderer.skin.spectrumWindowBackgroundOpacity` (= the skin's `window.opacity`) made Cava translucent on metal/modern skins that set a low window opacity — not wanted by default. Use `effectiveBackgroundOpacity` (1.0 unless `CavaSettings.transparentBackground` is on). Also fill the content background in `drawCavaContent` when opaque, because the timer fast-path (animation-rect-only redraw) skips `drawWindowBackground` and would otherwise leave the content transparent between frames. `transparentBackground` is a durable `CavaSettings`/UserDefaults pref, default false, modern-only.
 
 ### Colors follow the skin until the user overrides
-Cava's *default* gradient tracks the active skin; a user pick (via the Color menu) overrides it until they choose **Match Skin**:
+Cava's *default* gradient tracks the active skin; a user pick (via the Color menu) overrides it until
+they choose **Match Skin** or explicitly switch/reset skins. A same-skin app relaunch preserves the pick:
 - `CavaSettings.hasCustomColors` (UserDefaults) gates this. `effectiveLowColor`/`effectiveHighColor` return the user's stored colors when true, otherwise the in-memory skin default.
+- Explicit modern skin changes clear both Cava scopes from
+  `ModernSkinEngine.configureSkinDependencies(preservePersistedProfiles:)` when persisted profiles are
+  not being preserved. Classic skin changes clear them from `WindowManager.notifySkinChanged()`.
+  Startup restoration does not use either reset path.
 - The skin default is pushed by the **skin-aware views** (they can import `Skin/`/`ModernSkin/`; `CavaSettings` can't), in `commonInit` and `skinDidChange`:
   - **Classic standalone** (`CavaView`): the "Winamp Green" preset — green, like the classic Winamp spectrum.
   - **Classic inline** (`MainWindowView`): the active skin's ordered `visColors` palette, from the one-third point to its brightest endpoint. Starting above index 0 keeps short, quiet bars visible because Cava fills each whole bar with one intensity-derived color.


### PR DESCRIPTION
## Summary

- clear standalone and main-window Cava custom-color overrides on explicit classic and modern skin changes
- preserve custom colors during same-skin app relaunches through a dedicated classic restoration path and the modern persisted-profile gate
- add regression coverage that loads a real bundled classic skin and verifies restore-versus-explicit-load behavior
- document the updated persistence behavior

## Testing

- swift test --filter CavaSettingsTests (8 tests passed)
- swift test (355 tests passed)