### PR TITLE
Modern/Metal: replace CP button with CV to toggle Cava window

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@
 
 ### Improvements
 
+- **Modern/Metal main window: quick Cava toggle** — the first button in the modern/metal main-window button row now opens the Cava spectrum window (labeled **CV**) instead of toggling Compact Mode. Compact Mode remains available from the main-window right-click menu.
 - **Video playback now uses the LGPL VLCKit engine** — the video player and cast-source decoding moved from KSPlayer/FFmpegKit (GPL-3.0) to the vendored VLCKit/libVLC (LGPL-2.1+). Play/pause, seek, skip, volume, and audio/subtitle track selection carry over, including a subtitle **Off** and subtitle-delay control.
 
 ### Bug Fixes

--- a/Sources/NullPlayer/ModernSkin/ModernSkinRenderer.swift
+++ b/Sources/NullPlayer/ModernSkin/ModernSkinRenderer.swift
@@ -1117,7 +1117,7 @@ class ModernSkinRenderer {
         let isBoxedButton = (id == "btn_eq" ||
                              id == "btn_playlist" ||
                              id == "btn_library" ||
-                             id == "btn_compact" ||
+                             id == "btn_cava" ||
                              id == "btn_projectm" ||
                              id == "btn_networkmonitor" ||
                              id == "btn_peppymeter" ||

--- a/Sources/NullPlayer/Windows/ModernMainWindow/ModernMainWindowView.swift
+++ b/Sources/NullPlayer/Windows/ModernMainWindow/ModernMainWindowView.swift
@@ -57,10 +57,6 @@ class ModernMainWindowView: NSView {
     
     /// Mouse tracking state
     private var pressedElement: String?
-    /// Transiently forces the Compact (CP) button to draw active while the heavy compact-mode
-    /// switch runs on a later runloop tick, so the click registers visually instead of looking
-    /// like a hang. The fallback toggle-button renderer keys its highlight off the on-state only.
-    private var compactButtonActivating = false
     private var isDraggingSeek = false
     private var isDraggingVolume = false
     private var isDraggingWindow = false
@@ -750,7 +746,7 @@ class ModernMainWindowView: NSView {
         let startX = leftEdge
         
         let buttonDefs: [(String, String, Bool)] = [
-            ("btn_compact", "CP", WindowManager.shared.compactModeEnabled || compactButtonActivating),
+            ("btn_cava", "CV", WindowManager.shared.isCavaVisible),
             ("btn_projectm", "VZ", WindowManager.shared.isProjectMVisible),
             ("btn_networkmonitor", "FL", WindowManager.shared.isNetworkMonitorVisible),
             ("btn_peppymeter", "PM", WindowManager.shared.isPeppyMeterVisible),
@@ -1485,7 +1481,7 @@ class ModernMainWindowView: NSView {
             let rightEdge: CGFloat = 269
             let bw: CGFloat = 16
             let bs = (rightEdge - leftEdge - 10 * bw) / 9
-            let ids = ["btn_compact", "btn_projectm", "btn_networkmonitor", "btn_peppymeter",
+            let ids = ["btn_cava", "btn_projectm", "btn_networkmonitor", "btn_peppymeter",
                        "btn_eq", "btn_playlist", "btn_spectrum", "btn_audioanalysis",
                        "btn_waveform", "btn_library"]
             for (i, id) in ids.enumerated() {
@@ -1748,18 +1744,8 @@ class ModernMainWindowView: NSView {
         case "btn_waveform":
             WindowManager.shared.toggleWaveform()
             
-        case "btn_compact":
-            // Compact-mode entry does heavy synchronous AppKit work (activation-policy switch,
-            // window teardown, status-item creation). Force the button's active (on) state and
-            // paint it to screen *first* (synchronously), then run the switch on the next runloop
-            // — otherwise the heavy work runs before any repaint and the click looks like a hang.
-            compactButtonActivating = true
-            invalidateElement(elementId)
-            display()
-            DispatchQueue.main.async {
-                WindowManager.shared.toggleCompactMode()
-                self.compactButtonActivating = false
-            }
+        case "btn_cava":
+            WindowManager.shared.toggleCava()
 
         default:
             break


### PR DESCRIPTION
## Summary

Replaces the first button in the modern/metal main-window button row — previously **CP** (Compact Mode) — with a **CV** button that opens/toggles the **Cava spectrum window**.

- `btn_compact` → `btn_cava`, label `CP` → `CV`, in the button row, hit-test id list, and the boxed-button style list.
- The handler now calls `WindowManager.toggleCava()`; the button's on/off highlight reflects `WindowManager.isCavaVisible`.
- Drops the now-unused `compactButtonActivating` transient-repaint state (only Compact Mode's heavy synchronous switch needed it).

**Compact Mode is not lost** — it remains available from the main-window right-click context menu (`ContextMenuBuilder.swift`).

## Files

- `Sources/NullPlayer/Windows/ModernMainWindow/ModernMainWindowView.swift`
- `Sources/NullPlayer/ModernSkin/ModernSkinRenderer.swift`
- `CHANGELOG.md` (entry under 0.29.0 Improvements)

## Testing

- `swift build` succeeds (only pre-existing warnings).
- Manual: in modern and metal skins, the first button reads **CV**, toggles the Cava window (docks in the center stack), and shows its boxed ON state while Cava is visible. Compact Mode still works from the right-click menu.

🤖 Generated with [Claude Code](https://claude.com/claude-code)