### PR TITLE
Add GitHub-style listening activity heatmap to Library Data tab

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,11 @@
 # Changelog
 
+## Unreleased
+
+### New Features
+
+- **GitHub-style listening activity heatmap in the Library Data tab** — the **Data > Overview** tab now opens with a contribution-graph–style grid of the trailing year: one cell per day, shaded by minutes listened (relative to your busiest day), with month labels across the top, Mon/Wed/Fri row labels, a total-hours heading, and a Less→More legend. Hovering a cell shows the exact minutes and date. It always covers the last ~year regardless of the Overview time-range filter and appears in both the Library Data tab and the standalone Stats window.
+
 ## 0.29.4
 
 ### Bug Fixes

--- a/Sources/NullPlayer/Windows/ModernStats/ContributionHeatmapView.swift
+++ b/Sources/NullPlayer/Windows/ModernStats/ContributionHeatmapView.swift
@@ -7,6 +7,7 @@ import SwiftUI
 /// shade tracks the minutes listened that calendar day.
 struct ContributionHeatmapView: View {
     @ObservedObject var agent: PlayHistoryAgent
+    @State private var model: HeatmapModel
 
     // MARK: GitHub palette (fixed, skin-independent)
     private enum Palette {
@@ -26,10 +27,17 @@ struct ContributionHeatmapView: View {
     private let weekdayLabelWidth: CGFloat = 28
     private var colWidth: CGFloat { cellSize + gap }
 
+    init(agent: PlayHistoryAgent) {
+        self.agent = agent
+        _model = State(initialValue: Self.buildModel(from: agent.dailyActivity))
+    }
+
     var body: some View {
-        let model = buildModel()
         card(model)
             .frame(maxWidth: .infinity, alignment: .leading)
+            .onChange(of: agent.dailyActivity) { _, dailyActivity in
+                model = Self.buildModel(from: dailyActivity)
+            }
     }
 
     // MARK: - Card
@@ -37,12 +45,12 @@ struct ContributionHeatmapView: View {
     @ViewBuilder
     private func card(_ model: HeatmapModel) -> some View {
         VStack(alignment: .leading, spacing: 6) {
-            Text(headingText(minutes: model.totalMinutes))
+            Text(ContributionHeatmapFormatting.headingText(minutes: model.totalMinutes))
                 .font(.system(size: 14, weight: .semibold))
                 .foregroundColor(Palette.text)
                 .padding(.horizontal, 12)
                 .padding(.top, 12)
-            if agent.dailyActivity.isEmpty {
+            if !model.hasActivity {
                 Text("No listening activity yet.")
                     .font(.system(size: 12))
                     .foregroundColor(Palette.label)
@@ -113,7 +121,7 @@ struct ContributionHeatmapView: View {
         return RoundedRectangle(cornerRadius: 2)
             .fill(color(for: level))
             .frame(width: cellSize, height: cellSize)
-            .help(tooltip(for: day))
+            .help(day.tooltip)
     }
 
     private func legend() -> some View {
@@ -157,26 +165,13 @@ struct ContributionHeatmapView: View {
         return min(4, max(1, Int(ceil(ratio * 4))))
     }
 
-    private func headingText(minutes: Double) -> String {
-        if minutes < 60 {
-            return "\(Int(minutes.rounded())) minutes of listening in the last year"
-        }
-        return "\(Int(minutes / 60)) hours of listening in the last year"
-    }
-
-    private func tooltip(for day: DayCell) -> String {
-        guard let date = day.date else { return "" }
-        let formatter = DateFormatter()
-        formatter.dateStyle = .medium
-        return "\(Int(day.minutes.rounded())) min · \(formatter.string(from: date))"
-    }
-
     // MARK: - Grid model
 
     private struct DayCell: Identifiable {
         let id: Int
         let date: Date?    // nil = padding slot outside the [start, today] window
         let minutes: Double
+        let tooltip: String
     }
 
     private struct HeatmapModel {
@@ -184,24 +179,25 @@ struct ContributionHeatmapView: View {
         let monthLabels: [(col: Int, text: String)]
         let totalMinutes: Double
         let maxMinutes: Double
+        let hasActivity: Bool
     }
 
-    private func buildModel() -> HeatmapModel {
-        let calendar = Calendar.current
-
+    private static func buildModel(
+        from dailyActivity: [DailyActivityRow],
+        referenceDate: Date = Date(),
+        calendar: Calendar = .current
+    ) -> HeatmapModel {
         var minutesByDay: [Date: Double] = [:]
-        for row in agent.dailyActivity {
+        for row in dailyActivity {
             let day = calendar.startOfDay(for: row.date)
             minutesByDay[day, default: 0] += row.minutes
         }
 
-        let today = calendar.startOfDay(for: Date())
-        // Snap to the Sunday of the current week (GitHub uses Sunday-top rows), then back 52 weeks.
-        let weekday = calendar.component(.weekday, from: today) // 1 = Sunday
-        guard let currentWeekSunday = calendar.date(byAdding: .day, value: -(weekday - 1), to: today),
-              let startSunday = calendar.date(byAdding: .weekOfYear, value: -52, to: currentWeekSunday) else {
-            return HeatmapModel(weeks: [], monthLabels: [], totalMinutes: 0, maxMinutes: 0)
-        }
+        let dateWindow = ContributionHeatmapDateWindow.containing(
+            referenceDate,
+            calendar: calendar
+        )
+        let today = dateWindow.today
 
         let monthFormatter = DateFormatter()
         monthFormatter.locale = Locale(identifier: "en_US")
@@ -214,18 +210,28 @@ struct ContributionHeatmapView: View {
         var lastMonth = -1
         var totalMinutes = 0.0
         var maxMinutes = 0.0
-        var cursor = startSunday
+        var cursor = dateWindow.start
 
         while cursor <= today {
             var column: [DayCell] = []
             for _ in 0..<7 {
                 if cursor > today {
-                    column.append(DayCell(id: index, date: nil, minutes: 0))
+                    column.append(DayCell(id: index, date: nil, minutes: 0, tooltip: ""))
                 } else {
                     let minutes = minutesByDay[cursor] ?? 0
                     totalMinutes += minutes
                     maxMinutes = max(maxMinutes, minutes)
-                    column.append(DayCell(id: index, date: cursor, minutes: minutes))
+                    column.append(
+                        DayCell(
+                            id: index,
+                            date: cursor,
+                            minutes: minutes,
+                            tooltip: ContributionHeatmapFormatting.tooltip(
+                                minutes: minutes,
+                                date: cursor
+                            )
+                        )
+                    )
                 }
                 index += 1
                 cursor = calendar.date(byAdding: .day, value: 1, to: cursor) ?? cursor.addingTimeInterval(86400)
@@ -246,6 +252,31 @@ struct ContributionHeatmapView: View {
             col += 1
         }
 
-        return HeatmapModel(weeks: weeks, monthLabels: monthLabels, totalMinutes: totalMinutes, maxMinutes: maxMinutes)
+        return HeatmapModel(
+            weeks: weeks,
+            monthLabels: monthLabels,
+            totalMinutes: totalMinutes,
+            maxMinutes: maxMinutes,
+            hasActivity: !dailyActivity.isEmpty
+        )
+    }
+}
+
+enum ContributionHeatmapFormatting {
+    private static let tooltipDateFormat = Date.FormatStyle(date: .abbreviated, time: .omitted)
+
+    static func headingText(minutes: Double) -> String {
+        if minutes < 60 {
+            let roundedMinutes = max(0, Int(minutes.rounded()))
+            let unit = roundedMinutes == 1 ? "minute" : "minutes"
+            return "\(roundedMinutes) \(unit) of listening in the last year"
+        }
+        let roundedHours = max(0, Int((minutes / 60).rounded()))
+        let unit = roundedHours == 1 ? "hour" : "hours"
+        return "\(roundedHours) \(unit) of listening in the last year"
+    }
+
+    static func tooltip(minutes: Double, date: Date) -> String {
+        "\(Int(minutes.rounded())) min · \(date.formatted(tooltipDateFormat))"
     }
 }

--- a/Sources/NullPlayer/Windows/ModernStats/ContributionHeatmapView.swift
+++ b/Sources/NullPlayer/Windows/ModernStats/ContributionHeatmapView.swift
@@ -1,0 +1,251 @@
+import SwiftUI
+
+/// A GitHub-style contribution heatmap of daily listening activity over the trailing year.
+///
+/// Rendered as a self-contained light "card" with the exact GitHub contribution palette so it looks
+/// identical in every skin (it deliberately does NOT adopt the surrounding skin colors). Each cell's
+/// shade tracks the minutes listened that calendar day.
+struct ContributionHeatmapView: View {
+    @ObservedObject var agent: PlayHistoryAgent
+
+    // MARK: GitHub palette (fixed, skin-independent)
+    private enum Palette {
+        static let l0     = Color(red: 235/255, green: 237/255, blue: 240/255) // #ebedf0
+        static let l1     = Color(red: 155/255, green: 233/255, blue: 168/255) // #9be9a8
+        static let l2     = Color(red:  64/255, green: 196/255, blue:  99/255) // #40c463
+        static let l3     = Color(red:  48/255, green: 161/255, blue:  78/255) // #30a14e
+        static let l4     = Color(red:  33/255, green: 110/255, blue:  57/255) // #216e39
+        static let card   = Color.white                                        // #ffffff
+        static let border = Color(red: 208/255, green: 215/255, blue: 222/255) // #d0d7de
+        static let text   = Color(red:  31/255, green:  35/255, blue:  40/255) // #1f2328
+        static let label  = Color(red:  89/255, green:  99/255, blue: 110/255) // #59636e
+    }
+
+    private let cellSize: CGFloat = 11
+    private let gap: CGFloat = 3
+    private let weekdayLabelWidth: CGFloat = 28
+    private var colWidth: CGFloat { cellSize + gap }
+
+    var body: some View {
+        let model = buildModel()
+        card(model)
+            .frame(maxWidth: .infinity, alignment: .leading)
+    }
+
+    // MARK: - Card
+
+    @ViewBuilder
+    private func card(_ model: HeatmapModel) -> some View {
+        VStack(alignment: .leading, spacing: 6) {
+            Text(headingText(minutes: model.totalMinutes))
+                .font(.system(size: 14, weight: .semibold))
+                .foregroundColor(Palette.text)
+                .padding(.horizontal, 12)
+                .padding(.top, 12)
+            if agent.dailyActivity.isEmpty {
+                Text("No listening activity yet.")
+                    .font(.system(size: 12))
+                    .foregroundColor(Palette.label)
+                    .padding(12)
+            } else {
+                ScrollViewReader { proxy in
+                    ScrollView(.horizontal, showsIndicators: false) {
+                        VStack(alignment: .leading, spacing: 4) {
+                            monthRow(model)
+                            HStack(alignment: .top, spacing: gap) {
+                                weekdayColumn()
+                                HStack(alignment: .top, spacing: gap) {
+                                    ForEach(Array(model.weeks.enumerated()), id: \.offset) { index, week in
+                                        VStack(spacing: gap) {
+                                            ForEach(week) { day in
+                                                cellView(day, max: model.maxMinutes)
+                                            }
+                                        }
+                                        .id(index)
+                                    }
+                                }
+                            }
+                        }
+                        .padding(12)
+                    }
+                    .onAppear {
+                        guard !model.weeks.isEmpty else { return }
+                        proxy.scrollTo(model.weeks.count - 1, anchor: .trailing)
+                    }
+                }
+                legend()
+                    .padding(.horizontal, 12)
+                    .padding(.bottom, 10)
+            }
+        }
+        .background(RoundedRectangle(cornerRadius: 8).fill(Palette.card))
+        .overlay(RoundedRectangle(cornerRadius: 8).stroke(Palette.border, lineWidth: 1))
+    }
+
+    private func monthRow(_ model: HeatmapModel) -> some View {
+        HStack(spacing: 0) {
+            Color.clear.frame(width: weekdayLabelWidth + gap, height: 12)
+            ZStack(alignment: .topLeading) {
+                ForEach(model.monthLabels, id: \.col) { label in
+                    Text(label.text)
+                        .font(.system(size: 10))
+                        .foregroundColor(Palette.label)
+                        .offset(x: CGFloat(label.col) * colWidth)
+                }
+            }
+            .frame(width: CGFloat(max(model.weeks.count, 1)) * colWidth, height: 12, alignment: .topLeading)
+        }
+    }
+
+    private func weekdayColumn() -> some View {
+        VStack(spacing: gap) {
+            ForEach(0..<7, id: \.self) { row in
+                Text(weekdayLabel(row))
+                    .font(.system(size: 9))
+                    .foregroundColor(Palette.label)
+                    .frame(width: weekdayLabelWidth, height: cellSize, alignment: .leading)
+            }
+        }
+    }
+
+    private func cellView(_ day: DayCell, max maxMinutes: Double) -> some View {
+        let level = day.date == nil ? 0 : intensityLevel(day.minutes, max: maxMinutes)
+        return RoundedRectangle(cornerRadius: 2)
+            .fill(color(for: level))
+            .frame(width: cellSize, height: cellSize)
+            .help(tooltip(for: day))
+    }
+
+    private func legend() -> some View {
+        HStack(spacing: 4) {
+            Spacer()
+            Text("Less").font(.system(size: 10)).foregroundColor(Palette.label)
+            ForEach(0..<5, id: \.self) { level in
+                RoundedRectangle(cornerRadius: 2)
+                    .fill(color(for: level))
+                    .frame(width: cellSize, height: cellSize)
+            }
+            Text("More").font(.system(size: 10)).foregroundColor(Palette.label)
+        }
+    }
+
+    // MARK: - Helpers
+
+    private func weekdayLabel(_ row: Int) -> String {
+        switch row {
+        case 1: return "Mon"
+        case 3: return "Wed"
+        case 5: return "Fri"
+        default: return ""
+        }
+    }
+
+    private func color(for level: Int) -> Color {
+        switch level {
+        case 1:  return Palette.l1
+        case 2:  return Palette.l2
+        case 3:  return Palette.l3
+        case 4:  return Palette.l4
+        default: return Palette.l0
+        }
+    }
+
+    private func intensityLevel(_ minutes: Double, max maxMinutes: Double) -> Int {
+        guard minutes > 0 else { return 0 }
+        guard maxMinutes > 0 else { return 1 }
+        let ratio = minutes / maxMinutes
+        return min(4, max(1, Int(ceil(ratio * 4))))
+    }
+
+    private func headingText(minutes: Double) -> String {
+        if minutes < 60 {
+            return "\(Int(minutes.rounded())) minutes of listening in the last year"
+        }
+        return "\(Int(minutes / 60)) hours of listening in the last year"
+    }
+
+    private func tooltip(for day: DayCell) -> String {
+        guard let date = day.date else { return "" }
+        let formatter = DateFormatter()
+        formatter.dateStyle = .medium
+        return "\(Int(day.minutes.rounded())) min · \(formatter.string(from: date))"
+    }
+
+    // MARK: - Grid model
+
+    private struct DayCell: Identifiable {
+        let id: Int
+        let date: Date?    // nil = padding slot outside the [start, today] window
+        let minutes: Double
+    }
+
+    private struct HeatmapModel {
+        let weeks: [[DayCell]]                     // week columns, each 7 cells (Sun…Sat)
+        let monthLabels: [(col: Int, text: String)]
+        let totalMinutes: Double
+        let maxMinutes: Double
+    }
+
+    private func buildModel() -> HeatmapModel {
+        let calendar = Calendar.current
+
+        var minutesByDay: [Date: Double] = [:]
+        for row in agent.dailyActivity {
+            let day = calendar.startOfDay(for: row.date)
+            minutesByDay[day, default: 0] += row.minutes
+        }
+
+        let today = calendar.startOfDay(for: Date())
+        // Snap to the Sunday of the current week (GitHub uses Sunday-top rows), then back 52 weeks.
+        let weekday = calendar.component(.weekday, from: today) // 1 = Sunday
+        guard let currentWeekSunday = calendar.date(byAdding: .day, value: -(weekday - 1), to: today),
+              let startSunday = calendar.date(byAdding: .weekOfYear, value: -52, to: currentWeekSunday) else {
+            return HeatmapModel(weeks: [], monthLabels: [], totalMinutes: 0, maxMinutes: 0)
+        }
+
+        let monthFormatter = DateFormatter()
+        monthFormatter.locale = Locale(identifier: "en_US")
+        monthFormatter.dateFormat = "MMM"
+
+        var weeks: [[DayCell]] = []
+        var monthLabels: [(col: Int, text: String)] = []
+        var index = 0
+        var col = 0
+        var lastMonth = -1
+        var totalMinutes = 0.0
+        var maxMinutes = 0.0
+        var cursor = startSunday
+
+        while cursor <= today {
+            var column: [DayCell] = []
+            for _ in 0..<7 {
+                if cursor > today {
+                    column.append(DayCell(id: index, date: nil, minutes: 0))
+                } else {
+                    let minutes = minutesByDay[cursor] ?? 0
+                    totalMinutes += minutes
+                    maxMinutes = max(maxMinutes, minutes)
+                    column.append(DayCell(id: index, date: cursor, minutes: minutes))
+                }
+                index += 1
+                cursor = calendar.date(byAdding: .day, value: 1, to: cursor) ?? cursor.addingTimeInterval(86400)
+            }
+            if let firstDate = column.first(where: { $0.date != nil })?.date {
+                let month = calendar.component(.month, from: firstDate)
+                if month != lastMonth {
+                    // Drop a preceding label that would sit too close (e.g. a 1-column leading
+                    // partial month) so labels never overlap, matching GitHub's spacing.
+                    if let last = monthLabels.last, col - last.col < 3 {
+                        monthLabels.removeLast()
+                    }
+                    monthLabels.append((col: col, text: monthFormatter.string(from: firstDate)))
+                    lastMonth = month
+                }
+            }
+            weeks.append(column)
+            col += 1
+        }
+
+        return HeatmapModel(weeks: weeks, monthLabels: monthLabels, totalMinutes: totalMinutes, maxMinutes: maxMinutes)
+    }
+}

--- a/Sources/NullPlayer/Windows/ModernStats/PlayHistoryAgent.swift
+++ b/Sources/NullPlayer/Windows/ModernStats/PlayHistoryAgent.swift
@@ -54,6 +54,7 @@ private struct StatsRefreshResult {
     var recentEvents: [RecentEventRow]
     var artistTracks: [ArtistTrackRow]
     var genreArtists: [TopDimensionRow]
+    var dailyActivity: [DailyActivityRow]
 }
 
 @MainActor
@@ -72,6 +73,7 @@ final class PlayHistoryAgent: ObservableObject {
     @Published var recentEvents:   [RecentEventRow]  = []
     @Published var artistTracks:   [ArtistTrackRow]  = []
     @Published var genreArtists:   [TopDimensionRow] = []
+    @Published var dailyActivity:  [DailyActivityRow] = []
     @Published var isLoading: Bool = false
     @Published var error: String? = nil
     @Published var isBackfilling = false
@@ -108,6 +110,7 @@ final class PlayHistoryAgent: ObservableObject {
     private var cachedRecentEvents:   [RecentEventRow]?
     private var cachedArtistTracks:   [ArtistTrackRow]?
     private var cachedGenreArtists:   [TopDimensionRow]?
+    private var cachedDailyActivity:  [DailyActivityRow]?
 
     private let store = PlayHistoryStore()
 
@@ -155,6 +158,7 @@ final class PlayHistoryAgent: ObservableObject {
         cachedRecentEvents = nil
         cachedArtistTracks = nil
         cachedGenreArtists = nil
+        cachedDailyActivity = nil
     }
 
     func scheduleRefresh() {
@@ -197,6 +201,8 @@ final class PlayHistoryAgent: ObservableObject {
                 let artistTracks = try store.fetchArtistTracks(filter: currentFilter)
                 try Task.checkCancellation()
                 let genreArtists = try store.fetchGenreArtists(filter: currentFilter)
+                try Task.checkCancellation()
+                let dailyActivity = try store.fetchDailyActivity(filter: currentFilter)
                 return StatsRefreshResult(
                     playTimeSummaries: playTimeSummaries,
                     topArtists: topArtists,
@@ -211,7 +217,8 @@ final class PlayHistoryAgent: ObservableObject {
                     outputDeviceBreakdown: outputDeviceBreakdown,
                     recentEvents: recentEvents,
                     artistTracks: artistTracks,
-                    genreArtists: genreArtists
+                    genreArtists: genreArtists,
+                    dailyActivity: dailyActivity
                 )
             }.value
             try Task.checkCancellation()
@@ -229,6 +236,7 @@ final class PlayHistoryAgent: ObservableObject {
             recentEvents = result.recentEvents
             artistTracks = result.artistTracks
             genreArtists = result.genreArtists
+            dailyActivity = result.dailyActivity
             cachedPlayTimeSummaries = result.playTimeSummaries
             cachedTopArtists = result.topArtists
             cachedTopMovies = result.topMovies
@@ -243,6 +251,7 @@ final class PlayHistoryAgent: ObservableObject {
             cachedRecentEvents = result.recentEvents
             cachedArtistTracks = result.artistTracks
             cachedGenreArtists = result.genreArtists
+            cachedDailyActivity = result.dailyActivity
         } catch is CancellationError {
             // Refresh was superseded by a newer request — discard results silently
         } catch {

--- a/Sources/NullPlayer/Windows/ModernStats/PlayHistoryStore.swift
+++ b/Sources/NullPlayer/Windows/ModernStats/PlayHistoryStore.swift
@@ -78,6 +78,13 @@ struct PlayTimeSummaryRow: Identifiable, Sendable {
     let durationListened: Double
 }
 
+struct DailyActivityRow: Identifiable, Sendable {
+    let id: String       // "yyyy-MM-dd"
+    let date: Date       // start of the calendar day
+    let plays: Int
+    let minutes: Double
+}
+
 // MARK: - Store
 
 final class PlayHistoryStore: Sendable {
@@ -299,6 +306,40 @@ final class PlayHistoryStore: Sendable {
                 playCount: count,
                 totalMinutes: mins
             )
+        }
+    }
+
+    /// Daily play activity over the trailing year, for the GitHub-style contribution heatmap.
+    /// Always covers the last 365 days (regardless of the visible time-range filter) while still
+    /// honoring the active source / content-type / excludeSkipped filters. Grouped by calendar day.
+    func fetchDailyActivity(filter: StatsFilterState) throws -> [DailyActivityRow] {
+        var yearFilter = filter
+        yearFilter.timeRange = .last365Days
+        let (whereStr, params) = whereClause(for: yearFilter)
+        // Start of day in local time, returned as unix epoch — same expression fetchTimeSeries uses.
+        let bucketExpr = "strftime('%s', strftime('%Y-%m-%d', played_at, 'unixepoch', 'localtime'), 'utc')"
+        let sql = """
+            SELECT \(bucketExpr),
+                   COUNT(*),
+                   COALESCE(SUM(pe.duration_listened), 0.0) / 60.0
+            \(historyFromClause)
+            \(whereStr)
+            GROUP BY 1
+            ORDER BY 1 ASC
+            """
+        guard let db = MediaLibraryStore.shared.analyticsConnection else { return [] }
+        let stmt = try db.prepare(sql, params)
+        let labelFormatter = DateFormatter()
+        labelFormatter.locale = Locale(identifier: "en_US_POSIX")
+        labelFormatter.dateFormat = "yyyy-MM-dd"
+        return stmt.compactMap { row in
+            guard let tsStr = row[0] as? String,
+                  let ts = Double(tsStr) else { return nil }
+            let date = Date(timeIntervalSince1970: ts)
+            let bucket = labelFormatter.string(from: date)
+            let count = Int(row[1] as? Int64 ?? 0)
+            let mins = row[2] as? Double ?? 0
+            return DailyActivityRow(id: bucket, date: date, plays: count, minutes: mins)
         }
     }
 

--- a/Sources/NullPlayer/Windows/ModernStats/PlayHistoryStore.swift
+++ b/Sources/NullPlayer/Windows/ModernStats/PlayHistoryStore.swift
@@ -78,11 +78,40 @@ struct PlayTimeSummaryRow: Identifiable, Sendable {
     let durationListened: Double
 }
 
-struct DailyActivityRow: Identifiable, Sendable {
+struct DailyActivityRow: Identifiable, Sendable, Equatable {
     let id: String       // "yyyy-MM-dd"
     let date: Date       // start of the calendar day
     let plays: Int
     let minutes: Double
+}
+
+struct ContributionHeatmapDateWindow: Equatable, Sendable {
+    let start: Date
+    let end: Date
+    let today: Date
+
+    static func containing(
+        _ referenceDate: Date = Date(),
+        calendar: Calendar = .current
+    ) -> ContributionHeatmapDateWindow {
+        let today = calendar.startOfDay(for: referenceDate)
+        let daysSinceSunday = calendar.component(.weekday, from: today) - 1
+        let currentWeekSunday = calendar.date(
+            byAdding: .day,
+            value: -daysSinceSunday,
+            to: today
+        ) ?? today
+        let startSunday = calendar.date(
+            byAdding: .weekOfYear,
+            value: -52,
+            to: currentWeekSunday
+        ) ?? currentWeekSunday
+        return ContributionHeatmapDateWindow(
+            start: startSunday,
+            end: referenceDate,
+            today: today
+        )
+    }
 }
 
 // MARK: - Store
@@ -310,11 +339,13 @@ final class PlayHistoryStore: Sendable {
     }
 
     /// Daily play activity over the trailing year, for the GitHub-style contribution heatmap.
-    /// Always covers the last 365 days (regardless of the visible time-range filter) while still
-    /// honoring the active source / content-type / excludeSkipped filters. Grouped by calendar day.
+    /// Always covers the heatmap's Sunday-aligned 53-week grid (regardless of the visible
+    /// time-range filter) while still honoring the active source / content-type / excludeSkipped
+    /// filters. Grouped by calendar day.
     func fetchDailyActivity(filter: StatsFilterState) throws -> [DailyActivityRow] {
         var yearFilter = filter
-        yearFilter.timeRange = .last365Days
+        let dateWindow = ContributionHeatmapDateWindow.containing()
+        yearFilter.timeRange = .custom(dateWindow.start, dateWindow.end)
         let (whereStr, params) = whereClause(for: yearFilter)
         // Start of day in local time, returned as unix epoch — same expression fetchTimeSeries uses.
         let bucketExpr = "strftime('%s', strftime('%Y-%m-%d', played_at, 'unixepoch', 'localtime'), 'utc')"

--- a/Sources/NullPlayer/Windows/ModernStats/StatsContentView.swift
+++ b/Sources/NullPlayer/Windows/ModernStats/StatsContentView.swift
@@ -105,6 +105,8 @@ struct StatsOverviewView: View {
     var body: some View {
         ScrollView(.vertical) {
             VStack(spacing: 16) {
+                ContributionHeatmapView(agent: agent)
+
                 PlayTimeSummarySection(agent: agent, skinTextColor: skinTextColor)
 
                 TopDimensionChartView(

--- a/Tests/NullPlayerAppTests/ContributionHeatmapTests.swift
+++ b/Tests/NullPlayerAppTests/ContributionHeatmapTests.swift
@@ -1,0 +1,98 @@
+import XCTest
+@testable import NullPlayer
+
+final class ContributionHeatmapTests: XCTestCase {
+    private var calendar: Calendar!
+
+    override func setUp() {
+        super.setUp()
+        calendar = Calendar(identifier: .gregorian)
+        calendar.locale = Locale(identifier: "en_US_POSIX")
+        calendar.timeZone = TimeZone(secondsFromGMT: 0)!
+    }
+
+    override func tearDown() {
+        calendar = nil
+        super.tearDown()
+    }
+
+    func testDateWindowStartsOnSundayFiftyTwoWeeksBeforeCurrentWeek() throws {
+        let referenceDate = try XCTUnwrap(
+            calendar.date(from: DateComponents(
+                year: 2026,
+                month: 7,
+                day: 30,
+                hour: 15,
+                minute: 45
+            ))
+        )
+
+        let window = ContributionHeatmapDateWindow.containing(
+            referenceDate,
+            calendar: calendar
+        )
+
+        XCTAssertEqual(
+            window.start,
+            calendar.date(from: DateComponents(year: 2025, month: 7, day: 27))
+        )
+        XCTAssertEqual(
+            window.today,
+            calendar.date(from: DateComponents(year: 2026, month: 7, day: 30))
+        )
+        XCTAssertEqual(window.end, referenceDate)
+        XCTAssertEqual(calendar.component(.weekday, from: window.start), 1)
+    }
+
+    func testDateWindowIncludesEveryDayRenderedByTheGrid() throws {
+        let referenceDate = try XCTUnwrap(
+            calendar.date(from: DateComponents(
+                year: 2026,
+                month: 8,
+                day: 1,
+                hour: 12
+            ))
+        )
+        let window = ContributionHeatmapDateWindow.containing(
+            referenceDate,
+            calendar: calendar
+        )
+        let renderedDayCount = try XCTUnwrap(
+            calendar.dateComponents(
+                [.day],
+                from: window.start,
+                to: window.today
+            ).day
+        ) + 1
+
+        XCTAssertEqual(renderedDayCount, 371)
+        XCTAssertLessThanOrEqual(window.start, window.end)
+        XCTAssertGreaterThanOrEqual(window.end, window.today)
+    }
+
+    func testHeadingUsesSingularUnits() {
+        XCTAssertEqual(
+            ContributionHeatmapFormatting.headingText(minutes: 1),
+            "1 minute of listening in the last year"
+        )
+        XCTAssertEqual(
+            ContributionHeatmapFormatting.headingText(minutes: 89),
+            "1 hour of listening in the last year"
+        )
+    }
+
+    func testHeadingRoundsHoursInsteadOfTruncating() {
+        XCTAssertEqual(
+            ContributionHeatmapFormatting.headingText(minutes: 90),
+            "2 hours of listening in the last year"
+        )
+        XCTAssertEqual(
+            ContributionHeatmapFormatting.headingText(minutes: 149),
+            "2 hours of listening in the last year"
+        )
+        XCTAssertEqual(
+            ContributionHeatmapFormatting.headingText(minutes: 150),
+            "3 hours of listening in the last year"
+        )
+    }
+}


### PR DESCRIPTION
## Summary

Adds a GitHub contribution-graph–style heatmap to the top of the Library **Data → Overview** tab, visualizing daily listening activity over the trailing year.

- Each cell = one calendar day, shaded by **minutes listened** relative to the busiest day.
- Month labels across the top, **Mon/Wed/Fri** row labels, a total-hours heading, and a **Less→More** legend.
- Hovering a cell shows the exact minutes + date.
- Always covers the last ~year regardless of the Overview time-range filter; appears in both the Library Data tab and the standalone Stats window (they share the Overview).

## Implementation

- **`PlayHistoryStore`** — new `fetchDailyActivity(filter:)` aggregating daily minutes over the last 365 days from the existing `play_events` table, reusing the day bucket expression and `whereClause`.
- **`PlayHistoryAgent`** — publishes `dailyActivity`, fetched in the existing refresh pipeline with caching/invalidation.
- **`ContributionHeatmapView`** (new) — self-contained SwiftUI view using the exact GitHub green palette (skin-independent white card so it looks identical in every skin), Sunday-top rows, labels, legend, and tooltips.
- **`StatsContentView`** — renders it as the first Overview section.

## Verification

Built (`swift build`) and launched the app in the NeonWave modern skin; confirmed the heatmap renders in **Data → Overview** with correct month/weekday labels, green intensity ramp, legend, and a "248 hours of listening in the last year" heading matching the data.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Added a GitHub-style listening activity heatmap to the Library Data tab and the standalone Stats window.
  - Shows trailing-year activity regardless of the Overview date filter.
  - Hover over any day to view detailed listening information, with a clear empty state when no activity is available.
- **Tests**
  - Added automated tests for heatmap date-window calculations and activity time wording/rounding.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->