### PR TITLE
Prevent waveform decode crashes from AVAudioFile exceptions

### DIFF
--- a/Sources/NullPlayer/App/AppDelegate.swift
+++ b/Sources/NullPlayer/App/AppDelegate.swift
@@ -29,11 +29,11 @@ class AppDelegate: NSObject, NSApplicationDelegate {
         // One-time video-engine configuration hook
         VideoPlayerWindowController.configureVideoEngine()
 
-        // Reclaim disk from rip staging folders orphaned by an interrupted rip
-        // (app quit/crash/sleep mid-download). Runs off-main so it never delays
-        // launch; skips folders an active rip is still writing into.
+        // Reclaim disk from temp artifacts orphaned by interrupted rip,
+        // waveform-prerender, or skin-extraction operations. Runs off-main so
+        // it never delays launch; skips items that may still be active.
         DispatchQueue.global(qos: .utility).async {
-            StreamRipper.reapOrphanedStaging()
+            StreamRipper.reapOrphanedTempItems()
         }
 
         // Initialize Plex manager early to start preloading library data

--- a/Sources/NullPlayer/ModernSkin/ModernSkinLoader.swift
+++ b/Sources/NullPlayer/ModernSkin/ModernSkinLoader.swift
@@ -10,6 +10,7 @@ class ModernSkinLoader {
     static let shared = ModernSkinLoader()
 
     static let bundleExtension = "nsz"
+    static let temporaryDirectoryPrefix = "ModernSkin_"
     
     private init() {}
 
@@ -54,7 +55,7 @@ class ModernSkinLoader {
     /// Load a skin from a `.nsz` ZIP bundle
     func loadFromBundle(at url: URL) throws -> ModernSkin {
         let tempDir = FileManager.default.temporaryDirectory
-            .appendingPathComponent("ModernSkin_\(UUID().uuidString)")
+            .appendingPathComponent("\(Self.temporaryDirectoryPrefix)\(UUID().uuidString)")
         
         try FileManager.default.createDirectory(at: tempDir, withIntermediateDirectories: true)
         

--- a/Sources/NullPlayer/Skin/SkinLoader.swift
+++ b/Sources/NullPlayer/Skin/SkinLoader.swift
@@ -7,6 +7,7 @@ class SkinLoader {
     // MARK: - Singleton
     
     static let shared = SkinLoader()
+    static let temporaryDirectoryPrefix = "ClassicSkin_"
     
     private init() {}
     
@@ -16,7 +17,7 @@ class SkinLoader {
     func load(from url: URL) throws -> Skin {
         // Create temporary directory for extraction
         let tempDir = FileManager.default.temporaryDirectory
-            .appendingPathComponent(UUID().uuidString)
+            .appendingPathComponent("\(Self.temporaryDirectoryPrefix)\(UUID().uuidString)")
         
         try FileManager.default.createDirectory(at: tempDir, withIntermediateDirectories: true)
         

--- a/Sources/NullPlayer/StreamRipper/StreamRipper.swift
+++ b/Sources/NullPlayer/StreamRipper/StreamRipper.swift
@@ -554,40 +554,44 @@ final class StreamRipper {
         }
     }
 
-    /// Filename prefixes of every temporary staging directory this ripper
-    /// creates under the system temp dir (`makeLocalStaging` for yt-dlp
-    /// downloads, and the radio/URL rip stager). An interrupted rip — app quit,
-    /// crash, or a sleep that kills the download — leaves one of these behind,
-    /// because the completion/recovery code that would delete it never runs.
-    nonisolated static let stagingPrefixes = ["nullplayer-rip-", "nullplayer-ytdl-"]
+    /// Filename prefixes for disk-significant temporary artifacts created by
+    /// interrupted rip, waveform-prerender, and skin-extraction operations.
+    nonisolated static let tempItemPrefixes = [
+        "nullplayer-rip-",
+        "nullplayer-ytdl-",
+        WaveformCacheService.prerenderTempPrefix,
+        ModernSkinLoader.temporaryDirectoryPrefix,
+        SkinLoader.temporaryDirectoryPrefix,
+    ]
 
-    /// Delete orphaned rip staging folders left in the system temp directory by
-    /// interrupted rips. Meant to be called once at app launch, off the main
-    /// thread. macOS only purges `/var/folders/.../T` after days of inactivity
-    /// and usually only on reboot, so multi-GB rips can sit there indefinitely.
+    /// Delete orphaned temporary artifacts left by interrupted operations.
+    /// Meant to be called once at app launch, off the main thread. macOS only
+    /// purges `/var/folders/.../T` after days of inactivity and usually only on
+    /// reboot, so large downloads can sit there indefinitely.
     ///
-    /// A folder is deleted only when its `StagingLease` can be acquired — i.e.
-    /// no rip in any process is still using it — and, as a secondary guard,
-    /// nothing inside it has been modified for at least `minInactivity` seconds.
-    /// The lease is held across the modification-time recheck and the delete, so
-    /// there is no window in which a rip could reclaim the folder between the two.
-    nonisolated static func reapOrphanedStaging(minInactivity: TimeInterval = 600) {
+    /// An item is deleted only when an exclusive lease can be acquired and it
+    /// has not been modified for at least `minInactivity` seconds. Rip staging
+    /// directories hold the same lease throughout active work; the inactivity
+    /// guard protects waveform files and skin directories, whose producers are
+    /// short-lived and do not hold a lease.
+    nonisolated static func reapOrphanedTempItems(
+        in tempDirectory: URL = FileManager.default.temporaryDirectory,
+        minInactivity: TimeInterval = 600
+    ) {
         let fm = FileManager.default
-        let tempDir = fm.temporaryDirectory
         let cutoff = Date().addingTimeInterval(-minInactivity)
         guard let entries = try? fm.contentsOfDirectory(
-            at: tempDir,
-            includingPropertiesForKeys: [.isDirectoryKey]
+            at: tempDirectory,
+            includingPropertiesForKeys: [.contentModificationDateKey]
         ) else { return }
 
         var reclaimed = 0
         for entry in entries {
             let name = entry.lastPathComponent
-            guard Self.stagingPrefixes.contains(where: { name.hasPrefix($0) }) else { continue }
-            guard (try? entry.resourceValues(forKeys: [.isDirectoryKey]))?.isDirectory == true else { continue }
-            // Acquire the folder's lease non-blocking. A live rip (in this or
-            // another process) holds it, so failure means the folder is in
-            // active use — leave it alone.
+            guard Self.tempItemPrefixes.contains(where: { name.hasPrefix($0) }) else { continue }
+            // Acquire the item's lease non-blocking. A live rip (in this or
+            // another process) holds its directory lease, so failure means the
+            // item may be active — leave it alone.
             guard let lease = StagingLease(entry) else { continue }
             defer { lease.release() }
             // Belt-and-braces under the held lease: skip anything modified
@@ -598,19 +602,18 @@ final class StreamRipper {
             }
         }
         if reclaimed > 0 {
-            NSLog("StreamRipper: reaped %d orphaned staging folder(s) from %@", reclaimed, tempDir.path)
+            NSLog("StreamRipper: reaped %d orphaned temporary item(s) from %@", reclaimed, tempDirectory.path)
         }
     }
 
-    /// Newest content-modification date of `directory` itself or any file
-    /// nested inside it. Used to tell an idle (orphaned) staging folder from one
-    /// an active download is still writing into — the folder's own mtime does
-    /// not update while yt-dlp/ffmpeg stream into an already-created `.part`.
-    private nonisolated static func newestModification(in directory: URL) -> Date? {
+    /// Newest content-modification date of `item` itself or any nested file.
+    /// Used to distinguish an idle artifact from one still being written; a
+    /// directory's own mtime does not change when an existing child is updated.
+    private nonisolated static func newestModification(in item: URL) -> Date? {
         let key: URLResourceKey = .contentModificationDateKey
-        var newest = (try? directory.resourceValues(forKeys: [key]))?.contentModificationDate
+        var newest = (try? item.resourceValues(forKeys: [key]))?.contentModificationDate
         guard let enumerator = FileManager.default.enumerator(
-            at: directory,
+            at: item,
             includingPropertiesForKeys: [key]
         ) else { return newest }
         for case let url as URL in enumerator {

--- a/Sources/NullPlayer/Waveform/WaveformCacheService.swift
+++ b/Sources/NullPlayer/Waveform/WaveformCacheService.swift
@@ -1,9 +1,11 @@
 import AVFoundation
 import CryptoKit
 import Foundation
+import ObjCExceptionCatcher
 
 actor WaveformCacheService {
     static let shared = WaveformCacheService()
+    static let prerenderTempPrefix = "waveform-prerender-"
 
     private struct CacheRecord: Codable {
         let sourcePath: String
@@ -207,16 +209,18 @@ actor WaveformCacheService {
 
         let audioFile: AVAudioFile
         do {
-            audioFile = try AVAudioFile(forReading: descriptor.sourceURL)
+            audioFile = try Self.catchingObjCException {
+                try AVAudioFile(forReading: descriptor.sourceURL)
+            }
         } catch {
             throw NSError(domain: "WaveformCacheService", code: 1, userInfo: [
                 NSLocalizedDescriptionKey: "Failed to open audio file: \((error as NSError).localizedDescription)",
                 NSUnderlyingErrorKey: error
             ])
         }
-        let totalFrames = max(audioFile.length, 1)
-        let fileDuration = descriptor.durationHint ?? (Double(totalFrames) / audioFile.processingFormat.sampleRate)
-        let processingFormat = audioFile.processingFormat
+        let totalFrames = try Self.catchingObjCException { max(audioFile.length, 1) }
+        let processingFormat = try Self.catchingObjCException { audioFile.processingFormat }
+        let fileDuration = descriptor.durationHint ?? (Double(totalFrames) / processingFormat.sampleRate)
         let channelCount = Int(processingFormat.channelCount)
         guard let buffer = AVAudioPCMBuffer(pcmFormat: processingFormat, frameCapacity: 16_384) else {
             throw NSError(domain: "WaveformCacheService", code: 1, userInfo: [
@@ -228,11 +232,14 @@ actor WaveformCacheService {
 
         while true {
             try Task.checkCancellation()
-            if audioFile.framePosition >= audioFile.length {
+            let position = try Self.catchingObjCException { audioFile.framePosition }
+            if position >= totalFrames {
                 break
             }
             do {
-                try audioFile.read(into: buffer)
+                try Self.catchingObjCException {
+                    try audioFile.read(into: buffer)
+                }
             } catch {
                 throw NSError(domain: "WaveformCacheService", code: 1, userInfo: [
                     NSLocalizedDescriptionKey: "Failed to read audio samples: \((error as NSError).localizedDescription)",
@@ -278,7 +285,7 @@ actor WaveformCacheService {
             return try await generateServiceSnapshotViaAssetReader(with: descriptor)
         } catch {
             NSLog(
-                "WaveformCacheService: Remote asset-reader prerender failed for %@: %@",
+                "WaveformCacheService: Direct prerender unavailable for %@; falling back to download: %@",
                 descriptor.sourcePath,
                 error.localizedDescription
             )
@@ -391,6 +398,7 @@ actor WaveformCacheService {
         try Task.checkCancellation()
 
         let (tempDownloadURL, response) = try await URLSession.shared.download(from: descriptor.sourceURL)
+        defer { try? FileManager.default.removeItem(at: tempDownloadURL) }
         if let httpResponse = response as? HTTPURLResponse,
            !(200...299).contains(httpResponse.statusCode) {
             throw NSError(domain: "WaveformCacheService", code: httpResponse.statusCode, userInfo: [
@@ -402,7 +410,7 @@ actor WaveformCacheService {
         // the temp download path, which has no extension and would resolve to ".bin"
         let sourceExt = descriptor.sourceURL.pathExtension
         let localURL = FileManager.default.temporaryDirectory
-            .appendingPathComponent("waveform-prerender-\(UUID().uuidString)")
+            .appendingPathComponent("\(Self.prerenderTempPrefix)\(UUID().uuidString)")
             .appendingPathExtension(sourceExt.isEmpty ? "bin" : sourceExt)
 
         try? FileManager.default.removeItem(at: localURL)
@@ -431,6 +439,37 @@ actor WaveformCacheService {
             allowsSeeking: true,
             isStreaming: true
         )
+    }
+
+    /// Runs `body`, converting any Objective-C `NSException` — which Swift
+    /// `do/catch` cannot intercept — into a throwable Swift error.
+    private static func catchingObjCException<T>(_ body: @escaping () throws -> T) throws -> T {
+        var result: Result<T, Error>?
+        var objcError: NSError?
+        let succeeded = NPObjCExceptionCatch({
+            do {
+                result = .success(try body())
+            } catch {
+                result = .failure(error)
+            }
+        }, &objcError)
+
+        guard succeeded else {
+            throw objcError ?? NSError(domain: "WaveformCacheService", code: 1, userInfo: [
+                NSLocalizedDescriptionKey: "AVFoundation raised an exception during waveform decode"
+            ])
+        }
+
+        switch result {
+        case .success(let value):
+            return value
+        case .failure(let error):
+            throw error
+        case .none:
+            throw NSError(domain: "WaveformCacheService", code: 1, userInfo: [
+                NSLocalizedDescriptionKey: "Waveform decode produced no result"
+            ])
+        }
     }
 
     private func loadAssetValues(for asset: AVAsset, keys: [String]) async throws {

--- a/Tests/NullPlayerAppTests/StreamRipperTests.swift
+++ b/Tests/NullPlayerAppTests/StreamRipperTests.swift
@@ -151,4 +151,45 @@ final class StreamRipperTests: XCTestCase {
         XCTAssertEqual(try Data(contentsOf: destination), Data("new cue".utf8))
         XCTAssertFalse(FileManager.default.fileExists(atPath: source.path))
     }
+
+    func testReapOrphanedTempItemsRemovesOnlyOldMatchingFilesAndDirectories() throws {
+        let oldDate = Date().addingTimeInterval(-1_200)
+        let oldNames = [
+            "nullplayer-rip-\(UUID().uuidString)",
+            "nullplayer-ytdl-\(UUID().uuidString)",
+            "ModernSkin_\(UUID().uuidString)",
+            "ClassicSkin_\(UUID().uuidString)",
+        ]
+        let oldDirectories = oldNames.map {
+            tempDirectory.appendingPathComponent($0, isDirectory: true)
+        }
+        for directory in oldDirectories {
+            try FileManager.default.createDirectory(at: directory, withIntermediateDirectories: true)
+            try FileManager.default.setAttributes([.modificationDate: oldDate], ofItemAtPath: directory.path)
+        }
+
+        let oldWaveform = tempDirectory.appendingPathComponent(
+            "waveform-prerender-\(UUID().uuidString).flac"
+        )
+        try Data("old waveform".utf8).write(to: oldWaveform)
+        try FileManager.default.setAttributes([.modificationDate: oldDate], ofItemAtPath: oldWaveform.path)
+
+        let recentWaveform = tempDirectory.appendingPathComponent(
+            "waveform-prerender-\(UUID().uuidString).mp3"
+        )
+        try Data("recent waveform".utf8).write(to: recentWaveform)
+
+        let unrelated = tempDirectory.appendingPathComponent("unrelated-\(UUID().uuidString).flac")
+        try Data("unrelated".utf8).write(to: unrelated)
+        try FileManager.default.setAttributes([.modificationDate: oldDate], ofItemAtPath: unrelated.path)
+
+        StreamRipper.reapOrphanedTempItems(in: tempDirectory, minInactivity: 600)
+
+        for directory in oldDirectories {
+            XCTAssertFalse(FileManager.default.fileExists(atPath: directory.path))
+        }
+        XCTAssertFalse(FileManager.default.fileExists(atPath: oldWaveform.path))
+        XCTAssertTrue(FileManager.default.fileExists(atPath: recentWaveform.path))
+        XCTAssertTrue(FileManager.default.fileExists(atPath: unrelated.path))
+    }
 }


### PR DESCRIPTION
## Summary

- convert Objective-C exceptions from AVAudioFile waveform decoding into normal Swift errors so waveform failure degrades gracefully instead of terminating playback
- clean URLSession download files on every fallback exit path and make the expected direct-prerender fallback log informational
- extend the existing startup reaper to remove stale waveform prerenders and classic/modern skin extraction artifacts using producer-owned prefixes
- cover stale files, stale directories, recent artifacts, and unrelated temp items with a regression test

## Testing

- swift build
- swift test --filter StreamRipperTests (9 tests passed)
- swift test (382 tests passed)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved startup cleanup to remove abandoned temporary files from ripping, waveform processing, downloads, and skin extraction.
  * Prevented recent temporary files and unrelated items from being removed.
  * Improved waveform decoding reliability by safely handling malformed or unsupported audio files.
  * Ensured temporary downloaded audio files are cleaned up promptly.

* **Maintenance**
  * Standardized temporary-file naming to support more reliable cleanup.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->