### PR TITLE
Modern/Metal: render ART-view rating as emoji stars

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,7 +9,6 @@
 
 ### Improvements
 
-- **ART tab rating uses emoji stars** — in Modern and Metal skins, the star rating shown at the top of the Library Browser's ART view now renders as ⭐/☆ emoji, matching the visualization menus. Star sizing and click-to-rate behavior are unchanged.
 - **ProjectM upgraded to 4.1.7, fixing preset crashes at the source** — the bundled libprojectM was updated from 4.1.6 to 4.1.7, which fixes a null-texture dereference (`Renderer::Texture::Empty()`) that crashed the app when rendering presets containing a commented-out `sampler` declaration in a shader (upstream #958), along with other preset crash and rendering fixes. Presets that previously had to be caught-and-disabled — like the bundled *suksma - dotes hostile undertake - offx - flacc* — now render normally. (The crash-detection safety net above remains for any future bad preset.)
 
   **If your visualizations have gone missing or thinned out over time, restore them:** open **Visuals > Visualizations > Restore Disabled ProjectM Presets**. The number next to it is how many presets are currently disabled — the earlier blacklisting bug may have quietly turned off many (or all) of your presets, and now that these crashes are fixed it's safe to bring them all back. Choosing it re-enables every disabled preset immediately.
@@ -17,6 +16,7 @@
 - **Video playback now uses the LGPL VLCKit engine** — the video player and cast-source decoding moved from KSPlayer/FFmpegKit (GPL-3.0) to the vendored VLCKit/libVLC (LGPL-2.1+). Play/pause, seek, skip, volume, and audio/subtitle track selection carry over, including a subtitle **Off** and subtitle-delay control.
 - **Accurate third-party attribution for the Cava and Flow visualizers** — NullPlayer's Cava spectrum analyzer and Flow network meter are clean-room Swift reimplementations of the [cava](https://github.com/karlstav/cava) (C) and [flow](https://github.com/programmersd21/flow) (Go terminal app) projects — not ports of their source code. Their bundled third-party notices now credit them as algorithm/design references (no upstream code is included) rather than reproducing licenses as though their source shipped in the app.
 - **Modern/Metal main window: quick Cava toggle** — the first button in the modern/metal main-window button row now opens the Cava spectrum window (labeled **CV**) instead of toggling Compact Mode. Compact Mode remains available from the main-window right-click menu.
+- **ART tab rating uses emoji stars** — in Modern and Metal skins, the star rating shown at the top of the Library Browser's ART view now renders as ⭐/☆ emoji, matching the visualization menus. Star sizing and click-to-rate behavior are unchanged.
 
 ### Bug Fixes
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@
 
 ### Improvements
 
+- **ART tab rating uses emoji stars** — in Modern and Metal skins, the star rating shown at the top of the Library Browser's ART view now renders as ⭐/☆ emoji, matching the visualization menus. Star sizing and click-to-rate behavior are unchanged.
 - **ProjectM upgraded to 4.1.7, fixing preset crashes at the source** — the bundled libprojectM was updated from 4.1.6 to 4.1.7, which fixes a null-texture dereference (`Renderer::Texture::Empty()`) that crashed the app when rendering presets containing a commented-out `sampler` declaration in a shader (upstream #958), along with other preset crash and rendering fixes. Presets that previously had to be caught-and-disabled — like the bundled *suksma - dotes hostile undertake - offx - flacc* — now render normally. (The crash-detection safety net above remains for any future bad preset.)
 
   **If your visualizations have gone missing or thinned out over time, restore them:** open **Visuals > Visualizations > Restore Disabled ProjectM Presets**. The number next to it is how many presets are currently disabled — the earlier blacklisting bug may have quietly turned off many (or all) of your presets, and now that these crashes are fixed it's safe to bring them all back. Choosing it re-enables every disabled preset immediately.

--- a/Sources/NullPlayer/Windows/ModernLibraryBrowser/ModernLibraryBrowserView.swift
+++ b/Sources/NullPlayer/Windows/ModernLibraryBrowser/ModernLibraryBrowserView.swift
@@ -1634,16 +1634,13 @@ class ModernLibraryBrowserView: NSView {
             let rating = currentTrackRating ?? 0
             let filledCount = rating / 2
             
-            let filledColor = isMetalRenderStyle
-                ? metalRatingColor
-                : NSColor(srgbRed: 0.98, green: 0.78, blue: 0.20, alpha: 1.0)
             let emptyColor = dimColor.withAlphaComponent(0.3)
-            
+
             for i in 0..<totalStars {
                 let x = starsX + CGFloat(i) * (starSize + starSpacing)
                 let starRect = NSRect(x: x, y: starY, width: starSize, height: starSize)
                 let isFilled = i < filledCount
-                drawPixelStar(in: starRect, color: isFilled ? filledColor : emptyColor)
+                drawEmojiStar(in: starRect, filled: isFilled, emptyColor: emptyColor)
             }
             
             // Store hit rect for click detection
@@ -2037,39 +2034,21 @@ class ModernLibraryBrowserView: NSView {
         context.restoreGState()
     }
 
-    /// Draw a low-res pixel-art star for server bar rating display
-    /// Pattern is top-down but macOS Y goes up, so we draw rows from maxY downward
-    private func drawPixelStar(in rect: NSRect, color: NSColor) {
-        let pattern: [[Int]] = [
-            [0, 0, 0, 0, 1, 0, 0, 0, 0],
-            [0, 0, 0, 1, 1, 1, 0, 0, 0],
-            [0, 0, 0, 1, 1, 1, 0, 0, 0],
-            [1, 1, 1, 1, 1, 1, 1, 1, 1],
-            [0, 1, 1, 1, 1, 1, 1, 1, 0],
-            [0, 0, 1, 1, 1, 1, 1, 0, 0],
-            [0, 0, 1, 1, 0, 1, 1, 0, 0],
-            [0, 1, 1, 0, 0, 0, 1, 1, 0],
-            [1, 1, 0, 0, 0, 0, 0, 1, 1],
-        ]
-        
-        let patternSize = 9
-        let pixelW = rect.width / CGFloat(patternSize)
-        let pixelH = rect.height / CGFloat(patternSize)
-        
-        color.setFill()
-
-        for row in 0..<patternSize {
-            for col in 0..<patternSize {
-                if pattern[row][col] == 1 {
-                    let x = rect.minX + CGFloat(col) * pixelW
-                    // Flip Y: row 0 (top of star) draws at maxY, row 8 at minY
-                    let y = rect.maxY - CGFloat(row + 1) * pixelH
-                    NSBezierPath.fill(NSRect(x: x, y: y, width: ceil(pixelW), height: ceil(pixelH)))
-                }
-            }
+    /// Draw an emoji-style rating star (matching the visualization menus) centered in `rect`.
+    /// Filled uses the color ⭐ emoji; empty uses the ☆ outline glyph tinted with `emptyColor`.
+    private func drawEmojiStar(in rect: NSRect, filled: Bool, emptyColor: NSColor) {
+        let glyph = filled ? "⭐" : "☆"
+        let font = NSFont.systemFont(ofSize: rect.height)
+        var attrs: [NSAttributedString.Key: Any] = [.font: font]
+        if !filled {
+            attrs[.foregroundColor] = emptyColor
         }
+        let str = NSAttributedString(string: glyph, attributes: attrs)
+        let size = str.size()
+        let point = NSPoint(x: rect.midX - size.width / 2, y: rect.midY - size.height / 2)
+        str.draw(at: point)
     }
-    
+
     // MARK: - Search Bar Drawing
     
     private func drawSearchBar(in context: CGContext, searchBarY: CGFloat, skin: ModernSkin) {


### PR DESCRIPTION
## Summary

In the Modern and Metal skins, the star rating shown at the top of the Library Browser's **ART** view now renders as ⭐/☆ emoji, matching the visualization menus. Previously it used a hand-rolled low-res pixel-art star (`drawPixelStar`).

- New `drawEmojiStar(in:filled:emptyColor:)` helper: color `⭐` for filled, `☆` outline (tinted with the empty color) for empty, centered in the star rect.
- Removes the now-unused `drawPixelStar` helper and the `filledColor` computation from the ART rating call site.
- Star sizing, layout, and click-to-rate behavior are unchanged.

Scope is limited to `ModernLibraryBrowserView.swift`; the classic `PlexBrowserView` pixel star is untouched.

## Background

This change was recovered from stale uncommitted work in a worktree. The rest of that worktree's changes were dupes/reverts of work already merged to `main` (projectM 4.1.7 bump, bootstrap/license edits) and were discarded. Only this emoji-star change was genuinely new, so it was re-applied cleanly on top of current `main`.

## Testing

Self-contained function swap using standard AppKit text-drawing APIs already used elsewhere in the file. Manual QA: open the Library Browser ART view in Modern and Metal skins, confirm the rating renders as ⭐/☆ and click-to-rate still works.

🤖 Generated with [Claude Code](https://claude.com/claude-code)