### PR TITLE
Add Library and Compact visual backdrops

### DIFF
--- a/Sources/NullPlayer/App/AppCapabilities.swift
+++ b/Sources/NullPlayer/App/AppCapabilities.swift
@@ -13,6 +13,7 @@ enum AppFeature {
     case classicMode
     case modernMode
     case metalMode
+    case compactWindowVisualsMenu
 }
 
 /// Edition-agnostic capability seam.

--- a/Sources/NullPlayer/App/ContextMenuBuilder.swift
+++ b/Sources/NullPlayer/App/ContextMenuBuilder.swift
@@ -5,6 +5,8 @@ import NullPlayerCore
 
 /// Builds the shared right-click context menu for all skin windows
 class ContextMenuBuilder {
+    /// Keeps menu targets alive when the compact window has not been created yet.
+    private static let compactBackdropFallbackPresenter = CavaPresenter(scope: .compactWindow)
     
     // MARK: - Main Menu Builder
     
@@ -429,6 +431,7 @@ class ContextMenuBuilder {
     /// Builds the top-level "Visuals" menu content for the macOS menu bar.
     static func buildMenuBarVisualsMenu() -> NSMenu {
         let menu = NSMenu()
+        let wm = WindowManager.shared
 
         let mainWindowItem = NSMenuItem(title: "Main Window", action: nil, keyEquivalent: "")
         mainWindowItem.submenu = buildMainVisualizationSubmenu()
@@ -439,10 +442,48 @@ class ContextMenuBuilder {
         menu.addItem(spectrumWindowItem)
 
         menu.addItem(buildVisualizationsMenuItem())
+        if wm.isRunningModernUI {
+            let compactWindowItem = NSMenuItem(title: "Compact Window", action: nil, keyEquivalent: "")
+            compactWindowItem.submenu = buildCompactBackdropMenu()
+            menu.addItem(compactWindowItem)
+        }
         menu.addItem(NSMenuItem.separator())
         let resetAll = NSMenuItem(title: "Reset All Visualization Preferences...", action: #selector(MenuActions.resetAllVisualizationPreferences), keyEquivalent: "")
         resetAll.target = MenuActions.shared
         menu.addItem(resetAll)
+        menu.autoenablesItems = false
+        return menu
+    }
+
+    static func buildCompactBackdropMenu(presenter explicitPresenter: CavaPresenter? = nil) -> NSMenu {
+        let menu = NSMenu()
+        let wm = WindowManager.shared
+        let currentMode = wm.compactBackdropMode
+
+        for mode in CompactBackdropMode.allCases {
+            let item = NSMenuItem(
+                title: mode.title,
+                action: #selector(MenuActions.setCompactBackdropMode(_:)),
+                keyEquivalent: ""
+            )
+            item.target = MenuActions.shared
+            item.representedObject = mode
+            item.state = currentMode == mode ? .on : .off
+            menu.addItem(item)
+        }
+
+        if currentMode == .cava {
+            menu.addItem(.separator())
+            let presenter = explicitPresenter
+                ?? wm.compactBackdropPresenter
+                ?? compactBackdropFallbackPresenter
+            let cavaMenu = presenter.buildMenu(showTransparency: false, includeClose: false)
+            while cavaMenu.numberOfItems > 0, let item = cavaMenu.item(at: 0) {
+                cavaMenu.removeItem(at: 0)
+                menu.addItem(item)
+            }
+        }
+
         menu.autoenablesItems = false
         return menu
     }
@@ -4979,6 +5020,11 @@ class MenuActions: NSObject {
 
     @objc func toggleCompactWindow() {
         WindowManager.shared.toggleCompactWindow()
+    }
+
+    @objc func setCompactBackdropMode(_ sender: NSMenuItem) {
+        guard let mode = sender.representedObject as? CompactBackdropMode else { return }
+        WindowManager.shared.setCompactBackdropMode(mode)
     }
 
     @objc func setUIScaleLevel(_ sender: NSMenuItem) {

--- a/Sources/NullPlayer/App/ContextMenuBuilder.swift
+++ b/Sources/NullPlayer/App/ContextMenuBuilder.swift
@@ -5,8 +5,9 @@ import NullPlayerCore
 
 /// Builds the shared right-click context menu for all skin windows
 class ContextMenuBuilder {
-    /// Keeps menu targets alive when the compact window has not been created yet.
+    /// Keeps menu targets alive when their browser window has not been created yet.
     private static let compactBackdropFallbackPresenter = CavaPresenter(scope: .compactWindow)
+    private static let libraryBackdropFallbackPresenter = CavaPresenter(scope: .libraryWindow)
     
     // MARK: - Main Menu Builder
     
@@ -442,6 +443,11 @@ class ContextMenuBuilder {
         menu.addItem(spectrumWindowItem)
 
         menu.addItem(buildVisualizationsMenuItem())
+        if wm.isRunningModernUI {
+            let libraryWindowItem = NSMenuItem(title: "Library Window", action: nil, keyEquivalent: "")
+            libraryWindowItem.submenu = buildLibraryBackdropMenu()
+            menu.addItem(libraryWindowItem)
+        }
         if wm.isRunningModernUI,
            AppCapabilities.supports(.compactWindowVisualsMenu) {
             let compactWindowItem = NSMenuItem(title: "Compact Window", action: nil, keyEquivalent: "")
@@ -457,15 +463,39 @@ class ContextMenuBuilder {
     }
 
     static func buildCompactBackdropMenu(presenter explicitPresenter: CavaPresenter? = nil) -> NSMenu {
-        let menu = NSMenu()
-        guard AppCapabilities.supports(.compactWindowVisualsMenu) else { return menu }
+        guard AppCapabilities.supports(.compactWindowVisualsMenu) else { return NSMenu() }
         let wm = WindowManager.shared
-        let currentMode = wm.compactBackdropMode
+        return buildBrowserBackdropMenu(
+            currentMode: wm.compactBackdropMode,
+            presenter: explicitPresenter
+                ?? wm.compactBackdropPresenter
+                ?? compactBackdropFallbackPresenter,
+            action: #selector(MenuActions.setCompactBackdropMode(_:))
+        )
+    }
 
-        for mode in CompactBackdropMode.allCases {
+    static func buildLibraryBackdropMenu(presenter explicitPresenter: CavaPresenter? = nil) -> NSMenu {
+        let wm = WindowManager.shared
+        return buildBrowserBackdropMenu(
+            currentMode: wm.libraryBackdropMode,
+            presenter: explicitPresenter
+                ?? wm.libraryBackdropPresenter
+                ?? libraryBackdropFallbackPresenter,
+            action: #selector(MenuActions.setLibraryBackdropMode(_:))
+        )
+    }
+
+    private static func buildBrowserBackdropMenu(
+        currentMode: BrowserBackdropMode,
+        presenter: CavaPresenter,
+        action: Selector
+    ) -> NSMenu {
+        let menu = NSMenu()
+
+        for mode in BrowserBackdropMode.allCases {
             let item = NSMenuItem(
                 title: mode.title,
-                action: #selector(MenuActions.setCompactBackdropMode(_:)),
+                action: action,
                 keyEquivalent: ""
             )
             item.target = MenuActions.shared
@@ -476,9 +506,6 @@ class ContextMenuBuilder {
 
         if currentMode == .cava {
             menu.addItem(.separator())
-            let presenter = explicitPresenter
-                ?? wm.compactBackdropPresenter
-                ?? compactBackdropFallbackPresenter
             let cavaMenu = presenter.buildMenu(showTransparency: false, includeClose: false)
             while cavaMenu.numberOfItems > 0, let item = cavaMenu.item(at: 0) {
                 cavaMenu.removeItem(at: 0)
@@ -5026,8 +5053,13 @@ class MenuActions: NSObject {
 
     @objc func setCompactBackdropMode(_ sender: NSMenuItem) {
         guard AppCapabilities.supports(.compactWindowVisualsMenu) else { return }
-        guard let mode = sender.representedObject as? CompactBackdropMode else { return }
+        guard let mode = sender.representedObject as? BrowserBackdropMode else { return }
         WindowManager.shared.setCompactBackdropMode(mode)
+    }
+
+    @objc func setLibraryBackdropMode(_ sender: NSMenuItem) {
+        guard let mode = sender.representedObject as? BrowserBackdropMode else { return }
+        WindowManager.shared.setLibraryBackdropMode(mode)
     }
 
     @objc func setUIScaleLevel(_ sender: NSMenuItem) {

--- a/Sources/NullPlayer/App/ContextMenuBuilder.swift
+++ b/Sources/NullPlayer/App/ContextMenuBuilder.swift
@@ -504,7 +504,7 @@ class ContextMenuBuilder {
             menu.addItem(item)
         }
 
-        if currentMode == .cava {
+        if currentMode.showsCava {
             menu.addItem(.separator())
             let cavaMenu = presenter.buildMenu(showTransparency: false, includeClose: false)
             while cavaMenu.numberOfItems > 0, let item = cavaMenu.item(at: 0) {
@@ -1220,11 +1220,14 @@ class ContextMenuBuilder {
         
         optionsMenu.addItem(NSMenuItem.separator())
         
-        // Visual Options
-        let artworkBgItem = NSMenuItem(title: "Browser Album Art Background", action: #selector(MenuActions.toggleBrowserArtworkBackground), keyEquivalent: "")
-        artworkBgItem.target = MenuActions.shared
-        artworkBgItem.state = wm.showBrowserArtworkBackground ? .on : .off
-        optionsMenu.addItem(artworkBgItem)
+        // Modern/Metal expose window-specific Art and Cava + Art choices in Visuals.
+        // Keep the legacy global toggle only for the classic browser.
+        if !wm.isRunningModernUI {
+            let artworkBgItem = NSMenuItem(title: "Browser Album Art Background", action: #selector(MenuActions.toggleBrowserArtworkBackground), keyEquivalent: "")
+            artworkBgItem.target = MenuActions.shared
+            artworkBgItem.state = wm.showBrowserArtworkBackground ? .on : .off
+            optionsMenu.addItem(artworkBgItem)
+        }
 
         return optionsMenu
     }

--- a/Sources/NullPlayer/App/ContextMenuBuilder.swift
+++ b/Sources/NullPlayer/App/ContextMenuBuilder.swift
@@ -442,7 +442,8 @@ class ContextMenuBuilder {
         menu.addItem(spectrumWindowItem)
 
         menu.addItem(buildVisualizationsMenuItem())
-        if wm.isRunningModernUI {
+        if wm.isRunningModernUI,
+           AppCapabilities.supports(.compactWindowVisualsMenu) {
             let compactWindowItem = NSMenuItem(title: "Compact Window", action: nil, keyEquivalent: "")
             compactWindowItem.submenu = buildCompactBackdropMenu()
             menu.addItem(compactWindowItem)
@@ -457,6 +458,7 @@ class ContextMenuBuilder {
 
     static func buildCompactBackdropMenu(presenter explicitPresenter: CavaPresenter? = nil) -> NSMenu {
         let menu = NSMenu()
+        guard AppCapabilities.supports(.compactWindowVisualsMenu) else { return menu }
         let wm = WindowManager.shared
         let currentMode = wm.compactBackdropMode
 
@@ -5023,6 +5025,7 @@ class MenuActions: NSObject {
     }
 
     @objc func setCompactBackdropMode(_ sender: NSMenuItem) {
+        guard AppCapabilities.supports(.compactWindowVisualsMenu) else { return }
         guard let mode = sender.representedObject as? CompactBackdropMode else { return }
         WindowManager.shared.setCompactBackdropMode(mode)
     }

--- a/Sources/NullPlayer/App/LibraryBrowserWindowProviding.swift
+++ b/Sources/NullPlayer/App/LibraryBrowserWindowProviding.swift
@@ -30,4 +30,13 @@ protocol LibraryBrowserWindowProviding: ModeDependentWindow {
     /// Used by AppStateManager to save/restore the active tab
     var browseModeRawValue: Int { get set }
 
+    /// Modern/Metal Library backdrop integration. Classic uses the no-op defaults below.
+    var libraryBackdropPresenter: CavaPresenter? { get }
+    func refreshLibraryBackdrop()
+
+}
+
+extension LibraryBrowserWindowProviding {
+    var libraryBackdropPresenter: CavaPresenter? { nil }
+    func refreshLibraryBackdrop() {}
 }

--- a/Sources/NullPlayer/App/WindowManager.swift
+++ b/Sources/NullPlayer/App/WindowManager.swift
@@ -128,15 +128,27 @@ private enum CompactModeState {
 }
 
 enum BrowserBackdropMode: Int, CaseIterable {
-    case off
-    case albumArt
-    case cava
+    case off = 0
+    case art = 1
+    case cava = 2
+    case cavaAndArt = 3
+
+    static let allCases: [BrowserBackdropMode] = [.off, .cava, .art, .cavaAndArt]
+
+    var showsCava: Bool {
+        self == .cava || self == .cavaAndArt
+    }
+
+    var showsArt: Bool {
+        self == .art || self == .cavaAndArt
+    }
 
     var title: String {
         switch self {
         case .off: return "Off"
-        case .albumArt: return "Album Art"
+        case .art: return "Art"
         case .cava: return "Cava"
+        case .cavaAndArt: return "Cava + Art"
         }
     }
 }

--- a/Sources/NullPlayer/App/WindowManager.swift
+++ b/Sources/NullPlayer/App/WindowManager.swift
@@ -134,6 +134,7 @@ enum BrowserBackdropMode: Int, CaseIterable {
     case cavaAndArt = 3
 
     static let allCases: [BrowserBackdropMode] = [.off, .cava, .art, .cavaAndArt]
+    static let defaultMode: BrowserBackdropMode = .cavaAndArt
 
     var showsCava: Bool {
         self == .cava || self == .cavaAndArt
@@ -364,7 +365,7 @@ class WindowManager {
         guard isRunningModernUI else { return .off }
         return BrowserBackdropMode(
             rawValue: UserDefaults.standard.integer(forKey: "compactBackdropMode")
-        ) ?? .off
+        ) ?? .defaultMode
     }
 
     var compactBackdropPresenter: CavaPresenter? {
@@ -382,7 +383,7 @@ class WindowManager {
         guard isRunningModernUI else { return .off }
         return BrowserBackdropMode(
             rawValue: UserDefaults.standard.integer(forKey: "libraryBackdropMode")
-        ) ?? .off
+        ) ?? .defaultMode
     }
 
     var libraryBackdropPresenter: CavaPresenter? {
@@ -733,8 +734,8 @@ class WindowManager {
             "waveformHideTooltip": false,
             "compactModeEnabled": false,
             "compactWindowEnabled": false,
-            "compactBackdropMode": BrowserBackdropMode.off.rawValue,
-            "libraryBackdropMode": BrowserBackdropMode.off.rawValue
+            "compactBackdropMode": BrowserBackdropMode.defaultMode.rawValue,
+            "libraryBackdropMode": BrowserBackdropMode.defaultMode.rawValue
         ])
     }
     

--- a/Sources/NullPlayer/App/WindowManager.swift
+++ b/Sources/NullPlayer/App/WindowManager.swift
@@ -127,7 +127,7 @@ private enum CompactModeState {
     case exiting
 }
 
-enum CompactBackdropMode: Int, CaseIterable {
+enum BrowserBackdropMode: Int, CaseIterable {
     case off
     case albumArt
     case cava
@@ -348,9 +348,9 @@ class WindowManager {
     private var compactWindowController: CompactModeWindowController?
 
     /// Backdrop used by the modern/metal compact surface. Classic always resolves to Off.
-    var compactBackdropMode: CompactBackdropMode {
+    var compactBackdropMode: BrowserBackdropMode {
         guard isRunningModernUI else { return .off }
-        return CompactBackdropMode(
+        return BrowserBackdropMode(
             rawValue: UserDefaults.standard.integer(forKey: "compactBackdropMode")
         ) ?? .off
     }
@@ -360,10 +360,28 @@ class WindowManager {
         return compactWindowController?.compactBackdropPresenter
     }
 
-    func setCompactBackdropMode(_ mode: CompactBackdropMode) {
+    func setCompactBackdropMode(_ mode: BrowserBackdropMode) {
         guard isRunningModernUI else { return }
         UserDefaults.standard.set(mode.rawValue, forKey: "compactBackdropMode")
         compactWindowController?.refreshCompactBackdrop()
+    }
+
+    var libraryBackdropMode: BrowserBackdropMode {
+        guard isRunningModernUI else { return .off }
+        return BrowserBackdropMode(
+            rawValue: UserDefaults.standard.integer(forKey: "libraryBackdropMode")
+        ) ?? .off
+    }
+
+    var libraryBackdropPresenter: CavaPresenter? {
+        guard isRunningModernUI else { return nil }
+        return plexBrowserWindowController?.libraryBackdropPresenter
+    }
+
+    func setLibraryBackdropMode(_ mode: BrowserBackdropMode) {
+        guard isRunningModernUI else { return }
+        UserDefaults.standard.set(mode.rawValue, forKey: "libraryBackdropMode")
+        plexBrowserWindowController?.refreshLibraryBackdrop()
     }
 
     /// Marks mode-dependent player windows so stale instances can be distinguished from
@@ -703,7 +721,8 @@ class WindowManager {
             "waveformHideTooltip": false,
             "compactModeEnabled": false,
             "compactWindowEnabled": false,
-            "compactBackdropMode": CompactBackdropMode.off.rawValue
+            "compactBackdropMode": BrowserBackdropMode.off.rawValue,
+            "libraryBackdropMode": BrowserBackdropMode.off.rawValue
         ])
     }
     
@@ -1042,6 +1061,7 @@ class WindowManager {
                 }
             }
         }
+        plexBrowserWindowController?.refreshLibraryBackdrop()
         postLayoutChangeNotification()
     }
 
@@ -1134,6 +1154,7 @@ class WindowManager {
         if let controller = plexBrowserWindowController, controller.window?.isVisible == true {
             rememberPlexBrowserFrame()
             controller.window?.orderOut(nil)
+            controller.refreshLibraryBackdrop()
         } else {
             showPlexBrowser()
         }
@@ -2914,6 +2935,7 @@ class WindowManager {
     func refreshCavaWindowAfterReset() {
         cavaWindowController?.refreshAfterReset()
         compactWindowController?.refreshCompactBackdrop()
+        plexBrowserWindowController?.refreshLibraryBackdrop()
     }
     
     /// Get information about loaded presets (bundled count, custom count, custom path)

--- a/Sources/NullPlayer/App/WindowManager.swift
+++ b/Sources/NullPlayer/App/WindowManager.swift
@@ -127,6 +127,20 @@ private enum CompactModeState {
     case exiting
 }
 
+enum CompactBackdropMode: Int, CaseIterable {
+    case off
+    case albumArt
+    case cava
+
+    var title: String {
+        switch self {
+        case .off: return "Off"
+        case .albumArt: return "Album Art"
+        case .cava: return "Cava"
+        }
+    }
+}
+
 private struct WindowSnapshot {
     var wasVisible: Bool
     var frame: NSRect
@@ -332,6 +346,25 @@ class WindowManager {
     private var compactStatusItem: NSStatusItem?
 
     private var compactWindowController: CompactModeWindowController?
+
+    /// Backdrop used by the modern/metal compact surface. Classic always resolves to Off.
+    var compactBackdropMode: CompactBackdropMode {
+        guard isRunningModernUI else { return .off }
+        return CompactBackdropMode(
+            rawValue: UserDefaults.standard.integer(forKey: "compactBackdropMode")
+        ) ?? .off
+    }
+
+    var compactBackdropPresenter: CavaPresenter? {
+        guard isRunningModernUI else { return nil }
+        return compactWindowController?.compactBackdropPresenter
+    }
+
+    func setCompactBackdropMode(_ mode: CompactBackdropMode) {
+        guard isRunningModernUI else { return }
+        UserDefaults.standard.set(mode.rawValue, forKey: "compactBackdropMode")
+        compactWindowController?.refreshCompactBackdrop()
+    }
 
     /// Marks mode-dependent player windows so stale instances can be distinguished from
     /// legitimate standalone dialogs when sweeping NSApp.windows.
@@ -669,7 +702,8 @@ class WindowManager {
             "waveformShowCuePoints": false,
             "waveformHideTooltip": false,
             "compactModeEnabled": false,
-            "compactWindowEnabled": false
+            "compactWindowEnabled": false,
+            "compactBackdropMode": CompactBackdropMode.off.rawValue
         ])
     }
     
@@ -2879,6 +2913,7 @@ class WindowManager {
     /// skin-default colors after "Reset All Visualization Preferences" cleared its keys.
     func refreshCavaWindowAfterReset() {
         cavaWindowController?.refreshAfterReset()
+        compactWindowController?.refreshCompactBackdrop()
     }
     
     /// Get information about loaded presets (bundled count, custom count, custom path)

--- a/Sources/NullPlayer/Cava/CavaDrawing.swift
+++ b/Sources/NullPlayer/Cava/CavaDrawing.swift
@@ -3,6 +3,11 @@ import AppKit
 /// Mode-neutral Cava spectrum analyzer CoreGraphics rendering.
 /// Draws gradient bars (mono as single row, stereo as mirrored L vs R).
 enum CavaDrawing {
+    enum MonoLayout {
+        case frequencySweep
+        case mirrored
+    }
+
     /// Draw cava bars in a given rect.
     ///
     /// - Parameters:
@@ -16,13 +21,20 @@ enum CavaDrawing {
         barArrays: [[Float]],
         lowColor: NSColor,
         highColor: NSColor,
-        mode: CavaSettings.Mode
+        mode: CavaSettings.Mode,
+        monoLayout: MonoLayout = .frequencySweep
     ) {
         guard !rect.isEmpty, !barArrays.isEmpty else { return }
 
         switch mode {
         case .mono:
-            drawMonoMode(in: rect, bars: barArrays[0], lowColor: lowColor, highColor: highColor)
+            drawMonoMode(
+                in: rect,
+                bars: barArrays[0],
+                lowColor: lowColor,
+                highColor: highColor,
+                layout: monoLayout
+            )
         case .stereo:
             drawStereoMode(in: rect, barArrays: barArrays, lowColor: lowColor, highColor: highColor)
         }
@@ -32,25 +44,66 @@ enum CavaDrawing {
         in rect: CGRect,
         bars: [Float],
         lowColor: NSColor,
-        highColor: NSColor
+        highColor: NSColor,
+        layout: MonoLayout
     ) {
         guard !bars.isEmpty else { return }
 
-        let barCount = bars.count
-        let barWidth = rect.width / CGFloat(barCount)
+        for (barRect, value) in monoBarRects(in: rect, bars: bars, layout: layout) {
+            drawGradientBar(in: barRect, intensity: CGFloat(value), lowColor: lowColor, highColor: highColor)
+        }
+    }
+
+    /// Backdrop mono uses a center-out mirrored spectrum so one channel cannot occupy only one
+    /// side of a wide surface. Standalone and inline Cava retain the left-to-right sweep.
+    static func monoBarRects(
+        in rect: CGRect,
+        bars: [Float],
+        layout: MonoLayout
+    ) -> [(rect: CGRect, value: Float)] {
+        guard !rect.isEmpty, !bars.isEmpty else { return [] }
         let barHeight = rect.height
 
-        for (i, value) in bars.enumerated() {
-            let height = barHeight * CGFloat(value)
-            // Views are non-flipped (origin bottom-left), so bars grow up from the bottom edge.
-            let barRect = CGRect(
-                x: rect.minX + CGFloat(i) * barWidth,
-                y: rect.minY,
-                width: barWidth,
-                height: height
-            )
-
-            drawGradientBar(in: barRect, intensity: CGFloat(value), lowColor: lowColor, highColor: highColor)
+        switch layout {
+        case .frequencySweep:
+            let barWidth = rect.width / CGFloat(bars.count)
+            return bars.enumerated().map { index, value in
+                (
+                    CGRect(
+                        x: rect.minX + CGFloat(index) * barWidth,
+                        y: rect.minY,
+                        width: barWidth,
+                        height: barHeight * CGFloat(value)
+                    ),
+                    value
+                )
+            }
+        case .mirrored:
+            let barWidth = (rect.width / 2) / CGFloat(bars.count)
+            return bars.enumerated().flatMap { index, value in
+                let height = barHeight * CGFloat(value)
+                let offset = CGFloat(index) * barWidth
+                return [
+                    (
+                        CGRect(
+                            x: rect.midX - offset - barWidth,
+                            y: rect.minY,
+                            width: barWidth,
+                            height: height
+                        ),
+                        value
+                    ),
+                    (
+                        CGRect(
+                            x: rect.midX + offset,
+                            y: rect.minY,
+                            width: barWidth,
+                            height: height
+                        ),
+                        value
+                    ),
+                ]
+            }
         }
     }
 

--- a/Sources/NullPlayer/Cava/CavaPresenter.swift
+++ b/Sources/NullPlayer/Cava/CavaPresenter.swift
@@ -119,7 +119,7 @@ final class CavaPresenter: NSObject {
     // MARK: Menu building
 
     /// Build the right-click menu. `showTransparency` gates the modern-only transparency toggle.
-    func buildMenu(showTransparency: Bool) -> NSMenu {
+    func buildMenu(showTransparency: Bool, includeClose: Bool = true) -> NSMenu {
         let menu = NSMenu()
 
         addCheckItem(to: menu, title: "Mono", action: #selector(modeAction(_:)),
@@ -151,11 +151,13 @@ final class CavaPresenter: NSObject {
         resetItem.target = self
         menu.addItem(resetItem)
 
-        menu.addItem(.separator())
+        if includeClose {
+            menu.addItem(.separator())
 
-        let closeItem = NSMenuItem(title: "Close", action: #selector(closeAction(_:)), keyEquivalent: "")
-        closeItem.target = self
-        menu.addItem(closeItem)
+            let closeItem = NSMenuItem(title: "Close", action: #selector(closeAction(_:)), keyEquivalent: "")
+            closeItem.target = self
+            menu.addItem(closeItem)
+        }
 
         return menu
     }

--- a/Sources/NullPlayer/Cava/CavaSettings.swift
+++ b/Sources/NullPlayer/Cava/CavaSettings.swift
@@ -74,6 +74,7 @@ enum CavaSettings {
     // Factory defaults for the exposed tuning knobs (the "Reset to Defaults" target).
     static let defaultBarCount = 32
     static let defaultNoiseReduction = 0.65   // smoothing / latency; lower = snappier
+    static let defaultCompactNoiseReduction = 0.80
     static let defaultBassTilt = 0.3          // band bin-count exponent; higher = more bass
 
     /// Canonical menu presets shared by the standalone and embedded Cava controls.
@@ -103,12 +104,13 @@ enum CavaSettings {
     // MARK: - Mode (Mono/Stereo)
 
     static func mode(for scope: Scope) -> Mode {
-        // Stereo is unreadable in the 16px-tall embedded visualization area.
+        // The tiny main-window strip is always mono. Compact starts mono but remains configurable.
         guard scope != .mainWindow else { return .mono }
+        let defaultMode: Mode = scope == .compactWindow ? .mono : .stereo
         let preferenceKey = key(.mode, for: scope)
-        guard defaults.object(forKey: preferenceKey) != nil else { return .stereo }
+        guard defaults.object(forKey: preferenceKey) != nil else { return defaultMode }
         let raw = defaults.integer(forKey: preferenceKey)
-        return Mode(rawValue: raw) ?? .stereo
+        return Mode(rawValue: raw) ?? defaultMode
     }
 
     static func setMode(_ mode: Mode, for scope: Scope) {
@@ -141,7 +143,10 @@ enum CavaSettings {
     /// Temporal smoothing (0…0.95). Higher = smoother but laggier; lower = snappier/more real-time.
     static func noiseReduction(for scope: Scope) -> Double {
         let preferenceKey = key(.noiseReduction, for: scope)
-        guard defaults.object(forKey: preferenceKey) != nil else { return defaultNoiseReduction }
+        let defaultValue = scope == .compactWindow
+            ? defaultCompactNoiseReduction
+            : defaultNoiseReduction
+        guard defaults.object(forKey: preferenceKey) != nil else { return defaultValue }
         return min(0.95, max(0.0, defaults.double(forKey: preferenceKey)))
     }
 

--- a/Sources/NullPlayer/Cava/CavaSettings.swift
+++ b/Sources/NullPlayer/Cava/CavaSettings.swift
@@ -77,6 +77,7 @@ enum CavaSettings {
 
     // Factory defaults for the exposed tuning knobs (the "Reset to Defaults" target).
     static let defaultBarCount = 32
+    static let defaultBrowserBarCount = 64
     static let defaultNoiseReduction = 0.65   // smoothing / latency; lower = snappier
     static let defaultCompactNoiseReduction = 0.80
     static let defaultBassTilt = 0.3          // band bin-count exponent; higher = more bass
@@ -130,7 +131,13 @@ enum CavaSettings {
 
     static func barCount(for scope: Scope) -> Int {
         let count = defaults.integer(forKey: key(.barCount, for: scope))
-        return count > 0 ? count : defaultBarCount
+        guard count <= 0 else { return count }
+        switch scope {
+        case .libraryWindow, .compactWindow:
+            return defaultBrowserBarCount
+        case .cavaWindow, .mainWindow:
+            return defaultBarCount
+        }
     }
 
     static func setBarCount(_ count: Int, for scope: Scope) {

--- a/Sources/NullPlayer/Cava/CavaSettings.swift
+++ b/Sources/NullPlayer/Cava/CavaSettings.swift
@@ -10,12 +10,14 @@ enum CavaSettings {
         case cavaWindow
         case mainWindow
         case compactWindow
+        case libraryWindow
 
         var identifier: String {
             switch self {
             case .cavaWindow: return "window"
             case .mainWindow: return "mainWindow"
             case .compactWindow: return "compactWindow"
+            case .libraryWindow: return "libraryWindow"
             }
         }
     }
@@ -57,6 +59,8 @@ enum CavaSettings {
             return "cava.mainWindow.\(setting.rawValue)"
         case .compactWindow:
             return "cava.compactWindow.\(setting.rawValue)"
+        case .libraryWindow:
+            return "cava.libraryWindow.\(setting.rawValue)"
         }
     }
 
@@ -80,7 +84,7 @@ enum CavaSettings {
     /// Canonical menu presets shared by the standalone and embedded Cava controls.
     static func barCountPresets(for scope: Scope) -> [Int] {
         switch scope {
-        case .cavaWindow, .compactWindow:
+        case .cavaWindow, .compactWindow, .libraryWindow:
             return [16, 24, 32, 48, 64]
         case .mainWindow:
             return [12, 19, 24, 32]
@@ -104,9 +108,9 @@ enum CavaSettings {
     // MARK: - Mode (Mono/Stereo)
 
     static func mode(for scope: Scope) -> Mode {
-        // The tiny main-window strip is always mono. Compact starts mono but remains configurable.
+        // The tiny main-window strip is always mono. Other scopes remain configurable.
         guard scope != .mainWindow else { return .mono }
-        let defaultMode: Mode = scope == .compactWindow ? .mono : .stereo
+        let defaultMode: Mode = scope == .libraryWindow ? .mono : .stereo
         let preferenceKey = key(.mode, for: scope)
         guard defaults.object(forKey: preferenceKey) != nil else { return defaultMode }
         let raw = defaults.integer(forKey: preferenceKey)
@@ -360,6 +364,7 @@ enum CavaSettings {
         setHasCustomColors(false, for: .cavaWindow)
         setHasCustomColors(false, for: .mainWindow)
         setHasCustomColors(false, for: .compactWindow)
+        setHasCustomColors(false, for: .libraryWindow)
         setTransparentBackground(defaultTransparency, customized: false)
     }
 

--- a/Sources/NullPlayer/Cava/CavaSettings.swift
+++ b/Sources/NullPlayer/Cava/CavaSettings.swift
@@ -9,11 +9,13 @@ enum CavaSettings {
     enum Scope: CaseIterable {
         case cavaWindow
         case mainWindow
+        case compactWindow
 
         var identifier: String {
             switch self {
             case .cavaWindow: return "window"
             case .mainWindow: return "mainWindow"
+            case .compactWindow: return "compactWindow"
             }
         }
     }
@@ -53,13 +55,15 @@ enum CavaSettings {
             }
         case .mainWindow:
             return "cava.mainWindow.\(setting.rawValue)"
+        case .compactWindow:
+            return "cava.compactWindow.\(setting.rawValue)"
         }
     }
 
     /// Durable keys owned by a scope. Used by the centralized visualization reset path.
     static func preferenceKeys(for scope: Scope) -> [String] {
         SettingKey.allCases.compactMap { setting in
-            if scope == .mainWindow
+            if scope != .cavaWindow
                 && (setting == .transparentBackground || setting == .transparencyCustomized) {
                 return nil
             }
@@ -75,7 +79,7 @@ enum CavaSettings {
     /// Canonical menu presets shared by the standalone and embedded Cava controls.
     static func barCountPresets(for scope: Scope) -> [Int] {
         switch scope {
-        case .cavaWindow:
+        case .cavaWindow, .compactWindow:
             return [16, 24, 32, 48, 64]
         case .mainWindow:
             return [12, 19, 24, 32]
@@ -350,6 +354,7 @@ enum CavaSettings {
     static func resetAppearanceForSkinChange(transparentBackground defaultTransparency: Bool = false) {
         setHasCustomColors(false, for: .cavaWindow)
         setHasCustomColors(false, for: .mainWindow)
+        setHasCustomColors(false, for: .compactWindow)
         setTransparentBackground(defaultTransparency, customized: false)
     }
 

--- a/Sources/NullPlayer/Visualization/VisualizationPreferences.swift
+++ b/Sources/NullPlayer/Visualization/VisualizationPreferences.swift
@@ -41,7 +41,8 @@ enum VisualizationPreferences {
             return browserArtworkKeys
         case .all:
             return Array(Set(mainWindowKeys + spectrumWindowKeys + visualizationWindowKeys
-                + browserArtworkKeys + cavaWindowKeys + compactWindowCavaKeys))
+                + browserArtworkKeys + cavaWindowKeys + compactWindowCavaKeys
+                + libraryWindowCavaKeys))
         }
     }
 
@@ -51,6 +52,7 @@ enum VisualizationPreferences {
     /// clearing these restores mode-correct defaults.
     private static let cavaWindowKeys = CavaSettings.preferenceKeys(for: .cavaWindow)
     private static let compactWindowCavaKeys = CavaSettings.preferenceKeys(for: .compactWindow)
+    private static let libraryWindowCavaKeys = CavaSettings.preferenceKeys(for: .libraryWindow)
 
     private static let legacyVisClassicKeys = [
         "visClassicLastProfileName",

--- a/Sources/NullPlayer/Visualization/VisualizationPreferences.swift
+++ b/Sources/NullPlayer/Visualization/VisualizationPreferences.swift
@@ -40,7 +40,8 @@ enum VisualizationPreferences {
         case .browserArtwork:
             return browserArtworkKeys
         case .all:
-            return Array(Set(mainWindowKeys + spectrumWindowKeys + visualizationWindowKeys + browserArtworkKeys + cavaWindowKeys))
+            return Array(Set(mainWindowKeys + spectrumWindowKeys + visualizationWindowKeys
+                + browserArtworkKeys + cavaWindowKeys + compactWindowCavaKeys))
         }
     }
 
@@ -49,6 +50,7 @@ enum VisualizationPreferences {
     /// colors fall back to the active skin's gradient (pushed per-UI by the Cava view), so
     /// clearing these restores mode-correct defaults.
     private static let cavaWindowKeys = CavaSettings.preferenceKeys(for: .cavaWindow)
+    private static let compactWindowCavaKeys = CavaSettings.preferenceKeys(for: .compactWindow)
 
     private static let legacyVisClassicKeys = [
         "visClassicLastProfileName",
@@ -262,8 +264,8 @@ enum VisualizationPreferences {
             WindowManager.shared.resetVisualizationWindowPreferences()
         }
         if scope == .all {
-            // The standalone Cava window keys are only cleared as part of `.all`; force the
-            // open window (if any) to re-read tuning and re-derive its skin-default gradient.
+            // The standalone and compact-window Cava keys are only cleared as part of `.all`;
+            // force open views to re-read tuning and re-derive their skin-default gradients.
             WindowManager.shared.refreshCavaWindowAfterReset()
         }
     }

--- a/Sources/NullPlayer/Windows/CompactMode/CompactModeWindowController.swift
+++ b/Sources/NullPlayer/Windows/CompactMode/CompactModeWindowController.swift
@@ -8,8 +8,15 @@ private protocol CompactModeBrowserSurface: AnyObject {
     func updateCompactBarTime(current: TimeInterval, duration: TimeInterval)
     func updateCompactBarTrack(_ track: Track?)
     func updateCompactBarPlaybackState()
+    var compactBackdropPresenter: CavaPresenter? { get }
+    func refreshCompactBackdrop()
     func skinDidChange()
     func prepareForUITeardown()
+}
+
+private extension CompactModeBrowserSurface {
+    var compactBackdropPresenter: CavaPresenter? { nil }
+    func refreshCompactBackdrop() {}
 }
 
 extension PlexBrowserWindowController: CompactModeBrowserSurface {}
@@ -156,6 +163,14 @@ final class CompactModeWindowController: NSWindowController {
         window?.displayIfNeeded()
     }
 
+    var compactBackdropPresenter: CavaPresenter? {
+        browserController.compactBackdropPresenter
+    }
+
+    func refreshCompactBackdrop() {
+        browserController.refreshCompactBackdrop()
+    }
+
     /// Order the compact window front on the *current* Space while still invisible (alpha 0),
     /// without revealing or repositioning it. Called at Compact-Mode entry **before** the regular
     /// windows are hidden and the app drops to `.accessory`, so NullPlayer always has a window on
@@ -192,6 +207,7 @@ final class CompactModeWindowController: NSWindowController {
             window.makeKey()
             window.hasShadow = true
             window.alphaValue = 1
+            browserController.refreshCompactBackdrop()
             return
         }
 
@@ -265,6 +281,7 @@ final class CompactModeWindowController: NSWindowController {
         window.hasShadow = true
         window.orderFront(nil)
         window.makeKey()
+        browserController.refreshCompactBackdrop()
     }
 
     /// Start observing the status-item window's move and resize notifications to detect
@@ -328,6 +345,7 @@ final class CompactModeWindowController: NSWindowController {
         window.hasShadow = true
         window.alphaValue = 1
         window.makeKey()
+        browserController.refreshCompactBackdrop()
     }
 
     /// Start observing display-configuration changes (added/removed screens, resolution changes).
@@ -424,6 +442,7 @@ final class CompactModeWindowController: NSWindowController {
         anchorButton = nil
         window?.alphaValue = 0
         window?.orderOut(nil)
+        browserController.refreshCompactBackdrop()
     }
 
     private func persistFloatingFrameIfNeeded() {

--- a/Sources/NullPlayer/Windows/ModernLibraryBrowser/CompactBackdropView.swift
+++ b/Sources/NullPlayer/Windows/ModernLibraryBrowser/CompactBackdropView.swift
@@ -1,13 +1,15 @@
 import AppKit
 
-/// Independently rendered backdrop beneath the modern compact browser surface.
+/// Independently rendered backdrop beneath a modern Library or Compact browser surface.
 final class CompactBackdropView: NSView {
     private var artwork: NSImage?
     private var presenterStorage: CavaPresenter?
+    let scope: CavaSettings.Scope
+    private let modeProvider: () -> BrowserBackdropMode
 
     var presenter: CavaPresenter {
         if let presenterStorage { return presenterStorage }
-        let presenter = CavaPresenter(scope: .compactWindow)
+        let presenter = CavaPresenter(scope: scope)
         presenter.onNeedsDisplay = { [weak self] in
             self?.needsDisplay = true
         }
@@ -15,7 +17,13 @@ final class CompactBackdropView: NSView {
         return presenter
     }
 
-    override init(frame frameRect: NSRect) {
+    init(
+        frame frameRect: NSRect,
+        scope: CavaSettings.Scope,
+        modeProvider: @escaping () -> BrowserBackdropMode
+    ) {
+        self.scope = scope
+        self.modeProvider = modeProvider
         super.init(frame: frameRect)
         wantsLayer = true
         layer?.backgroundColor = NSColor.clear.cgColor
@@ -23,6 +31,8 @@ final class CompactBackdropView: NSView {
     }
 
     required init?(coder: NSCoder) {
+        scope = .compactWindow
+        modeProvider = { WindowManager.shared.compactBackdropMode }
         super.init(coder: coder)
         wantsLayer = true
         layer?.backgroundColor = NSColor.clear.cgColor
@@ -37,13 +47,13 @@ final class CompactBackdropView: NSView {
 
     func updateArtwork(_ artwork: NSImage?) {
         self.artwork = artwork
-        if WindowManager.shared.compactBackdropMode == .albumArt {
+        if modeProvider() == .albumArt {
             needsDisplay = true
         }
     }
 
     func reload() {
-        let mode = WindowManager.shared.compactBackdropMode
+        let mode = modeProvider()
         isHidden = mode == .off
 
         let skin = ModernSkinEngine.shared.currentSkin ?? ModernSkinLoader.shared.loadDefault()
@@ -52,7 +62,7 @@ final class CompactBackdropView: NSView {
         CavaSettings.setSkinDefaultColors(
             low: skin.primaryColor,
             high: skin.accentColor,
-            scope: .compactWindow
+            scope: scope
         )
 
         if mode == .cava, shouldAnimate {
@@ -82,7 +92,7 @@ final class CompactBackdropView: NSView {
         skin.backgroundColor.setFill()
         bounds.fill()
 
-        switch WindowManager.shared.compactBackdropMode {
+        switch modeProvider() {
         case .off:
             return
         case .albumArt:
@@ -104,7 +114,8 @@ final class CompactBackdropView: NSView {
                 barArrays: presenter.barArrays,
                 lowColor: presenter.lowGradientColor,
                 highColor: presenter.highGradientColor,
-                mode: presenter.mode
+                mode: presenter.mode,
+                monoLayout: .mirrored
             )
         }
     }

--- a/Sources/NullPlayer/Windows/ModernLibraryBrowser/CompactBackdropView.swift
+++ b/Sources/NullPlayer/Windows/ModernLibraryBrowser/CompactBackdropView.swift
@@ -2,7 +2,6 @@ import AppKit
 
 /// Independently rendered backdrop beneath a modern Library or Compact browser surface.
 final class CompactBackdropView: NSView {
-    private var artwork: NSImage?
     private var presenterStorage: CavaPresenter?
     let scope: CavaSettings.Scope
     private let modeProvider: () -> BrowserBackdropMode
@@ -45,16 +44,9 @@ final class CompactBackdropView: NSView {
 
     override func hitTest(_ point: NSPoint) -> NSView? { nil }
 
-    func updateArtwork(_ artwork: NSImage?) {
-        self.artwork = artwork
-        if modeProvider() == .albumArt {
-            needsDisplay = true
-        }
-    }
-
     func reload() {
         let mode = modeProvider()
-        isHidden = mode == .off
+        isHidden = !mode.showsCava
 
         let skin = ModernSkinEngine.shared.currentSkin ?? ModernSkinLoader.shared.loadDefault()
         layer?.cornerRadius = skin.config.window.cornerRadius ?? 0
@@ -65,7 +57,7 @@ final class CompactBackdropView: NSView {
             scope: scope
         )
 
-        if mode == .cava, shouldAnimate {
+        if mode.showsCava, shouldAnimate {
             presenter.start()
             presenter.settingsDidChange()
         } else {
@@ -87,28 +79,14 @@ final class CompactBackdropView: NSView {
     }
 
     override func draw(_ dirtyRect: NSRect) {
-        guard let context = NSGraphicsContext.current?.cgContext else { return }
         let skin = ModernSkinEngine.shared.currentSkin ?? ModernSkinLoader.shared.loadDefault()
         skin.backgroundColor.setFill()
         bounds.fill()
 
         switch modeProvider() {
-        case .off:
+        case .off, .art:
             return
-        case .albumArt:
-            guard let artwork,
-                  let image = artwork.cgImage(forProposedRect: nil, context: nil, hints: nil) else {
-                return
-            }
-            context.saveGState()
-            context.clip(to: bounds)
-            context.interpolationQuality = .high
-            context.draw(image, in: Self.aspectFillRect(
-                imageSize: NSSize(width: image.width, height: image.height),
-                targetRect: bounds
-            ))
-            context.restoreGState()
-        case .cava:
+        case .cava, .cavaAndArt:
             CavaDrawing.draw(
                 in: bounds,
                 barArrays: presenter.barArrays,
@@ -118,18 +96,5 @@ final class CompactBackdropView: NSView {
                 monoLayout: .mirrored
             )
         }
-    }
-
-    static func aspectFillRect(imageSize: NSSize, targetRect: NSRect) -> NSRect {
-        guard imageSize.width > 0, imageSize.height > 0,
-              targetRect.width > 0, targetRect.height > 0 else { return targetRect }
-        let scale = max(targetRect.width / imageSize.width, targetRect.height / imageSize.height)
-        let size = NSSize(width: imageSize.width * scale, height: imageSize.height * scale)
-        return NSRect(
-            x: targetRect.midX - size.width / 2,
-            y: targetRect.midY - size.height / 2,
-            width: size.width,
-            height: size.height
-        )
     }
 }

--- a/Sources/NullPlayer/Windows/ModernLibraryBrowser/CompactBackdropView.swift
+++ b/Sources/NullPlayer/Windows/ModernLibraryBrowser/CompactBackdropView.swift
@@ -1,0 +1,124 @@
+import AppKit
+
+/// Independently rendered backdrop beneath the modern compact browser surface.
+final class CompactBackdropView: NSView {
+    private var artwork: NSImage?
+    private var presenterStorage: CavaPresenter?
+
+    var presenter: CavaPresenter {
+        if let presenterStorage { return presenterStorage }
+        let presenter = CavaPresenter(scope: .compactWindow)
+        presenter.onNeedsDisplay = { [weak self] in
+            self?.needsDisplay = true
+        }
+        presenterStorage = presenter
+        return presenter
+    }
+
+    override init(frame frameRect: NSRect) {
+        super.init(frame: frameRect)
+        wantsLayer = true
+        layer?.backgroundColor = NSColor.clear.cgColor
+        autoresizingMask = [.width, .height]
+    }
+
+    required init?(coder: NSCoder) {
+        super.init(coder: coder)
+        wantsLayer = true
+        layer?.backgroundColor = NSColor.clear.cgColor
+        autoresizingMask = [.width, .height]
+    }
+
+    deinit {
+        presenterStorage?.stop()
+    }
+
+    override func hitTest(_ point: NSPoint) -> NSView? { nil }
+
+    func updateArtwork(_ artwork: NSImage?) {
+        self.artwork = artwork
+        if WindowManager.shared.compactBackdropMode == .albumArt {
+            needsDisplay = true
+        }
+    }
+
+    func reload() {
+        let mode = WindowManager.shared.compactBackdropMode
+        isHidden = mode == .off
+
+        let skin = ModernSkinEngine.shared.currentSkin ?? ModernSkinLoader.shared.loadDefault()
+        layer?.cornerRadius = skin.config.window.cornerRadius ?? 0
+        layer?.masksToBounds = (skin.config.window.cornerRadius ?? 0) > 0
+        CavaSettings.setSkinDefaultColors(
+            low: skin.primaryColor,
+            high: skin.accentColor,
+            scope: .compactWindow
+        )
+
+        if mode == .cava, shouldAnimate {
+            presenter.start()
+            presenter.settingsDidChange()
+        } else {
+            presenterStorage?.stop()
+        }
+        needsDisplay = true
+    }
+
+    func stop() {
+        presenterStorage?.stop()
+    }
+
+    private var shouldAnimate: Bool {
+        guard let window else { return false }
+        return window.isVisible
+            && window.alphaValue > 0
+            && !window.isMiniaturized
+            && window.occlusionState.contains(.visible)
+    }
+
+    override func draw(_ dirtyRect: NSRect) {
+        guard let context = NSGraphicsContext.current?.cgContext else { return }
+        let skin = ModernSkinEngine.shared.currentSkin ?? ModernSkinLoader.shared.loadDefault()
+        skin.backgroundColor.setFill()
+        bounds.fill()
+
+        switch WindowManager.shared.compactBackdropMode {
+        case .off:
+            return
+        case .albumArt:
+            guard let artwork,
+                  let image = artwork.cgImage(forProposedRect: nil, context: nil, hints: nil) else {
+                return
+            }
+            context.saveGState()
+            context.clip(to: bounds)
+            context.interpolationQuality = .high
+            context.draw(image, in: Self.aspectFillRect(
+                imageSize: NSSize(width: image.width, height: image.height),
+                targetRect: bounds
+            ))
+            context.restoreGState()
+        case .cava:
+            CavaDrawing.draw(
+                in: bounds,
+                barArrays: presenter.barArrays,
+                lowColor: presenter.lowGradientColor,
+                highColor: presenter.highGradientColor,
+                mode: presenter.mode
+            )
+        }
+    }
+
+    static func aspectFillRect(imageSize: NSSize, targetRect: NSRect) -> NSRect {
+        guard imageSize.width > 0, imageSize.height > 0,
+              targetRect.width > 0, targetRect.height > 0 else { return targetRect }
+        let scale = max(targetRect.width / imageSize.width, targetRect.height / imageSize.height)
+        let size = NSSize(width: imageSize.width * scale, height: imageSize.height * scale)
+        return NSRect(
+            x: targetRect.midX - size.width / 2,
+            y: targetRect.midY - size.height / 2,
+            width: size.width,
+            height: size.height
+        )
+    }
+}

--- a/Sources/NullPlayer/Windows/ModernLibraryBrowser/ModernLibraryBrowserView.swift
+++ b/Sources/NullPlayer/Windows/ModernLibraryBrowser/ModernLibraryBrowserView.swift
@@ -1056,16 +1056,39 @@ class ModernLibraryBrowserView: NSView {
         backdropView.frame = container.bounds
     }
 
+    /// Switching from an opaque browser to a translucent backdrop composition can leave portions
+    /// of AppKit's layer cache untouched on the first selection. Repaint the complete sibling
+    /// hierarchy now and once more after menu tracking/layout has returned to the main run loop.
+    private func redrawBackdropComposition(in container: NSView?) {
+        guard let container else {
+            needsDisplay = true
+            return
+        }
+
+        container.markSubtreeForDisplayAndLayout()
+        container.layoutSubtreeIfNeeded()
+        container.window?.displayIfNeeded()
+
+        DispatchQueue.main.async { [weak self, weak container] in
+            guard let self, let container, self.superview === container else { return }
+            self.updateBackdropFrame()
+            container.markSubtreeForDisplayAndLayout()
+            container.layoutSubtreeIfNeeded()
+            container.window?.displayIfNeeded()
+        }
+    }
+
     func refreshBackdrop() {
+        let container = superview
         guard !isPreparingForUITeardown,
               WindowManager.shared.isRunningModernUI,
               effectiveBackdropMode != .off,
-              let container = superview else {
+              let container else {
             backdropView?.stop()
             backdropView?.removeFromSuperview()
             backdropView = nil
             updateHistoryHostingBackground()
-            needsDisplay = true
+            redrawBackdropComposition(in: container)
             return
         }
 
@@ -1093,7 +1116,7 @@ class ModernLibraryBrowserView: NSView {
            artworkTrackId != track.id || currentTrackArtwork == nil {
             loadArtwork(for: track)
         }
-        needsDisplay = true
+        redrawBackdropComposition(in: container)
     }
 
     func stopBackdrop() {

--- a/Sources/NullPlayer/Windows/ModernLibraryBrowser/ModernLibraryBrowserView.swift
+++ b/Sources/NullPlayer/Windows/ModernLibraryBrowser/ModernLibraryBrowserView.swift
@@ -859,7 +859,7 @@ class ModernLibraryBrowserView: NSView {
         startServerNameScroll()
         
         // Load artwork for current track
-        if WindowManager.shared.showBrowserArtworkBackground {
+        if showsLegacyArtwork {
             loadArtwork(for: WindowManager.shared.audioEngine.currentTrack)
         }
         
@@ -951,7 +951,11 @@ class ModernLibraryBrowserView: NSView {
     private let backdropScrimAlpha: CGFloat = 0.72
 
     private var backdropActive: Bool {
-        WindowManager.shared.isRunningModernUI && effectiveBackdropMode != .off
+        WindowManager.shared.isRunningModernUI && effectiveBackdropMode.showsCava
+    }
+
+    private var showsLegacyArtwork: Bool {
+        WindowManager.shared.isRunningModernUI && effectiveBackdropMode.showsArt
     }
 
     private var effectiveBackdropMode: BrowserBackdropMode {
@@ -1082,12 +1086,17 @@ class ModernLibraryBrowserView: NSView {
         let container = superview
         guard !isPreparingForUITeardown,
               WindowManager.shared.isRunningModernUI,
-              effectiveBackdropMode != .off,
+              effectiveBackdropMode.showsCava,
               let container else {
             backdropView?.stop()
             backdropView?.removeFromSuperview()
             backdropView = nil
             updateHistoryHostingBackground()
+            if showsLegacyArtwork,
+               let track = WindowManager.shared.audioEngine.currentTrack,
+               artworkTrackId != track.id || currentTrackArtwork == nil {
+                loadArtwork(for: track)
+            }
             redrawBackdropComposition(in: container)
             return
         }
@@ -1107,11 +1116,10 @@ class ModernLibraryBrowserView: NSView {
             backdropView = backdrop
         }
         backdrop.frame = container.bounds
-        backdrop.updateArtwork(currentTrackArtwork)
         backdrop.reload()
         updateHistoryHostingBackground()
 
-        if effectiveBackdropMode == .albumArt,
+        if showsLegacyArtwork,
            let track = WindowManager.shared.audioEngine.currentTrack,
            artworkTrackId != track.id || currentTrackArtwork == nil {
             loadArtwork(for: track)
@@ -2392,7 +2400,7 @@ class ModernLibraryBrowserView: NSView {
     }
 
     private func drawArtworkBackground(in context: CGContext, listRect: NSRect, artwork: NSImage?) {
-        guard WindowManager.shared.showBrowserArtworkBackground,
+        guard showsLegacyArtwork,
               let artworkImage = artwork,
               let cgImage = artworkImage.cgImage(forProposedRect: nil, context: nil, hints: nil) else { return }
 
@@ -7653,14 +7661,12 @@ class ModernLibraryBrowserView: NSView {
             loadAllArtworkForCurrentTrack()
             return
         }
-        let needsCurrentTrackArtwork = WindowManager.shared.showBrowserArtworkBackground
-            || (backdropActive && effectiveBackdropMode == .albumArt)
+        let needsCurrentTrackArtwork = showsLegacyArtwork
         guard needsCurrentTrackArtwork else {
             if currentArtwork != nil || currentTrackArtwork != nil {
                 currentArtwork = nil
                 currentTrackArtwork = nil
                 artworkTrackId = nil
-                backdropView?.updateArtwork(nil)
                 needsDisplay = true
             }
             return
@@ -8567,12 +8573,10 @@ class ModernLibraryBrowserView: NSView {
             currentArtwork = nil
             currentTrackArtwork = nil
             artworkTrackId = nil
-            backdropView?.updateArtwork(nil)
             needsDisplay = true
             return
         }
         guard track.id != artworkTrackId || currentTrackArtwork == nil else {
-            backdropView?.updateArtwork(currentTrackArtwork)
             return
         }
         currentTrackArtworkLoadTask = Task { [weak self] in
@@ -8599,7 +8603,6 @@ class ModernLibraryBrowserView: NSView {
                 self.currentArtwork = image
                 self.currentTrackArtwork = image
                 self.artworkTrackId = track.id
-                self.backdropView?.updateArtwork(image)
                 self.needsDisplay = true
             }
         }
@@ -8774,7 +8777,6 @@ class ModernLibraryBrowserView: NSView {
                 self.currentArtwork = images.first
                 self.currentTrackArtwork = images.first
                 self.artworkTrackId = currentTrack.id
-                self.backdropView?.updateArtwork(images.first)
                 self.needsDisplay = true
             }
         }
@@ -8792,7 +8794,6 @@ class ModernLibraryBrowserView: NSView {
         currentArtwork = nil
         currentTrackArtwork = nil
         artworkTrackId = nil
-        backdropView?.updateArtwork(nil)
         isArtOnlyMode = false
         needsDisplay = true
     }
@@ -8802,12 +8803,11 @@ class ModernLibraryBrowserView: NSView {
         artworkIndex = (artworkIndex + 1) % artworkImages.count
         currentArtwork = artworkImages[artworkIndex]
         currentTrackArtwork = currentArtwork
-        backdropView?.updateArtwork(currentArtwork)
         needsDisplay = true
     }
     
     private func loadArtworkForSelection() {
-        guard WindowManager.shared.showBrowserArtworkBackground else { return }
+        guard showsLegacyArtwork else { return }
         guard let index = selectedIndices.first, index < displayItems.count else { return }
         
         let item = displayItems[index]

--- a/Sources/NullPlayer/Windows/ModernLibraryBrowser/ModernLibraryBrowserView.swift
+++ b/Sources/NullPlayer/Windows/ModernLibraryBrowser/ModernLibraryBrowserView.swift
@@ -194,11 +194,17 @@ class ModernLibraryBrowserView: NSView {
     var compactMode: Bool = false {
         didSet {
             guard compactMode != oldValue else { return }
+            refreshCompactBackdrop()
             needsLayout = true
             needsDisplay = true
         }
     }
     private var compactPlayerBar: CompactPlayerBarView?
+    private var backdropView: CompactBackdropView?
+
+    var compactBackdropPresenter: CavaPresenter? {
+        backdropView?.presenter
+    }
 
     /// Height of the embedded compact player bar (0 when not in compact mode).
     private var compactPlayerBarHeight: CGFloat {
@@ -569,12 +575,16 @@ class ModernLibraryBrowserView: NSView {
     
     // Artwork
     private var currentArtwork: NSImage?
+    /// Artwork for the playing track, kept separate from selection-driven browser artwork.
+    private var currentTrackArtwork: NSImage?
     private var artworkTrackId: UUID?
+    private var currentTrackArtworkLoadTask: Task<Void, Never>?
     private var artworkLoadTask: Task<Void, Never>?
     private var artworkCyclingTask: Task<Void, Never>?
     private var radioLoadTask: Task<Void, Never>?
     private var radioPlayTask: Task<Void, Never>?
     private var loadGeneration: Int = 0
+    private var isPreparingForUITeardown = false
     private static let artworkCache = NSCache<NSString, NSImage>()
     private var artworkImages: [NSImage] = []
     private var artworkIndex: Int = 0
@@ -868,6 +878,7 @@ class ModernLibraryBrowserView: NSView {
         stopLoadingAnimation(force: true)
         stopServerNameScroll()
         stopVisualizerTimer()
+        backdropView?.stop()
     }
 
     /// Synchronously cancel every in-flight task, work item, and timer this view owns so it can
@@ -876,6 +887,7 @@ class ModernLibraryBrowserView: NSView {
     /// or a self-retaining repeating timer. `deinit` is deferred by AppKit's autorelease pool, so
     /// `WindowManager.teardownModeDependentWindows()` calls this *before* closing the window.
     func prepareForUITeardown() {
+        isPreparingForUITeardown = true
         // Async tasks — the detached @MainActor expand/load tasks don't inherit cancellation and
         // strongly capture self, so an in-flight one would survive teardown without this.
         for task in [localFolderBuildTask,
@@ -884,7 +896,7 @@ class ModernLibraryBrowserView: NSView {
                      jellyfinLoadTask, jellyfinAlbumWarmTask, jellyfinExpandTask,
                      youtubeExpandTask, youtubeDownloadTask,
                      embyLoadTask, embyExpandTask,
-                     ratingSubmitTask, artworkLoadTask, artworkCyclingTask,
+                     ratingSubmitTask, currentTrackArtworkLoadTask, artworkLoadTask, artworkCyclingTask,
                      radioLoadTask, radioPlayTask] {
             task?.cancel()
         }
@@ -894,7 +906,8 @@ class ModernLibraryBrowserView: NSView {
         jellyfinLoadTask = nil; jellyfinAlbumWarmTask = nil; jellyfinExpandTask = nil
         youtubeExpandTask = nil; youtubeDownloadTask = nil
         embyLoadTask = nil; embyExpandTask = nil
-        ratingSubmitTask = nil; artworkLoadTask = nil; artworkCyclingTask = nil
+        ratingSubmitTask = nil
+        currentTrackArtworkLoadTask = nil; artworkLoadTask = nil; artworkCyclingTask = nil
         radioLoadTask = nil; radioPlayTask = nil
 
         // Work items + timers (timers with a target/captured self can also pin the view alive).
@@ -904,13 +917,18 @@ class ModernLibraryBrowserView: NSView {
         stopLoadingAnimation(force: true)
         stopServerNameScroll()
         stopVisualizerTimer()
+        backdropView?.stop()
+        backdropView?.removeFromSuperview()
+        backdropView = nil
     }
 
     override func viewDidMoveToWindow() {
         super.viewDidMoveToWindow()
         layer?.isOpaque = false
+        layer?.backgroundColor = NSColor.clear.cgColor
         updateCornerMask()
         updateEmbeddedSubviewFrames()
+        refreshCompactBackdrop()
     }
 
     override func setFrameSize(_ newSize: NSSize) {
@@ -928,6 +946,26 @@ class ModernLibraryBrowserView: NSView {
     
     private func currentSkin() -> ModernSkin {
         return ModernSkinEngine.shared.currentSkin ?? ModernSkinLoader.shared.loadDefault()
+    }
+
+    private let backdropScrimAlpha: CGFloat = 0.72
+
+    private var backdropActive: Bool {
+        compactMode
+            && WindowManager.shared.isRunningModernUI
+            && WindowManager.shared.compactBackdropMode != .off
+    }
+
+    private func contentFill(_ base: NSColor) -> NSColor {
+        guard backdropActive else { return base }
+        return base.withAlphaComponent(base.alphaComponent * backdropScrimAlpha)
+    }
+
+    private func updateHistoryHostingBackground() {
+        guard let historyHostingView else { return }
+        let background = contentFill(currentSkin().backgroundColor)
+        historyHostingView.layer?.backgroundColor = background.cgColor
+        historyHostingView.layer?.isOpaque = !backdropActive && background.alphaComponent >= 1
     }
 
     private func updateCornerMask() {
@@ -958,8 +996,9 @@ class ModernLibraryBrowserView: NSView {
                                         headerTitle: "Library Data")
         let hostingView = NSHostingView(rootView: rootView)
         hostingView.wantsLayer = true
-        hostingView.layer?.backgroundColor = skin.backgroundColor.withAlphaComponent(1.0).cgColor
-        hostingView.layer?.isOpaque = true
+        let background = contentFill(skin.backgroundColor)
+        hostingView.layer?.backgroundColor = background.cgColor
+        hostingView.layer?.isOpaque = !backdropActive && background.alphaComponent >= 1
         hostingView.appearance = skinAppearance(for: skin)
         hostingView.setAccessibilityIdentifier("modernLibraryBrowser.data")
         hostingView.setAccessibilityLabel("Library Data")
@@ -1001,6 +1040,45 @@ class ModernLibraryBrowserView: NSView {
             ratingOverlay.frame = bounds
         }
         updateCompactPlayerBarFrame()
+        updateBackdropFrame()
+    }
+
+    private func updateBackdropFrame() {
+        backdropView?.frame = frame
+    }
+
+    func refreshCompactBackdrop() {
+        guard !isPreparingForUITeardown,
+              compactMode, WindowManager.shared.isRunningModernUI,
+              WindowManager.shared.compactBackdropMode != .off,
+              let container = superview else {
+            backdropView?.stop()
+            backdropView?.removeFromSuperview()
+            backdropView = nil
+            updateHistoryHostingBackground()
+            needsDisplay = true
+            return
+        }
+
+        let backdrop: CompactBackdropView
+        if let existing = backdropView {
+            backdrop = existing
+        } else {
+            backdrop = CompactBackdropView(frame: frame)
+            container.addSubview(backdrop, positioned: .below, relativeTo: self)
+            backdropView = backdrop
+        }
+        backdrop.frame = frame
+        backdrop.updateArtwork(currentTrackArtwork)
+        backdrop.reload()
+        updateHistoryHostingBackground()
+
+        if WindowManager.shared.compactBackdropMode == .albumArt,
+           let track = WindowManager.shared.audioEngine.currentTrack,
+           artworkTrackId != track.id || currentTrackArtwork == nil {
+            loadArtwork(for: track)
+        }
+        needsDisplay = true
     }
 
     /// Create/position/remove the embedded compact player bar to match the current mode.
@@ -1092,6 +1170,9 @@ class ModernLibraryBrowserView: NSView {
         
         let skin = currentSkin()
         let mainOpacity = skin.resolvedOpacity(for: .mainWindow)
+        let backgroundOpacity = backdropActive
+            ? mainOpacity.background * backdropScrimAlpha
+            : mainOpacity.background
 
         // Fast path: scroll timer marks only server bar dirty — skip full window redraw.
         // Always fill the full background first (copy blend mode) so the layer is never
@@ -1107,7 +1188,7 @@ class ModernLibraryBrowserView: NSView {
                 context: context,
                 adjacentEdges: adjacentEdges,
                 sharpCorners: sharpCorners,
-                backgroundOpacity: mainOpacity.background,
+                backgroundOpacity: backgroundOpacity,
                 drawMetalAccentStrip: false
             )
             context.saveGState()
@@ -1124,7 +1205,7 @@ class ModernLibraryBrowserView: NSView {
             context: context,
             adjacentEdges: adjacentEdges,
             sharpCorners: sharpCorners,
-            backgroundOpacity: mainOpacity.background,
+            backgroundOpacity: backgroundOpacity,
             drawMetalAccentStrip: false
         )
         renderer.drawWindowBorder(
@@ -1402,7 +1483,7 @@ class ModernLibraryBrowserView: NSView {
                                 width: bounds.width - Layout.borderWidth * 2, height: Layout.tabBarHeight)
         
         // Background
-        (isMetalRenderStyle ? metalControlBandFill : skin.surfaceColor.withAlphaComponent(0.4)).setFill()
+        contentFill(isMetalRenderStyle ? metalControlBandFill : skin.surfaceColor.withAlphaComponent(0.4)).setFill()
         context.fill(tabBarRect)
 
         let chromeScale = topChromeScale(for: skin)
@@ -1529,7 +1610,7 @@ class ModernLibraryBrowserView: NSView {
                             width: bounds.width - Layout.borderWidth * 2,
                             height: Layout.serverBarHeight)
         
-        (isMetalRenderStyle ? metalControlBandFill : skin.surfaceColor.withAlphaComponent(0.4)).setFill()
+        contentFill(isMetalRenderStyle ? metalControlBandFill : skin.surfaceColor.withAlphaComponent(0.4)).setFill()
         context.fill(barRect)
 
         let dimColor = skin.textDimColor
@@ -2065,7 +2146,7 @@ class ModernLibraryBrowserView: NSView {
                 ? skin.accentColor.withAlphaComponent(0.15)
                 : skin.surfaceColor.withAlphaComponent(0.3)
         }
-        bgColor.setFill()
+        contentFill(bgColor).setFill()
         let path = NSBezierPath(roundedRect: searchRect, xRadius: 3, yRadius: 3)
         path.fill()
         
@@ -2142,7 +2223,7 @@ class ModernLibraryBrowserView: NSView {
             let gapRect = NSRect(x: headerRect.maxX, y: headerY,
                                  width: bounds.width - Layout.borderWidth - headerRect.maxX,
                                  height: columnHeaderHeight)
-            (isMetalRenderStyle ? metalControlBandFill : skin.surfaceColor.withAlphaComponent(0.4)).setFill()
+            contentFill(isMetalRenderStyle ? metalControlBandFill : skin.surfaceColor.withAlphaComponent(0.4)).setFill()
             context.fill(gapRect)
             contentListY = listAreaY
         }
@@ -2288,7 +2369,7 @@ class ModernLibraryBrowserView: NSView {
         context.saveGState()
         context.clip(to: rect)
         
-        (isMetalRenderStyle ? metalControlBandFill : skin.surfaceColor.withAlphaComponent(0.4)).setFill()
+        contentFill(isMetalRenderStyle ? metalControlBandFill : skin.surfaceColor.withAlphaComponent(0.4)).setFill()
         context.fill(rect)
 
         let headerFont = skin.scaledSystemFont(size: 7.2, weight: .medium)
@@ -2527,9 +2608,9 @@ class ModernLibraryBrowserView: NSView {
     
     private func drawArtOnlyArea(in context: CGContext, contentRect: NSRect, skin: ModernSkin, artwork: NSImage?) {
         if isVisualizingArt {
-            (isMetalRenderStyle ? NSColor(calibratedRed: 0.34, green: 0.38, blue: 0.40, alpha: 1.0) : NSColor.black).setFill()
+            contentFill(isMetalRenderStyle ? NSColor(calibratedRed: 0.34, green: 0.38, blue: 0.40, alpha: 1.0) : NSColor.black).setFill()
         } else {
-            (isMetalRenderStyle ? metalControlFill : skin.surfaceColor).setFill()
+            contentFill(isMetalRenderStyle ? metalControlFill : skin.surfaceColor).setFill()
         }
         context.fill(contentRect)
         
@@ -2566,7 +2647,7 @@ class ModernLibraryBrowserView: NSView {
     private func drawAlphabetIndex(in context: CGContext, rect: NSRect, skin: ModernSkin) {
         // Metal: let the brushed-metal panel show through so the index reads as part of
         // the single continuous surface rather than a darker inset strip.
-        (isMetalRenderStyle ? NSColor.clear : skin.surfaceColor.withAlphaComponent(0.3)).setFill()
+        contentFill(isMetalRenderStyle ? NSColor.clear : skin.surfaceColor.withAlphaComponent(0.3)).setFill()
         context.fill(rect)
         
         let letterCount = CGFloat(alphabetLetters.count)
@@ -3948,7 +4029,14 @@ class ModernLibraryBrowserView: NSView {
             let menu = NSMenu()
             let manageFoldersItem = NSMenuItem(title: "Manage Folders...", action: #selector(manageWatchFolders), keyEquivalent: "")
             manageFoldersItem.target = self; menu.addItem(manageFoldersItem)
+            prependCompactBackdropMenu(to: menu)
             NSMenu.popUpContextMenu(menu, with: event, for: self); return
+        }
+        if compactMode {
+            let menu = NSMenu()
+            prependCompactBackdropMenu(to: menu)
+            NSMenu.popUpContextMenu(menu, with: event, for: self)
+            return
         }
         super.rightMouseDown(with: event)
     }
@@ -4988,6 +5076,7 @@ class ModernLibraryBrowserView: NSView {
         menu.addItem(NSMenuItem.separator())
         let offItem = NSMenuItem(title: "Turn Off", action: #selector(turnOffVisualization), keyEquivalent: "")
         offItem.target = self; menu.addItem(offItem)
+        prependCompactBackdropMenu(to: menu)
         NSMenu.popUpContextMenu(menu, with: event, for: self)
     }
     
@@ -5021,19 +5110,37 @@ class ModernLibraryBrowserView: NSView {
         menu.addItem(NSMenuItem.separator())
         let exitItem = NSMenuItem(title: "Exit Art View", action: #selector(exitArtView), keyEquivalent: "")
         exitItem.target = self; menu.addItem(exitItem)
+        prependCompactBackdropMenu(to: menu)
         NSMenu.popUpContextMenu(menu, with: event, for: self)
     }
     
     private func showColumnConfigMenu(at event: NSEvent) {
-        if hasInternetRadioColumns { return }
+        if hasInternetRadioColumns {
+            guard compactMode else { return }
+            let menu = NSMenu()
+            prependCompactBackdropMenu(to: menu)
+            NSMenu.popUpContextMenu(menu, with: event, for: self)
+            return
+        }
         let menu = NSMenu()
         menu.autoenablesItems = false
 
         for group in columnGroupsForCurrentMenu() {
             addColumnVisibilityGroup(group, to: menu)
         }
-        
+
+        prependCompactBackdropMenu(to: menu)
         NSMenu.popUpContextMenu(menu, with: event, for: self)
+    }
+
+    private func prependCompactBackdropMenu(to menu: NSMenu) {
+        guard compactMode else { return }
+        if !menu.items.isEmpty {
+            menu.insertItem(.separator(), at: 0)
+        }
+        let item = NSMenuItem(title: "Compact Background", action: nil, keyEquivalent: "")
+        item.submenu = ContextMenuBuilder.buildCompactBackdropMenu(presenter: compactBackdropPresenter)
+        menu.insertItem(item, at: 0)
     }
 
     private func columnGroupsForCurrentMenu() -> [LibraryColumnVisibilityGroup] {
@@ -5598,6 +5705,7 @@ class ModernLibraryBrowserView: NSView {
             queueItem.target = self; queueItem.representedObject = track; menu.addItem(queueItem)
         case .header: return
         }
+        prependCompactBackdropMenu(to: menu)
         NSMenu.popUpContextMenu(menu, with: event, for: self)
     }
 
@@ -7236,7 +7344,8 @@ class ModernLibraryBrowserView: NSView {
                                                         skinTextColor: Color(skin.textColor),
                                                         headerTitle: "Library Data")
         historyHostingView?.appearance = skinAppearance(for: skin)
-        historyHostingView?.layer?.backgroundColor = skin.backgroundColor.withAlphaComponent(1.0).cgColor
+        updateHistoryHostingBackground()
+        backdropView?.reload()
         invalidateServerBarFontCache()
         updateCornerMask()
         updateEmbeddedSubviewFrames()
@@ -7492,8 +7601,17 @@ class ModernLibraryBrowserView: NSView {
             loadAllArtworkForCurrentTrack()
             return
         }
-        guard WindowManager.shared.showBrowserArtworkBackground else {
-            if currentArtwork != nil { currentArtwork = nil; artworkTrackId = nil; needsDisplay = true }; return
+        let needsCurrentTrackArtwork = WindowManager.shared.showBrowserArtworkBackground
+            || (backdropActive && WindowManager.shared.compactBackdropMode == .albumArt)
+        guard needsCurrentTrackArtwork else {
+            if currentArtwork != nil || currentTrackArtwork != nil {
+                currentArtwork = nil
+                currentTrackArtwork = nil
+                artworkTrackId = nil
+                backdropView?.updateArtwork(nil)
+                needsDisplay = true
+            }
+            return
         }
         loadArtwork(for: track)
     }
@@ -7516,6 +7634,7 @@ class ModernLibraryBrowserView: NSView {
         guard notification.object as? NSWindow == window else { return }
         stopServerNameScroll()
         if isVisualizingArt { visualizerWasActiveBeforeHide = true; stopVisualizerTimer() }
+        backdropView?.reload()
     }
     
     @objc private func windowDidDeminiaturize(_ notification: Notification) {
@@ -7523,6 +7642,7 @@ class ModernLibraryBrowserView: NSView {
         startServerNameScroll()
         if visualizerWasActiveBeforeHide && isVisualizingArt { startVisualizerTimer() }
         visualizerWasActiveBeforeHide = false
+        backdropView?.reload()
     }
     
     @objc private func windowDidChangeOcclusionState(_ notification: Notification) {
@@ -7534,6 +7654,7 @@ class ModernLibraryBrowserView: NSView {
             stopServerNameScroll()
             if visualizerTimer != nil { visualizerWasActiveBeforeHide = isVisualizingArt; stopVisualizerTimer() }
         }
+        backdropView?.reload()
     }
     
     // MARK: - Source Changed
@@ -8389,10 +8510,20 @@ class ModernLibraryBrowserView: NSView {
     // MARK: - Artwork Loading
     
     private func loadArtwork(for track: Track?) {
-        artworkLoadTask?.cancel(); artworkLoadTask = nil
-        guard let track = track else { currentArtwork = nil; artworkTrackId = nil; needsDisplay = true; return }
-        guard track.id != artworkTrackId else { return }
-        artworkLoadTask = Task { [weak self] in
+        currentTrackArtworkLoadTask?.cancel(); currentTrackArtworkLoadTask = nil
+        guard let track = track else {
+            currentArtwork = nil
+            currentTrackArtwork = nil
+            artworkTrackId = nil
+            backdropView?.updateArtwork(nil)
+            needsDisplay = true
+            return
+        }
+        guard track.id != artworkTrackId || currentTrackArtwork == nil else {
+            backdropView?.updateArtwork(currentTrackArtwork)
+            return
+        }
+        currentTrackArtworkLoadTask = Task { [weak self] in
             guard let self = self else { return }
             var image: NSImage?
             if let plexRatingKey = track.plexRatingKey {
@@ -8414,7 +8545,9 @@ class ModernLibraryBrowserView: NSView {
             await MainActor.run {
                 guard WindowManager.shared.audioEngine.currentTrack?.id == track.id else { return }
                 self.currentArtwork = image
+                self.currentTrackArtwork = image
                 self.artworkTrackId = track.id
+                self.backdropView?.updateArtwork(image)
                 self.needsDisplay = true
             }
         }
@@ -8550,6 +8683,7 @@ class ModernLibraryBrowserView: NSView {
     }
     
     private func loadAllArtworkForCurrentTrack() {
+        currentTrackArtworkLoadTask?.cancel(); currentTrackArtworkLoadTask = nil
         artworkLoadTask?.cancel(); artworkLoadTask = nil
         artworkCyclingTask?.cancel(); artworkCyclingTask = nil
         guard let currentTrack = WindowManager.shared.audioEngine.currentTrack else {
@@ -8586,13 +8720,17 @@ class ModernLibraryBrowserView: NSView {
 
                 self.artworkImages = images; self.artworkIndex = 0
                 self.currentArtwork = images.first
+                self.currentTrackArtwork = images.first
                 self.artworkTrackId = currentTrack.id
+                self.backdropView?.updateArtwork(images.first)
                 self.needsDisplay = true
             }
         }
     }
 
     private func exitArtOnlyModeForMissingArtwork() {
+        currentTrackArtworkLoadTask?.cancel()
+        currentTrackArtworkLoadTask = nil
         artworkLoadTask?.cancel()
         artworkLoadTask = nil
         artworkCyclingTask?.cancel()
@@ -8600,7 +8738,9 @@ class ModernLibraryBrowserView: NSView {
         artworkImages = []
         artworkIndex = 0
         currentArtwork = nil
+        currentTrackArtwork = nil
         artworkTrackId = nil
+        backdropView?.updateArtwork(nil)
         isArtOnlyMode = false
         needsDisplay = true
     }
@@ -8608,7 +8748,10 @@ class ModernLibraryBrowserView: NSView {
     private func cycleToNextArtwork() {
         guard artworkImages.count > 1 else { return }
         artworkIndex = (artworkIndex + 1) % artworkImages.count
-        currentArtwork = artworkImages[artworkIndex]; needsDisplay = true
+        currentArtwork = artworkImages[artworkIndex]
+        currentTrackArtwork = currentArtwork
+        backdropView?.updateArtwork(currentArtwork)
+        needsDisplay = true
     }
     
     private func loadArtworkForSelection() {

--- a/Sources/NullPlayer/Windows/ModernLibraryBrowser/ModernLibraryBrowserView.swift
+++ b/Sources/NullPlayer/Windows/ModernLibraryBrowser/ModernLibraryBrowserView.swift
@@ -1044,7 +1044,8 @@ class ModernLibraryBrowserView: NSView {
     }
 
     private func updateBackdropFrame() {
-        backdropView?.frame = frame
+        guard let backdropView, let container = superview else { return }
+        backdropView.frame = container.bounds
     }
 
     func refreshCompactBackdrop() {
@@ -1064,11 +1065,11 @@ class ModernLibraryBrowserView: NSView {
         if let existing = backdropView {
             backdrop = existing
         } else {
-            backdrop = CompactBackdropView(frame: frame)
+            backdrop = CompactBackdropView(frame: container.bounds)
             container.addSubview(backdrop, positioned: .below, relativeTo: self)
             backdropView = backdrop
         }
-        backdrop.frame = frame
+        backdrop.frame = container.bounds
         backdrop.updateArtwork(currentTrackArtwork)
         backdrop.reload()
         updateHistoryHostingBackground()
@@ -5134,7 +5135,8 @@ class ModernLibraryBrowserView: NSView {
     }
 
     private func prependCompactBackdropMenu(to menu: NSMenu) {
-        guard compactMode else { return }
+        guard compactMode,
+              AppCapabilities.supports(.compactWindowVisualsMenu) else { return }
         if !menu.items.isEmpty {
             menu.insertItem(.separator(), at: 0)
         }

--- a/Sources/NullPlayer/Windows/ModernLibraryBrowser/ModernLibraryBrowserView.swift
+++ b/Sources/NullPlayer/Windows/ModernLibraryBrowser/ModernLibraryBrowserView.swift
@@ -194,7 +194,7 @@ class ModernLibraryBrowserView: NSView {
     var compactMode: Bool = false {
         didSet {
             guard compactMode != oldValue else { return }
-            refreshCompactBackdrop()
+            refreshBackdrop()
             needsLayout = true
             needsDisplay = true
         }
@@ -202,7 +202,7 @@ class ModernLibraryBrowserView: NSView {
     private var compactPlayerBar: CompactPlayerBarView?
     private var backdropView: CompactBackdropView?
 
-    var compactBackdropPresenter: CavaPresenter? {
+    var backdropPresenter: CavaPresenter? {
         backdropView?.presenter
     }
 
@@ -928,7 +928,7 @@ class ModernLibraryBrowserView: NSView {
         layer?.backgroundColor = NSColor.clear.cgColor
         updateCornerMask()
         updateEmbeddedSubviewFrames()
-        refreshCompactBackdrop()
+        refreshBackdrop()
     }
 
     override func setFrameSize(_ newSize: NSSize) {
@@ -951,9 +951,17 @@ class ModernLibraryBrowserView: NSView {
     private let backdropScrimAlpha: CGFloat = 0.72
 
     private var backdropActive: Bool {
+        WindowManager.shared.isRunningModernUI && effectiveBackdropMode != .off
+    }
+
+    private var effectiveBackdropMode: BrowserBackdropMode {
         compactMode
-            && WindowManager.shared.isRunningModernUI
-            && WindowManager.shared.compactBackdropMode != .off
+            ? WindowManager.shared.compactBackdropMode
+            : WindowManager.shared.libraryBackdropMode
+    }
+
+    private var backdropScope: CavaSettings.Scope {
+        compactMode ? .compactWindow : .libraryWindow
     }
 
     private func contentFill(_ base: NSColor) -> NSColor {
@@ -1048,10 +1056,10 @@ class ModernLibraryBrowserView: NSView {
         backdropView.frame = container.bounds
     }
 
-    func refreshCompactBackdrop() {
+    func refreshBackdrop() {
         guard !isPreparingForUITeardown,
-              compactMode, WindowManager.shared.isRunningModernUI,
-              WindowManager.shared.compactBackdropMode != .off,
+              WindowManager.shared.isRunningModernUI,
+              effectiveBackdropMode != .off,
               let container = superview else {
             backdropView?.stop()
             backdropView?.removeFromSuperview()
@@ -1062,10 +1070,16 @@ class ModernLibraryBrowserView: NSView {
         }
 
         let backdrop: CompactBackdropView
-        if let existing = backdropView {
+        if let existing = backdropView, existing.scope == backdropScope {
             backdrop = existing
         } else {
-            backdrop = CompactBackdropView(frame: container.bounds)
+            backdropView?.stop()
+            backdropView?.removeFromSuperview()
+            backdrop = CompactBackdropView(
+                frame: container.bounds,
+                scope: backdropScope,
+                modeProvider: { [weak self] in self?.effectiveBackdropMode ?? .off }
+            )
             container.addSubview(backdrop, positioned: .below, relativeTo: self)
             backdropView = backdrop
         }
@@ -1074,12 +1088,16 @@ class ModernLibraryBrowserView: NSView {
         backdrop.reload()
         updateHistoryHostingBackground()
 
-        if WindowManager.shared.compactBackdropMode == .albumArt,
+        if effectiveBackdropMode == .albumArt,
            let track = WindowManager.shared.audioEngine.currentTrack,
            artworkTrackId != track.id || currentTrackArtwork == nil {
             loadArtwork(for: track)
         }
         needsDisplay = true
+    }
+
+    func stopBackdrop() {
+        backdropView?.stop()
     }
 
     /// Create/position/remove the embedded compact player bar to match the current mode.
@@ -4030,12 +4048,12 @@ class ModernLibraryBrowserView: NSView {
             let menu = NSMenu()
             let manageFoldersItem = NSMenuItem(title: "Manage Folders...", action: #selector(manageWatchFolders), keyEquivalent: "")
             manageFoldersItem.target = self; menu.addItem(manageFoldersItem)
-            prependCompactBackdropMenu(to: menu)
+            prependBackdropMenu(to: menu)
             NSMenu.popUpContextMenu(menu, with: event, for: self); return
         }
-        if compactMode {
+        if backdropMenuIsAvailable {
             let menu = NSMenu()
-            prependCompactBackdropMenu(to: menu)
+            prependBackdropMenu(to: menu)
             NSMenu.popUpContextMenu(menu, with: event, for: self)
             return
         }
@@ -5077,7 +5095,7 @@ class ModernLibraryBrowserView: NSView {
         menu.addItem(NSMenuItem.separator())
         let offItem = NSMenuItem(title: "Turn Off", action: #selector(turnOffVisualization), keyEquivalent: "")
         offItem.target = self; menu.addItem(offItem)
-        prependCompactBackdropMenu(to: menu)
+        prependBackdropMenu(to: menu)
         NSMenu.popUpContextMenu(menu, with: event, for: self)
     }
     
@@ -5111,15 +5129,15 @@ class ModernLibraryBrowserView: NSView {
         menu.addItem(NSMenuItem.separator())
         let exitItem = NSMenuItem(title: "Exit Art View", action: #selector(exitArtView), keyEquivalent: "")
         exitItem.target = self; menu.addItem(exitItem)
-        prependCompactBackdropMenu(to: menu)
+        prependBackdropMenu(to: menu)
         NSMenu.popUpContextMenu(menu, with: event, for: self)
     }
     
     private func showColumnConfigMenu(at event: NSEvent) {
         if hasInternetRadioColumns {
-            guard compactMode else { return }
+            guard backdropMenuIsAvailable else { return }
             let menu = NSMenu()
-            prependCompactBackdropMenu(to: menu)
+            prependBackdropMenu(to: menu)
             NSMenu.popUpContextMenu(menu, with: event, for: self)
             return
         }
@@ -5130,18 +5148,27 @@ class ModernLibraryBrowserView: NSView {
             addColumnVisibilityGroup(group, to: menu)
         }
 
-        prependCompactBackdropMenu(to: menu)
+        prependBackdropMenu(to: menu)
         NSMenu.popUpContextMenu(menu, with: event, for: self)
     }
 
-    private func prependCompactBackdropMenu(to menu: NSMenu) {
-        guard compactMode,
-              AppCapabilities.supports(.compactWindowVisualsMenu) else { return }
+    private var backdropMenuIsAvailable: Bool {
+        !compactMode || AppCapabilities.supports(.compactWindowVisualsMenu)
+    }
+
+    private func prependBackdropMenu(to menu: NSMenu) {
+        guard backdropMenuIsAvailable else { return }
         if !menu.items.isEmpty {
             menu.insertItem(.separator(), at: 0)
         }
-        let item = NSMenuItem(title: "Compact Background", action: nil, keyEquivalent: "")
-        item.submenu = ContextMenuBuilder.buildCompactBackdropMenu(presenter: compactBackdropPresenter)
+        let item = NSMenuItem(
+            title: compactMode ? "Compact Background" : "Library Background",
+            action: nil,
+            keyEquivalent: ""
+        )
+        item.submenu = compactMode
+            ? ContextMenuBuilder.buildCompactBackdropMenu(presenter: backdropPresenter)
+            : ContextMenuBuilder.buildLibraryBackdropMenu(presenter: backdropPresenter)
         menu.insertItem(item, at: 0)
     }
 
@@ -5707,7 +5734,7 @@ class ModernLibraryBrowserView: NSView {
             queueItem.target = self; queueItem.representedObject = track; menu.addItem(queueItem)
         case .header: return
         }
-        prependCompactBackdropMenu(to: menu)
+        prependBackdropMenu(to: menu)
         NSMenu.popUpContextMenu(menu, with: event, for: self)
     }
 
@@ -7604,7 +7631,7 @@ class ModernLibraryBrowserView: NSView {
             return
         }
         let needsCurrentTrackArtwork = WindowManager.shared.showBrowserArtworkBackground
-            || (backdropActive && WindowManager.shared.compactBackdropMode == .albumArt)
+            || (backdropActive && effectiveBackdropMode == .albumArt)
         guard needsCurrentTrackArtwork else {
             if currentArtwork != nil || currentTrackArtwork != nil {
                 currentArtwork = nil

--- a/Sources/NullPlayer/Windows/ModernLibraryBrowser/ModernLibraryBrowserWindowController.swift
+++ b/Sources/NullPlayer/Windows/ModernLibraryBrowser/ModernLibraryBrowserWindowController.swift
@@ -152,11 +152,21 @@ class ModernLibraryBrowserWindowController: NSWindowController, LibraryBrowserWi
     }
 
     var compactBackdropPresenter: CavaPresenter? {
-        browserView.compactBackdropPresenter
+        browserView.backdropPresenter
     }
 
     func refreshCompactBackdrop() {
-        browserView.refreshCompactBackdrop()
+        browserView.refreshBackdrop()
+    }
+
+    var libraryBackdropPresenter: CavaPresenter? {
+        guard !isCompactMode else { return nil }
+        return browserView.backdropPresenter
+    }
+
+    func refreshLibraryBackdrop() {
+        guard !isCompactMode else { return }
+        browserView.refreshBackdrop()
     }
 }
 
@@ -184,6 +194,7 @@ extension ModernLibraryBrowserWindowController: NSWindowDelegate {
     }
     
     func windowWillClose(_ notification: Notification) {
+        browserView.stopBackdrop()
         WindowManager.shared.rememberPlexBrowserFrameBeforeClose()
         WindowManager.shared.notifyMainWindowVisibilityChanged()
     }

--- a/Sources/NullPlayer/Windows/ModernLibraryBrowser/ModernLibraryBrowserWindowController.swift
+++ b/Sources/NullPlayer/Windows/ModernLibraryBrowser/ModernLibraryBrowserWindowController.swift
@@ -72,7 +72,14 @@ class ModernLibraryBrowserWindowController: NSWindowController, LibraryBrowserWi
         browserView = ModernLibraryBrowserView(frame: NSRect(origin: .zero, size: ModernSkinElements.libraryDefaultSize))
         browserView.controller = self
         browserView.autoresizingMask = [.width, .height]
-        window?.contentView = browserView
+
+        // The backdrop and browser are siblings so Cava can repaint independently beneath the
+        // browser's translucent custom drawing.
+        let container = NSView(frame: browserView.frame)
+        container.wantsLayer = true
+        container.layer?.backgroundColor = NSColor.clear.cgColor
+        container.addSubview(browserView)
+        window?.contentView = container
     }
     
     // MARK: - Public Methods
@@ -142,6 +149,14 @@ class ModernLibraryBrowserWindowController: NSWindowController, LibraryBrowserWi
 
     func updateCompactBarPlaybackState() {
         browserView.compactBarUpdatePlaybackState()
+    }
+
+    var compactBackdropPresenter: CavaPresenter? {
+        browserView.compactBackdropPresenter
+    }
+
+    func refreshCompactBackdrop() {
+        browserView.refreshCompactBackdrop()
     }
 }
 

--- a/Tests/NullPlayerAppTests/CavaSettingsTests.swift
+++ b/Tests/NullPlayerAppTests/CavaSettingsTests.swift
@@ -75,6 +75,29 @@ final class CavaSettingsTests: XCTestCase {
         XCTAssertEqual(CavaSettings.bassTilt, 0.7, accuracy: 0.001)
     }
 
+    func testCompactWindowTuningHasAnIndependentNamespace() {
+        CavaSettings.setBarCount(19, for: .mainWindow)
+        CavaSettings.setBarCount(48, for: .cavaWindow)
+        CavaSettings.setBarCount(64, for: .compactWindow)
+        CavaSettings.setNoiseReduction(0.8, for: .compactWindow)
+
+        XCTAssertEqual(CavaSettings.barCount(for: .compactWindow), 64)
+        XCTAssertEqual(CavaSettings.noiseReduction(for: .compactWindow), 0.8, accuracy: 0.001)
+        XCTAssertEqual(CavaSettings.barCount(for: .mainWindow), 19)
+        XCTAssertEqual(CavaSettings.barCount(for: .cavaWindow), 48)
+        XCTAssertEqual(CavaSettings.mode(for: .compactWindow), .stereo)
+        XCTAssertEqual(CavaSettings.barCountPresets(for: .compactWindow), [16, 24, 32, 48, 64])
+    }
+
+    func testCompactWindowPreferenceKeysExcludeStandaloneTransparency() {
+        let keys = CavaSettings.preferenceKeys(for: .compactWindow)
+
+        XCTAssertTrue(keys.contains("cava.compactWindow.barCount"))
+        XCTAssertTrue(keys.contains("cava.compactWindow.colorsCustomized"))
+        XCTAssertFalse(keys.contains("cava.compactWindow.transparentBackground"))
+        XCTAssertFalse(keys.contains("cava.compactWindow.transparencyCustomized"))
+    }
+
     func testMainWindowResetTuningLeavesStandaloneWindowUntouched() {
         CavaSettings.barCount = 48
         CavaSettings.setBarCount(12, for: .mainWindow)
@@ -97,12 +120,14 @@ final class CavaSettingsTests: XCTestCase {
         CavaSettings.setLowGradientColor(ice.low, for: .mainWindow)
         CavaSettings.setHighGradientColor(ice.high, for: .mainWindow)
         CavaSettings.setHasCustomColors(true, for: .mainWindow)
+        CavaSettings.setHasCustomColors(true, for: .compactWindow)
         CavaSettings.transparentBackground = true
 
         CavaSettings.resetAppearanceForSkinChange()
 
         XCTAssertFalse(CavaSettings.hasCustomColors(for: .cavaWindow))
         XCTAssertFalse(CavaSettings.hasCustomColors(for: .mainWindow))
+        XCTAssertFalse(CavaSettings.hasCustomColors(for: .compactWindow))
         XCTAssertFalse(CavaSettings.transparentBackground)
         XCTAssertEqual(CavaSettings.currentColorSchemeIndex(for: .cavaWindow), fireIndex)
         XCTAssertEqual(CavaSettings.currentColorSchemeIndex(for: .mainWindow), iceIndex)

--- a/Tests/NullPlayerAppTests/CavaSettingsTests.swift
+++ b/Tests/NullPlayerAppTests/CavaSettingsTests.swift
@@ -85,10 +85,16 @@ final class CavaSettingsTests: XCTestCase {
         XCTAssertTrue(AppCapabilities.supports(.compactWindowVisualsMenu))
 
         let menu = ContextMenuBuilder.buildCompactBackdropMenu()
-        XCTAssertEqual(Array(menu.items.prefix(3)).map(\.title), ["Off", "Album Art", "Cava"])
+        XCTAssertEqual(
+            Array(menu.items.prefix(4)).map(\.title),
+            ["Off", "Cava", "Art", "Cava + Art"]
+        )
 
         let libraryMenu = ContextMenuBuilder.buildLibraryBackdropMenu()
-        XCTAssertEqual(Array(libraryMenu.items.prefix(3)).map(\.title), ["Off", "Album Art", "Cava"])
+        XCTAssertEqual(
+            Array(libraryMenu.items.prefix(4)).map(\.title),
+            ["Off", "Cava", "Art", "Cava + Art"]
+        )
     }
 
     func testMainWindowTuningIsIndependentFromStandaloneWindow() {

--- a/Tests/NullPlayerAppTests/CavaSettingsTests.swift
+++ b/Tests/NullPlayerAppTests/CavaSettingsTests.swift
@@ -58,6 +58,28 @@ final class CavaSettingsTests: XCTestCase {
         XCTAssertEqual(CavaSettings.mode, .stereo)
     }
 
+    func testCompactWindowDefaultsToFullWidthMonoWithSmoothTuning() {
+        XCTAssertEqual(CavaSettings.mode(for: .compactWindow), .mono)
+        XCTAssertEqual(
+            CavaSettings.noiseReduction(for: .compactWindow),
+            CavaSettings.defaultCompactNoiseReduction,
+            accuracy: 0.001
+        )
+    }
+
+    func testCompactWindowCanStillUseExplicitStereo() {
+        CavaSettings.setMode(.stereo, for: .compactWindow)
+
+        XCTAssertEqual(CavaSettings.mode(for: .compactWindow), .stereo)
+    }
+
+    func testCompactWindowVisualsMenuIsAvailableInDefaultBuild() {
+        XCTAssertTrue(AppCapabilities.supports(.compactWindowVisualsMenu))
+
+        let menu = ContextMenuBuilder.buildCompactBackdropMenu()
+        XCTAssertEqual(Array(menu.items.prefix(3)).map(\.title), ["Off", "Album Art", "Cava"])
+    }
+
     func testMainWindowTuningIsIndependentFromStandaloneWindow() {
         CavaSettings.barCount = 64
         CavaSettings.noiseReduction = 0.9
@@ -85,7 +107,7 @@ final class CavaSettingsTests: XCTestCase {
         XCTAssertEqual(CavaSettings.noiseReduction(for: .compactWindow), 0.8, accuracy: 0.001)
         XCTAssertEqual(CavaSettings.barCount(for: .mainWindow), 19)
         XCTAssertEqual(CavaSettings.barCount(for: .cavaWindow), 48)
-        XCTAssertEqual(CavaSettings.mode(for: .compactWindow), .stereo)
+        XCTAssertEqual(CavaSettings.mode(for: .compactWindow), .mono)
         XCTAssertEqual(CavaSettings.barCountPresets(for: .compactWindow), [16, 24, 32, 48, 64])
     }
 

--- a/Tests/NullPlayerAppTests/CavaSettingsTests.swift
+++ b/Tests/NullPlayerAppTests/CavaSettingsTests.swift
@@ -58,8 +58,8 @@ final class CavaSettingsTests: XCTestCase {
         XCTAssertEqual(CavaSettings.mode, .stereo)
     }
 
-    func testCompactWindowDefaultsToFullWidthMonoWithSmoothTuning() {
-        XCTAssertEqual(CavaSettings.mode(for: .compactWindow), .mono)
+    func testCompactWindowDefaultsToStereoWithSmoothTuning() {
+        XCTAssertEqual(CavaSettings.mode(for: .compactWindow), .stereo)
         XCTAssertEqual(
             CavaSettings.noiseReduction(for: .compactWindow),
             CavaSettings.defaultCompactNoiseReduction,
@@ -67,10 +67,18 @@ final class CavaSettingsTests: XCTestCase {
         )
     }
 
-    func testCompactWindowCanStillUseExplicitStereo() {
-        CavaSettings.setMode(.stereo, for: .compactWindow)
+    func testCompactWindowCanStillUseExplicitMono() {
+        CavaSettings.setMode(.mono, for: .compactWindow)
 
-        XCTAssertEqual(CavaSettings.mode(for: .compactWindow), .stereo)
+        XCTAssertEqual(CavaSettings.mode(for: .compactWindow), .mono)
+    }
+
+    func testLibraryWindowDefaultsToMonoButPreservesExplicitStereo() {
+        XCTAssertEqual(CavaSettings.mode(for: .libraryWindow), .mono)
+
+        CavaSettings.setMode(.stereo, for: .libraryWindow)
+
+        XCTAssertEqual(CavaSettings.mode(for: .libraryWindow), .stereo)
     }
 
     func testCompactWindowVisualsMenuIsAvailableInDefaultBuild() {
@@ -78,6 +86,9 @@ final class CavaSettingsTests: XCTestCase {
 
         let menu = ContextMenuBuilder.buildCompactBackdropMenu()
         XCTAssertEqual(Array(menu.items.prefix(3)).map(\.title), ["Off", "Album Art", "Cava"])
+
+        let libraryMenu = ContextMenuBuilder.buildLibraryBackdropMenu()
+        XCTAssertEqual(Array(libraryMenu.items.prefix(3)).map(\.title), ["Off", "Album Art", "Cava"])
     }
 
     func testMainWindowTuningIsIndependentFromStandaloneWindow() {
@@ -107,8 +118,35 @@ final class CavaSettingsTests: XCTestCase {
         XCTAssertEqual(CavaSettings.noiseReduction(for: .compactWindow), 0.8, accuracy: 0.001)
         XCTAssertEqual(CavaSettings.barCount(for: .mainWindow), 19)
         XCTAssertEqual(CavaSettings.barCount(for: .cavaWindow), 48)
-        XCTAssertEqual(CavaSettings.mode(for: .compactWindow), .mono)
+        XCTAssertEqual(CavaSettings.mode(for: .compactWindow), .stereo)
         XCTAssertEqual(CavaSettings.barCountPresets(for: .compactWindow), [16, 24, 32, 48, 64])
+    }
+
+    func testLibraryWindowTuningHasAnIndependentNamespace() {
+        CavaSettings.setBarCount(48, for: .libraryWindow)
+        CavaSettings.setNoiseReduction(0.9, for: .libraryWindow)
+
+        XCTAssertEqual(CavaSettings.barCount(for: .libraryWindow), 48)
+        XCTAssertEqual(CavaSettings.noiseReduction(for: .libraryWindow), 0.9, accuracy: 0.001)
+        XCTAssertEqual(CavaSettings.barCount(for: .compactWindow), CavaSettings.defaultBarCount)
+        XCTAssertEqual(
+            CavaSettings.noiseReduction(for: .compactWindow),
+            CavaSettings.defaultCompactNoiseReduction,
+            accuracy: 0.001
+        )
+    }
+
+    func testMirroredMonoBackdropCoversBothHorizontalEdges() {
+        let entries = CavaDrawing.monoBarRects(
+            in: CGRect(x: 0, y: 0, width: 200, height: 100),
+            bars: [0.25, 0.75],
+            layout: .mirrored
+        ).sorted { $0.rect.minX < $1.rect.minX }
+
+        XCTAssertEqual(entries.count, 4)
+        XCTAssertEqual(entries.first?.rect.minX, 0)
+        XCTAssertEqual(entries.last?.rect.maxX, 200)
+        XCTAssertEqual(entries.map(\.rect.height), [75, 25, 25, 75])
     }
 
     func testCompactWindowPreferenceKeysExcludeStandaloneTransparency() {
@@ -118,6 +156,15 @@ final class CavaSettingsTests: XCTestCase {
         XCTAssertTrue(keys.contains("cava.compactWindow.colorsCustomized"))
         XCTAssertFalse(keys.contains("cava.compactWindow.transparentBackground"))
         XCTAssertFalse(keys.contains("cava.compactWindow.transparencyCustomized"))
+    }
+
+    func testLibraryWindowPreferenceKeysExcludeStandaloneTransparency() {
+        let keys = CavaSettings.preferenceKeys(for: .libraryWindow)
+
+        XCTAssertTrue(keys.contains("cava.libraryWindow.barCount"))
+        XCTAssertTrue(keys.contains("cava.libraryWindow.colorsCustomized"))
+        XCTAssertFalse(keys.contains("cava.libraryWindow.transparentBackground"))
+        XCTAssertFalse(keys.contains("cava.libraryWindow.transparencyCustomized"))
     }
 
     func testMainWindowResetTuningLeavesStandaloneWindowUntouched() {
@@ -143,6 +190,7 @@ final class CavaSettingsTests: XCTestCase {
         CavaSettings.setHighGradientColor(ice.high, for: .mainWindow)
         CavaSettings.setHasCustomColors(true, for: .mainWindow)
         CavaSettings.setHasCustomColors(true, for: .compactWindow)
+        CavaSettings.setHasCustomColors(true, for: .libraryWindow)
         CavaSettings.transparentBackground = true
 
         CavaSettings.resetAppearanceForSkinChange()
@@ -150,6 +198,7 @@ final class CavaSettingsTests: XCTestCase {
         XCTAssertFalse(CavaSettings.hasCustomColors(for: .cavaWindow))
         XCTAssertFalse(CavaSettings.hasCustomColors(for: .mainWindow))
         XCTAssertFalse(CavaSettings.hasCustomColors(for: .compactWindow))
+        XCTAssertFalse(CavaSettings.hasCustomColors(for: .libraryWindow))
         XCTAssertFalse(CavaSettings.transparentBackground)
         XCTAssertEqual(CavaSettings.currentColorSchemeIndex(for: .cavaWindow), fireIndex)
         XCTAssertEqual(CavaSettings.currentColorSchemeIndex(for: .mainWindow), iceIndex)

--- a/Tests/NullPlayerAppTests/CavaSettingsTests.swift
+++ b/Tests/NullPlayerAppTests/CavaSettingsTests.swift
@@ -60,6 +60,7 @@ final class CavaSettingsTests: XCTestCase {
 
     func testCompactWindowDefaultsToStereoWithSmoothTuning() {
         XCTAssertEqual(CavaSettings.mode(for: .compactWindow), .stereo)
+        XCTAssertEqual(CavaSettings.barCount(for: .compactWindow), CavaSettings.defaultBrowserBarCount)
         XCTAssertEqual(
             CavaSettings.noiseReduction(for: .compactWindow),
             CavaSettings.defaultCompactNoiseReduction,
@@ -75,6 +76,7 @@ final class CavaSettingsTests: XCTestCase {
 
     func testLibraryWindowDefaultsToMonoButPreservesExplicitStereo() {
         XCTAssertEqual(CavaSettings.mode(for: .libraryWindow), .mono)
+        XCTAssertEqual(CavaSettings.barCount(for: .libraryWindow), CavaSettings.defaultBrowserBarCount)
 
         CavaSettings.setMode(.stereo, for: .libraryWindow)
 
@@ -134,12 +136,23 @@ final class CavaSettingsTests: XCTestCase {
 
         XCTAssertEqual(CavaSettings.barCount(for: .libraryWindow), 48)
         XCTAssertEqual(CavaSettings.noiseReduction(for: .libraryWindow), 0.9, accuracy: 0.001)
-        XCTAssertEqual(CavaSettings.barCount(for: .compactWindow), CavaSettings.defaultBarCount)
+        XCTAssertEqual(CavaSettings.barCount(for: .compactWindow), CavaSettings.defaultBrowserBarCount)
         XCTAssertEqual(
             CavaSettings.noiseReduction(for: .compactWindow),
             CavaSettings.defaultCompactNoiseReduction,
             accuracy: 0.001
         )
+    }
+
+    func testBrowserWindowTuningResetRestoresSixtyFourBars() {
+        CavaSettings.setBarCount(16, for: .libraryWindow)
+        CavaSettings.setBarCount(24, for: .compactWindow)
+
+        CavaSettings.resetTuning(scope: .libraryWindow)
+        CavaSettings.resetTuning(scope: .compactWindow)
+
+        XCTAssertEqual(CavaSettings.barCount(for: .libraryWindow), 64)
+        XCTAssertEqual(CavaSettings.barCount(for: .compactWindow), 64)
     }
 
     func testMirroredMonoBackdropCoversBothHorizontalEdges() {

--- a/Tests/NullPlayerAppTests/VisualizationPreferencesTests.swift
+++ b/Tests/NullPlayerAppTests/VisualizationPreferencesTests.swift
@@ -87,23 +87,19 @@ final class VisualizationPreferencesTests: XCTestCase {
         XCTAssertFalse(keys.contains("cava.libraryWindow.transparentBackground"))
     }
 
-    func testCompactBackdropUsesAspectFillGeometry() {
-        let square = NSRect(x: 0, y: 0, width: 100, height: 100)
+    func testBrowserBackdropModesSeparateCavaAndLegacyArtwork() {
+        XCTAssertFalse(BrowserBackdropMode.off.showsCava)
+        XCTAssertFalse(BrowserBackdropMode.off.showsArt)
+        XCTAssertTrue(BrowserBackdropMode.cava.showsCava)
+        XCTAssertFalse(BrowserBackdropMode.cava.showsArt)
+        XCTAssertFalse(BrowserBackdropMode.art.showsCava)
+        XCTAssertTrue(BrowserBackdropMode.art.showsArt)
+        XCTAssertTrue(BrowserBackdropMode.cavaAndArt.showsCava)
+        XCTAssertTrue(BrowserBackdropMode.cavaAndArt.showsArt)
 
-        XCTAssertEqual(
-            CompactBackdropView.aspectFillRect(
-                imageSize: NSSize(width: 200, height: 100),
-                targetRect: square
-            ),
-            NSRect(x: -50, y: 0, width: 200, height: 100)
-        )
-        XCTAssertEqual(
-            CompactBackdropView.aspectFillRect(
-                imageSize: NSSize(width: 100, height: 200),
-                targetRect: square
-            ),
-            NSRect(x: 0, y: -50, width: 100, height: 200)
-        )
+        // Preserve the raw values already shipped on this branch: Album Art was 1 and Cava was 2.
+        XCTAssertEqual(BrowserBackdropMode.art.rawValue, 1)
+        XCTAssertEqual(BrowserBackdropMode.cava.rawValue, 2)
     }
 
     func testProjectMDisplayNamePreservesLegacyPreferenceValue() {

--- a/Tests/NullPlayerAppTests/VisualizationPreferencesTests.swift
+++ b/Tests/NullPlayerAppTests/VisualizationPreferencesTests.swift
@@ -88,6 +88,7 @@ final class VisualizationPreferencesTests: XCTestCase {
     }
 
     func testBrowserBackdropModesSeparateCavaAndLegacyArtwork() {
+        XCTAssertEqual(BrowserBackdropMode.defaultMode, .cavaAndArt)
         XCTAssertFalse(BrowserBackdropMode.off.showsCava)
         XCTAssertFalse(BrowserBackdropMode.off.showsArt)
         XCTAssertTrue(BrowserBackdropMode.cava.showsCava)

--- a/Tests/NullPlayerAppTests/VisualizationPreferencesTests.swift
+++ b/Tests/NullPlayerAppTests/VisualizationPreferencesTests.swift
@@ -76,12 +76,15 @@ final class VisualizationPreferencesTests: XCTestCase {
         XCTAssertEqual(defaults.string(forKey: "BrowserVisibleTrackColumns"), "keep")
     }
 
-    func testAllVisualizationResetIncludesCompactWindowCavaKeys() {
+    func testAllVisualizationResetIncludesBrowserWindowCavaKeys() {
         let keys = VisualizationPreferences.keys(for: .all)
 
         XCTAssertTrue(keys.contains("cava.compactWindow.barCount"))
         XCTAssertTrue(keys.contains("cava.compactWindow.colorsCustomized"))
         XCTAssertFalse(keys.contains("cava.compactWindow.transparentBackground"))
+        XCTAssertTrue(keys.contains("cava.libraryWindow.barCount"))
+        XCTAssertTrue(keys.contains("cava.libraryWindow.colorsCustomized"))
+        XCTAssertFalse(keys.contains("cava.libraryWindow.transparentBackground"))
     }
 
     func testCompactBackdropUsesAspectFillGeometry() {

--- a/Tests/NullPlayerAppTests/VisualizationPreferencesTests.swift
+++ b/Tests/NullPlayerAppTests/VisualizationPreferencesTests.swift
@@ -76,6 +76,33 @@ final class VisualizationPreferencesTests: XCTestCase {
         XCTAssertEqual(defaults.string(forKey: "BrowserVisibleTrackColumns"), "keep")
     }
 
+    func testAllVisualizationResetIncludesCompactWindowCavaKeys() {
+        let keys = VisualizationPreferences.keys(for: .all)
+
+        XCTAssertTrue(keys.contains("cava.compactWindow.barCount"))
+        XCTAssertTrue(keys.contains("cava.compactWindow.colorsCustomized"))
+        XCTAssertFalse(keys.contains("cava.compactWindow.transparentBackground"))
+    }
+
+    func testCompactBackdropUsesAspectFillGeometry() {
+        let square = NSRect(x: 0, y: 0, width: 100, height: 100)
+
+        XCTAssertEqual(
+            CompactBackdropView.aspectFillRect(
+                imageSize: NSSize(width: 200, height: 100),
+                targetRect: square
+            ),
+            NSRect(x: -50, y: 0, width: 200, height: 100)
+        )
+        XCTAssertEqual(
+            CompactBackdropView.aspectFillRect(
+                imageSize: NSSize(width: 100, height: 200),
+                targetRect: square
+            ),
+            NSRect(x: 0, y: -50, width: 100, height: 200)
+        )
+    }
+
     func testProjectMDisplayNamePreservesLegacyPreferenceValue() {
         XCTAssertEqual(VisualizationType.projectM.rawValue, "ProjectM (ProjectM)")
         XCTAssertEqual(VisualizationType.projectM.displayName, "ProjectM")

--- a/skills/cava/SKILL.md
+++ b/skills/cava/SKILL.md
@@ -13,6 +13,10 @@ Open **Windows > Cava** in the menu bar or right-click any main window to toggle
 Cava window. Cava is also available inside the 76×16 main-window visualization area via
 **Visuals > Main Window > Mode > Cava**.
 
+Modern and Metal Compact Window surfaces can also use Cava as a full-window backdrop via
+**Visuals > Compact Window > Cava** or the compact surface's context menu. This instance has its
+own settings scope and lifecycle; it does not borrow the standalone or main-window presenter.
+
 Cava is the shipped default for the embedded main-window visualization in every bundled modern
 skin and every built-in Metal finish. Classic UI continues to default the embedded visualization
 to `vis_classic`. A user's persisted mode still wins on a normal same-skin launch; selecting or
@@ -66,7 +70,11 @@ Output: Per-channel bar arrays in 0…1 range. The order matters: **autosens mus
 Both classic and modern views call `CavaDrawing.draw()` with current bar data, low/high colors, and mode.
 The embedded main-window instance uses its own `CavaPresenter(scope: .mainWindow)`, always renders
 mono, and has a scope-distinct audio consumer and processing queue so it can run independently beside
-the standalone window.
+the standalone window. The compact backdrop likewise uses `CavaPresenter(scope: .compactWindow)`.
+It defaults to mono so one spectrum spans the full backdrop and defaults to Smooth (`0.80`) temporal
+smoothing. Stereo remains an explicit menu choice. `CompactBackdropView` always draws into its full
+`bounds`; its frame must be the compact content container's `bounds`, not the browser view's frame,
+so resizing or an offset browser layout cannot confine the visualization to part of the window.
 
 ## Window Layout
 
@@ -87,6 +95,12 @@ the standalone window.
 - **Bass:** Bass↔treble tilt (`bandExponent`): Less (0.15) · Balanced (0.30, default) · More (0.50) · Max (0.70).
 - **Reset to Defaults:** Restores Bars / Smoothing / Bass to factory defaults (`CavaSettings.resetTuning()`); leaves mode, colors, and transparency untouched.
 - **Close:** Hide the window
+
+When Cava is the Compact Window backdrop, the same mode, color, bar-count, smoothing, bass, and reset
+controls appear under **Visuals > Compact Window** and in the compact surface's context menu.
+Transparency and Close are omitted because the backdrop is owned by the compact surface.
+Both entry points are gated by `AppCapabilities.supports(.compactWindowVisualsMenu)`; keep new
+compact-backdrop menu entry points behind the same capability.
 
 The menu is built and handled by `CavaPresenter` itself (an `NSObject` with `@objc` actions targeting `self`); the view only supplies the `onNeedsDisplay` / `onNeedsFullDisplay` / `onClose` closures. Changing Bars / Smoothing / Bass updates `CavaSettings`; `CavaRenderModel.settingsDidChange()` applies the change immediately and rebuilds `CavaCore` when bar count, sample rate, `noiseReduction`, or `bassTilt` differs.
 
@@ -114,12 +128,13 @@ Durable UserDefaults-backed preferences:
 
 Access via `CavaSettings.mode`, `CavaSettings.barCount`, etc. Menu and double-click changes take effect immediately; settings that alter DSP construction recreate CavaCore through `settingsDidChange()`.
 
-`CavaSettings.Scope` separates `.cavaWindow` from `.mainWindow`. The legacy static properties above
-remain wrappers for `.cavaWindow` and continue using the existing keys. Scope-aware accessors use
-`cava.mainWindow.*` keys for the embedded analyzer; its mode accessor always resolves to mono.
-Main-window tuning and color choices are reset with the centralized Main Window visualization reset
-and never modify the standalone window. Bar-count, smoothing, and bass menu presets are canonical
-`CavaSettings` collections shared by both menu builders.
+`CavaSettings.Scope` separates `.cavaWindow`, `.mainWindow`, and `.compactWindow`. The legacy static
+properties above remain wrappers for `.cavaWindow` and continue using the existing keys. Scope-aware
+accessors use `cava.mainWindow.*` for the embedded analyzer and `cava.compactWindow.*` for the compact
+backdrop. Main-window mode always resolves to mono. Compact mode defaults to mono but preserves an
+explicit stereo choice; compact smoothing defaults to `0.80`, while the other scopes default to
+`0.65`. Main-window and compact tuning/color choices never modify the standalone window. Bar-count,
+smoothing, and bass menu presets are canonical `CavaSettings` collections shared by the presenters.
 
 ## Visualization Reset and UI-Family Switches
 
@@ -127,9 +142,11 @@ and never modify the standalone window. Bar-count, smoothing, and bass menu pres
 
 Cava colors fall back to the active skin's gradient, pushed by `ModernCavaView` or `CavaView`.
 The embedded main-window Cava keys (`.mainWindow`) live in
-`VisualizationPreferences.mainWindowKeys`. The standalone window keys
+`VisualizationPreferences.mainWindowKeys`. Compact backdrop keys (`.compactWindow`) live in the
+compact visualization reset set. The standalone window keys
 (`CavaSettings.preferenceKeys(for: .cavaWindow)`) live in `cavaWindowKeys`, which is included
-only in the `.all` reset scope.
+only in the `.all` reset scope. Reset All clears all three scopes and restores the compact scope's
+mono/Smooth first-use defaults.
 
 `VisualizationPreferences.reset(.all)` therefore resets both Cava scopes. Its notification
 phase calls `WindowManager.refreshCavaWindowAfterReset()` and then the open controller's
@@ -179,6 +196,8 @@ written by older reset logic without discarding a real user choice.
 | `App/ContextMenuBuilder.swift` | Menu item: "Cava" in Windows menu + `toggleCava()` action |
 | `Windows/MainWindow/MainWindowView.swift` | Classic inline Cava rendering + lifecycle |
 | `Windows/ModernMainWindow/ModernMainWindowView.swift` | Modern inline Cava rendering + lifecycle |
+| `Windows/ModernLibraryBrowser/CompactBackdropView.swift` | Compact Cava presenter, lifecycle, and full-surface drawing |
+| `Windows/ModernLibraryBrowser/ModernLibraryBrowserView.swift` | Compact backdrop sizing, translucency, menus, and artwork routing |
 | `App/AppStateManager.swift` | State capture/restore: `isCavaVisible`, `cavaWindowFrame` |
 | `NullPlayerCore/Audio/CavaCore.swift` | DSP engine (pure Swift vDSP FFT + smoothing) |
 

--- a/skills/cava/SKILL.md
+++ b/skills/cava/SKILL.md
@@ -79,6 +79,10 @@ defaults to Stereo with Smooth (`0.80`) temporal smoothing. Backdrop Mono is cen
 the combined spectrum occupies the full width. `CompactBackdropView` always draws into its full
 `bounds`; its frame must be the window content container's `bounds`, not the browser view's frame,
 so resizing or an offset browser layout cannot confine the visualization to part of the window.
+On the first Off → Cava transition, invalidate and lay out the complete backdrop/browser sibling
+subtree immediately and again on the next main-run-loop turn. The browser was previously rendered
+opaque, and an ordinary view-only invalidation can leave a horizontal region of cached opaque
+content covering either Mono or Stereo until the window is reconstructed.
 
 ## Window Layout
 

--- a/skills/cava/SKILL.md
+++ b/skills/cava/SKILL.md
@@ -17,6 +17,8 @@ Modern and Metal Library and Compact Window surfaces can also use Cava as a full
 via **Visuals > Library Window > Cava**, **Visuals > Compact Window > Cava**, or the corresponding
 surface's context menu. Each backdrop has its own settings scope and lifecycle; neither borrows the
 standalone or main-window presenter.
+The window menus expose **Cava**, **Art**, and **Cava + Art** separately. Art always uses the legacy
+browser list-area renderer and geometry; there is no second full-window artwork renderer.
 
 Cava is the shipped default for the embedded main-window visualization in every bundled modern
 skin and every built-in Metal finish. Classic UI continues to default the embedded visualization
@@ -83,6 +85,8 @@ On the first Off → Cava transition, invalidate and lay out the complete backdr
 subtree immediately and again on the next main-run-loop turn. The browser was previously rendered
 opaque, and an ordinary view-only invalidation can leave a horizontal region of cached opaque
 content covering either Mono or Stereo until the window is reconstructed.
+Art-only does not create `CompactBackdropView`. Cava + Art keeps Cava in that full-window sibling
+while the browser draws exactly one legacy-sized artwork image in its established list-area path.
 
 ## Window Layout
 

--- a/skills/cava/SKILL.md
+++ b/skills/cava/SKILL.md
@@ -13,9 +13,10 @@ Open **Windows > Cava** in the menu bar or right-click any main window to toggle
 Cava window. Cava is also available inside the 76×16 main-window visualization area via
 **Visuals > Main Window > Mode > Cava**.
 
-Modern and Metal Compact Window surfaces can also use Cava as a full-window backdrop via
-**Visuals > Compact Window > Cava** or the compact surface's context menu. This instance has its
-own settings scope and lifecycle; it does not borrow the standalone or main-window presenter.
+Modern and Metal Library and Compact Window surfaces can also use Cava as a full-window backdrop
+via **Visuals > Library Window > Cava**, **Visuals > Compact Window > Cava**, or the corresponding
+surface's context menu. Each backdrop has its own settings scope and lifecycle; neither borrows the
+standalone or main-window presenter.
 
 Cava is the shipped default for the embedded main-window visualization in every bundled modern
 skin and every built-in Metal finish. Classic UI continues to default the embedded visualization
@@ -58,6 +59,8 @@ Output: Per-channel bar arrays in 0…1 range. The order matters: **autosens mus
 - Interpolates each bar's color between the low- and high-**intensity** colors by bar height (not by frequency)
 - Draws solid rectangles per bar with subtle borders for definition
 - Handles both mono (single row) and stereo (mirrored L/R) layouts
+- Supports a center-out mirrored mono layout for full-window backdrops, duplicating the combined
+  spectrum across both horizontal halves so the visualization fills the complete width
 
 `CavaRenderModel` drives a **60 Hz scheduler** on the main thread while confining all DSP to one serial worker queue:
 - The audio tap (~21 Hz) *stashes* the latest L/R buffer. On the next tick the worker calls `CavaCore.analyze(_:)` (the FFTs) **once per new buffer**, then `CavaCore.render()` (monstercat/smoothing/autosens/gravity) on render ticks so decay/smoothing advance at the display rate. Only the finished bar arrays return to the main thread. `execute(_:)` (= `analyze` + `render`) is kept for tests/one-shot callers.
@@ -70,10 +73,11 @@ Output: Per-channel bar arrays in 0…1 range. The order matters: **autosens mus
 Both classic and modern views call `CavaDrawing.draw()` with current bar data, low/high colors, and mode.
 The embedded main-window instance uses its own `CavaPresenter(scope: .mainWindow)`, always renders
 mono, and has a scope-distinct audio consumer and processing queue so it can run independently beside
-the standalone window. The compact backdrop likewise uses `CavaPresenter(scope: .compactWindow)`.
-It defaults to mono so one spectrum spans the full backdrop and defaults to Smooth (`0.80`) temporal
-smoothing. Stereo remains an explicit menu choice. `CompactBackdropView` always draws into its full
-`bounds`; its frame must be the compact content container's `bounds`, not the browser view's frame,
+the standalone window. The Library and Compact backdrops use `CavaPresenter(scope: .libraryWindow)`
+and `CavaPresenter(scope: .compactWindow)` respectively. Library defaults to Mono and Compact
+defaults to Stereo with Smooth (`0.80`) temporal smoothing. Backdrop Mono is center-out mirrored so
+the combined spectrum occupies the full width. `CompactBackdropView` always draws into its full
+`bounds`; its frame must be the window content container's `bounds`, not the browser view's frame,
 so resizing or an offset browser layout cannot confine the visualization to part of the window.
 
 ## Window Layout
@@ -96,11 +100,11 @@ so resizing or an offset browser layout cannot confine the visualization to part
 - **Reset to Defaults:** Restores Bars / Smoothing / Bass to factory defaults (`CavaSettings.resetTuning()`); leaves mode, colors, and transparency untouched.
 - **Close:** Hide the window
 
-When Cava is the Compact Window backdrop, the same mode, color, bar-count, smoothing, bass, and reset
-controls appear under **Visuals > Compact Window** and in the compact surface's context menu.
-Transparency and Close are omitted because the backdrop is owned by the compact surface.
-Both entry points are gated by `AppCapabilities.supports(.compactWindowVisualsMenu)`; keep new
-compact-backdrop menu entry points behind the same capability.
+When Cava is a Library or Compact Window backdrop, the same mode, color, bar-count, smoothing, bass,
+and reset controls appear under the corresponding **Visuals** submenu and in that surface's context
+menu. Transparency and Close are omitted because the backdrop is owned by its browser surface.
+Compact entry points are gated by `AppCapabilities.supports(.compactWindowVisualsMenu)`; keep new
+Compact Window backdrop menu entry points behind the same capability.
 
 The menu is built and handled by `CavaPresenter` itself (an `NSObject` with `@objc` actions targeting `self`); the view only supplies the `onNeedsDisplay` / `onNeedsFullDisplay` / `onClose` closures. Changing Bars / Smoothing / Bass updates `CavaSettings`; `CavaRenderModel.settingsDidChange()` applies the change immediately and rebuilds `CavaCore` when bar count, sample rate, `noiseReduction`, or `bassTilt` differs.
 
@@ -128,13 +132,15 @@ Durable UserDefaults-backed preferences:
 
 Access via `CavaSettings.mode`, `CavaSettings.barCount`, etc. Menu and double-click changes take effect immediately; settings that alter DSP construction recreate CavaCore through `settingsDidChange()`.
 
-`CavaSettings.Scope` separates `.cavaWindow`, `.mainWindow`, and `.compactWindow`. The legacy static
-properties above remain wrappers for `.cavaWindow` and continue using the existing keys. Scope-aware
-accessors use `cava.mainWindow.*` for the embedded analyzer and `cava.compactWindow.*` for the compact
-backdrop. Main-window mode always resolves to mono. Compact mode defaults to mono but preserves an
-explicit stereo choice; compact smoothing defaults to `0.80`, while the other scopes default to
-`0.65`. Main-window and compact tuning/color choices never modify the standalone window. Bar-count,
-smoothing, and bass menu presets are canonical `CavaSettings` collections shared by the presenters.
+`CavaSettings.Scope` separates `.cavaWindow`, `.mainWindow`, `.libraryWindow`, and `.compactWindow`.
+The legacy static properties above remain wrappers for `.cavaWindow` and continue using the existing
+keys. Scope-aware accessors use `cava.mainWindow.*` for the embedded analyzer,
+`cava.libraryWindow.*` for the regular Library backdrop, and `cava.compactWindow.*` for the Compact
+backdrop. Main-window mode always resolves to Mono. Library mode defaults to Mono, while Compact
+mode defaults to Stereo; both preserve an explicit mode choice. Compact smoothing defaults to
+`0.80`, while the other scopes default to `0.65`. Each scope's tuning and color choices are
+independent. Bar-count, smoothing, and bass menu presets are canonical `CavaSettings` collections
+shared by the presenters.
 
 ## Visualization Reset and UI-Family Switches
 
@@ -142,13 +148,13 @@ smoothing, and bass menu presets are canonical `CavaSettings` collections shared
 
 Cava colors fall back to the active skin's gradient, pushed by `ModernCavaView` or `CavaView`.
 The embedded main-window Cava keys (`.mainWindow`) live in
-`VisualizationPreferences.mainWindowKeys`. Compact backdrop keys (`.compactWindow`) live in the
-compact visualization reset set. The standalone window keys
-(`CavaSettings.preferenceKeys(for: .cavaWindow)`) live in `cavaWindowKeys`, which is included
-only in the `.all` reset scope. Reset All clears all three scopes and restores the compact scope's
-mono/Smooth first-use defaults.
+`VisualizationPreferences.mainWindowKeys`. Library (`.libraryWindow`) and Compact
+(`.compactWindow`) backdrop keys live in their visualization reset sets. The standalone window keys
+(`CavaSettings.preferenceKeys(for: .cavaWindow)`) live in `cavaWindowKeys`, which is included only
+in the `.all` reset scope. Reset All clears all four scopes and restores Library's Mono default and
+Compact's Stereo/Smooth first-use defaults.
 
-`VisualizationPreferences.reset(.all)` therefore resets both Cava scopes. Its notification
+`VisualizationPreferences.reset(.all)` therefore resets every Cava scope. Its notification
 phase calls `WindowManager.refreshCavaWindowAfterReset()` and then the open controller's
 `refreshAfterReset()`. The view re-reads tuning with `presenter.settingsDidChange()` and
 re-derives the active skin's default gradient through `skinDidChange()`. The standalone
@@ -156,11 +162,11 @@ window is intentionally not included in `.mainWindow` or `.spectrumWindow` reset
 
 ### Skin-Owned Appearance Across UI Families
 
-`CavaSettings.hasCustomColors` is persisted independently for `.cavaWindow` and `.mainWindow`.
+`CavaSettings.hasCustomColors` is persisted independently for every Cava scope.
 When a scope is customized, `effectiveLowColor` and `effectiveHighColor` ignore that scope's
 in-memory skin default. `CavaSettings.transparentBackground` applies only to the standalone
 modern/metal window. An explicit UI-family switch is a skin change and calls
-`CavaSettings.resetAppearanceForSkinChange(transparentBackground:)`, which clears both custom-color
+`CavaSettings.resetAppearanceForSkinChange(transparentBackground:)`, which clears all custom-color
 flags and applies the incoming skin's Cava transparency default. Modern skins derive that default
 from `window.opacity < 1`; classic passes false:
 
@@ -196,8 +202,8 @@ written by older reset logic without discarding a real user choice.
 | `App/ContextMenuBuilder.swift` | Menu item: "Cava" in Windows menu + `toggleCava()` action |
 | `Windows/MainWindow/MainWindowView.swift` | Classic inline Cava rendering + lifecycle |
 | `Windows/ModernMainWindow/ModernMainWindowView.swift` | Modern inline Cava rendering + lifecycle |
-| `Windows/ModernLibraryBrowser/CompactBackdropView.swift` | Compact Cava presenter, lifecycle, and full-surface drawing |
-| `Windows/ModernLibraryBrowser/ModernLibraryBrowserView.swift` | Compact backdrop sizing, translucency, menus, and artwork routing |
+| `Windows/ModernLibraryBrowser/CompactBackdropView.swift` | Shared Library/Compact Cava presenter, lifecycle, and full-surface drawing |
+| `Windows/ModernLibraryBrowser/ModernLibraryBrowserView.swift` | Library/Compact backdrop sizing, translucency, menus, and artwork routing |
 | `App/AppStateManager.swift` | State capture/restore: `isCavaVisible`, `cavaWindowFrame` |
 | `NullPlayerCore/Audio/CavaCore.swift` | DSP engine (pure Swift vDSP FFT + smoothing) |
 
@@ -290,7 +296,7 @@ overwriting an explicit user override.
 Cava's *default* gradient tracks the active skin; a user pick (via the Color menu) overrides it until
 they choose **Match Skin** or explicitly switch/reset skins. A same-skin app relaunch preserves the pick:
 - `CavaSettings.hasCustomColors` (UserDefaults) gates this. `effectiveLowColor`/`effectiveHighColor` return the user's stored colors when true, otherwise the in-memory skin default.
-- Explicit modern skin changes clear both Cava scopes from
+- Explicit modern skin changes clear every Cava scope from
   `ModernSkinEngine.configureSkinDependencies(preservePersistedProfiles:)` when persisted profiles are
   not being preserved. Explicit classic loads clear them from `WindowManager.loadSkin(from:)` and
   `loadBundledDefaultSkin()`; launch restoration uses the preserving `restoreClassicSkin(from:)` path.

--- a/skills/cava/SKILL.md
+++ b/skills/cava/SKILL.md
@@ -18,7 +18,8 @@ via **Visuals > Library Window > Cava**, **Visuals > Compact Window > Cava**, or
 surface's context menu. Each backdrop has its own settings scope and lifecycle; neither borrows the
 standalone or main-window presenter.
 The window menus expose **Cava**, **Art**, and **Cava + Art** separately. Art always uses the legacy
-browser list-area renderer and geometry; there is no second full-window artwork renderer.
+browser list-area renderer and geometry; there is no second full-window artwork renderer. Both
+windows default to **Cava + Art** on first use while preserving an existing saved selection.
 
 Cava is the shipped default for the embedded main-window visualization in every bundled modern
 skin and every built-in Metal finish. Classic UI continues to default the embedded visualization
@@ -77,9 +78,10 @@ The embedded main-window instance uses its own `CavaPresenter(scope: .mainWindow
 mono, and has a scope-distinct audio consumer and processing queue so it can run independently beside
 the standalone window. The Library and Compact backdrops use `CavaPresenter(scope: .libraryWindow)`
 and `CavaPresenter(scope: .compactWindow)` respectively. Library defaults to Mono and Compact
-defaults to Stereo with Smooth (`0.80`) temporal smoothing. Backdrop Mono is center-out mirrored so
-the combined spectrum occupies the full width. `CompactBackdropView` always draws into its full
-`bounds`; its frame must be the window content container's `bounds`, not the browser view's frame,
+defaults to Stereo with Smooth (`0.80`) temporal smoothing. Both browser scopes default to 64 bars.
+Backdrop Mono is center-out mirrored so the combined spectrum occupies the full width.
+`CompactBackdropView` always draws into its full `bounds`; its frame must be the window content
+container's `bounds`, not the browser view's frame,
 so resizing or an offset browser layout cannot confine the visualization to part of the window.
 On the first Off → Cava transition, invalidate and lay out the complete backdrop/browser sibling
 subtree immediately and again on the next main-run-loop turn. The browser was previously rendered
@@ -146,9 +148,10 @@ keys. Scope-aware accessors use `cava.mainWindow.*` for the embedded analyzer,
 `cava.libraryWindow.*` for the regular Library backdrop, and `cava.compactWindow.*` for the Compact
 backdrop. Main-window mode always resolves to Mono. Library mode defaults to Mono, while Compact
 mode defaults to Stereo; both preserve an explicit mode choice. Compact smoothing defaults to
-`0.80`, while the other scopes default to `0.65`. Each scope's tuning and color choices are
-independent. Bar-count, smoothing, and bass menu presets are canonical `CavaSettings` collections
-shared by the presenters.
+`0.80`, while the other scopes default to `0.65`. Library and Compact bar count defaults to `64`;
+standalone and main-window Cava remain at `32`. Each scope's tuning and color choices are independent.
+Bar-count, smoothing, and bass menu presets are canonical `CavaSettings` collections shared by the
+presenters.
 
 ## Visualization Reset and UI-Family Switches
 
@@ -159,8 +162,8 @@ The embedded main-window Cava keys (`.mainWindow`) live in
 `VisualizationPreferences.mainWindowKeys`. Library (`.libraryWindow`) and Compact
 (`.compactWindow`) backdrop keys live in their visualization reset sets. The standalone window keys
 (`CavaSettings.preferenceKeys(for: .cavaWindow)`) live in `cavaWindowKeys`, which is included only
-in the `.all` reset scope. Reset All clears all four scopes and restores Library's Mono default and
-Compact's Stereo/Smooth first-use defaults.
+in the `.all` reset scope. Reset All clears all four scopes and restores Library's Mono/64-bar
+default and Compact's Stereo/Smooth/64-bar first-use defaults.
 
 `VisualizationPreferences.reset(.all)` therefore resets every Cava scope. Its notification
 phase calls `WindowManager.refreshCavaWindowAfterReset()` and then the open controller's

--- a/skills/ui-guide/SKILL.md
+++ b/skills/ui-guide/SKILL.md
@@ -816,6 +816,36 @@ Implementation rules:
 - Live UI switching should exit Compact Window, rebuild the mode-dependent window layer, then
   re-enter Compact Window so the embedded classic/modern compact surface matches the new mode.
 
+### Compact Window visual backdrops (Modern/Metal)
+
+The modern compact surface supports a durable `compactBackdropMode`: **Off**, **Album Art**, or
+**Cava**. The controls live under **Visuals > Compact Window** and in the compact surface's context
+menus. Classic resolves the mode to Off.
+
+Implementation rules:
+- `ModernLibraryBrowserWindowController` installs a clear container as the window content view.
+  `CompactBackdropView` and `ModernLibraryBrowserView` are siblings, with the backdrop positioned
+  below the browser. Do not make the backdrop a child of the browser; the browser's layer clipping
+  and redraw behavior would clip or erase it.
+- Size the backdrop from the content container's `bounds` on creation and every layout pass. Do not
+  copy the browser's `frame`: an offset or partially sized browser frame can restrict Cava or album
+  art to one side of the compact window. Keep the backdrop autoresizing in width and height.
+- The browser remains above the backdrop and uses translucent background/panel fills while a
+  backdrop is active. Text, controls, borders, and hit testing remain browser-owned and fully
+  interactive. `CompactBackdropView.hitTest` returns `nil`.
+- Album Art follows the playing track, not the selected browser row. Keep current-track artwork and
+  its load task separate from selection-driven browser artwork; cancel both paths during UI teardown.
+- Cava uses `CavaPresenter(scope: .compactWindow)` and draws into the backdrop's complete `bounds`.
+  Its first-use defaults are Mono and Smooth (`noiseReduction = 0.80`); explicit Stereo remains
+  supported. Start its audio consumer only while Cava is selected and the compact window is visible,
+  non-miniaturized, and on-screen; stop it for Off, Album Art, hide, occlusion, and teardown.
+- The compact Cava menu omits standalone-only Transparency and Close actions. Compact tuning and
+  colors use `cava.compactWindow.*` keys and participate in visualization reset independently.
+- Every Compact Window visuals menu entry point must check
+  `AppCapabilities.supports(.compactWindowVisualsMenu)`: the top-level Visuals submenu, compact
+  surface context-menu injection, the shared menu builder, and its selection action. This is a UI
+  visibility seam only; backdrop rendering and persisted mode resolution remain independent.
+
 ## Window Docking
 
 Complex snapping logic in `WindowManager`:

--- a/skills/ui-guide/SKILL.md
+++ b/skills/ui-guide/SKILL.md
@@ -818,8 +818,8 @@ Implementation rules:
 
 ### Library and Compact Window visual backdrops (Modern/Metal)
 
-The regular Library and Compact surfaces each support a durable backdrop mode: **Off**,
-**Album Art**, or **Cava**. They persist independently as `libraryBackdropMode` and
+The regular Library and Compact surfaces each support a durable visual mode: **Off**, **Cava**,
+**Art**, or **Cava + Art**. They persist independently as `libraryBackdropMode` and
 `compactBackdropMode`. Controls live under **Visuals > Library Window** or
 **Visuals > Compact Window** and in the corresponding surface's context menus. Classic resolves
 both modes to Off.
@@ -830,8 +830,8 @@ Implementation rules:
   presentations, with the backdrop positioned below the browser. Do not make the backdrop a child
   of the browser; the browser's layer clipping and redraw behavior would clip or erase it.
 - Size the backdrop from the content container's `bounds` on creation and every layout pass. Do not
-  copy the browser's `frame`: an offset or partially sized browser frame can restrict Cava or album
-  art to one side of the compact window. Keep the backdrop autoresizing in width and height.
+  copy the browser's `frame`: an offset or partially sized browser frame can restrict Cava to one
+  side of the compact window. Keep the backdrop autoresizing in width and height.
 - When a backdrop is first selected from Off, mark the complete container subtree for display and
   layout immediately and again on the next main-run-loop turn. This transition changes the browser
   from an opaque cached surface into a translucent sibling composition; invalidating only the
@@ -839,15 +839,17 @@ Implementation rules:
 - The browser remains above the backdrop and uses translucent background/panel fills while a
   backdrop is active. Text, controls, borders, and hit testing remain browser-owned and fully
   interactive. `CompactBackdropView.hitTest` returns `nil`.
-- Album Art follows the playing track, not the selected browser row. Keep current-track artwork and
-  its load task separate from selection-driven browser artwork; cancel both paths during UI teardown.
+- Art and Cava + Art must use the existing legacy browser artwork renderer and its list-area
+  geometry. Never add a full-window/aspect-fill artwork sibling: it duplicates the legacy image and
+  changes its established size. Art creates no backdrop sibling; Cava + Art draws the one legacy
+  artwork image in the browser above the Cava sibling.
 - Cava uses `CavaPresenter(scope: .libraryWindow)` in the regular Library and
   `CavaPresenter(scope: .compactWindow)` in Compact. It draws into the backdrop's complete `bounds`.
   Library's first-use mode is Mono. Compact's first-use mode is Stereo and its smoothing is Smooth
   (`noiseReduction = 0.80`). In backdrop Mono, mirror the combined spectrum center-out across both
   horizontal halves; a one-way frequency sweep can look like half the surface is unused. Start the
   audio consumer only while Cava is selected and the owning window is visible, non-miniaturized,
-  and on-screen; stop it for Off, Album Art, hide, occlusion, and teardown.
+  and on-screen; stop it for Off, Art, hide, occlusion, and teardown.
 - Backdrop Cava menus omit standalone-only Transparency and Close actions. Library and Compact
   tuning/colors use `cava.libraryWindow.*` and `cava.compactWindow.*` keys and participate in
   visualization reset independently.

--- a/skills/ui-guide/SKILL.md
+++ b/skills/ui-guide/SKILL.md
@@ -832,6 +832,10 @@ Implementation rules:
 - Size the backdrop from the content container's `bounds` on creation and every layout pass. Do not
   copy the browser's `frame`: an offset or partially sized browser frame can restrict Cava or album
   art to one side of the compact window. Keep the backdrop autoresizing in width and height.
+- When a backdrop is first selected from Off, mark the complete container subtree for display and
+  layout immediately and again on the next main-run-loop turn. This transition changes the browser
+  from an opaque cached surface into a translucent sibling composition; invalidating only the
+  browser can leave a horizontal cached region covering the backdrop until relaunch.
 - The browser remains above the backdrop and uses translucent background/panel fills while a
   backdrop is active. Text, controls, borders, and hit testing remain browser-owned and fully
   interactive. `CompactBackdropView.hitTest` returns `nil`.

--- a/skills/ui-guide/SKILL.md
+++ b/skills/ui-guide/SKILL.md
@@ -822,7 +822,8 @@ The regular Library and Compact surfaces each support a durable visual mode: **O
 **Art**, or **Cava + Art**. They persist independently as `libraryBackdropMode` and
 `compactBackdropMode`. Controls live under **Visuals > Library Window** or
 **Visuals > Compact Window** and in the corresponding surface's context menus. Classic resolves
-both modes to Off.
+both modes to Off. Modern and Metal default both windows to **Cava + Art** on first use; persisted
+window-specific selections still win.
 
 Implementation rules:
 - `ModernLibraryBrowserWindowController` installs a clear container as the window content view.
@@ -845,11 +846,12 @@ Implementation rules:
   artwork image in the browser above the Cava sibling.
 - Cava uses `CavaPresenter(scope: .libraryWindow)` in the regular Library and
   `CavaPresenter(scope: .compactWindow)` in Compact. It draws into the backdrop's complete `bounds`.
-  Library's first-use mode is Mono. Compact's first-use mode is Stereo and its smoothing is Smooth
-  (`noiseReduction = 0.80`). In backdrop Mono, mirror the combined spectrum center-out across both
-  horizontal halves; a one-way frequency sweep can look like half the surface is unused. Start the
-  audio consumer only while Cava is selected and the owning window is visible, non-miniaturized,
-  and on-screen; stop it for Off, Art, hide, occlusion, and teardown.
+  Both scopes default to 64 bars. Library's first-use mode is Mono. Compact's first-use mode is
+  Stereo and its smoothing is Smooth (`noiseReduction = 0.80`). In backdrop Mono, mirror the
+  combined spectrum center-out across both horizontal halves; a one-way frequency sweep can look
+  like half the surface is unused. Start the audio consumer only while Cava is selected and the
+  owning window is visible, non-miniaturized, and on-screen; stop it for Off, Art, hide, occlusion,
+  and teardown.
 - Backdrop Cava menus omit standalone-only Transparency and Close actions. Library and Compact
   tuning/colors use `cava.libraryWindow.*` and `cava.compactWindow.*` keys and participate in
   visualization reset independently.

--- a/skills/ui-guide/SKILL.md
+++ b/skills/ui-guide/SKILL.md
@@ -816,17 +816,19 @@ Implementation rules:
 - Live UI switching should exit Compact Window, rebuild the mode-dependent window layer, then
   re-enter Compact Window so the embedded classic/modern compact surface matches the new mode.
 
-### Compact Window visual backdrops (Modern/Metal)
+### Library and Compact Window visual backdrops (Modern/Metal)
 
-The modern compact surface supports a durable `compactBackdropMode`: **Off**, **Album Art**, or
-**Cava**. The controls live under **Visuals > Compact Window** and in the compact surface's context
-menus. Classic resolves the mode to Off.
+The regular Library and Compact surfaces each support a durable backdrop mode: **Off**,
+**Album Art**, or **Cava**. They persist independently as `libraryBackdropMode` and
+`compactBackdropMode`. Controls live under **Visuals > Library Window** or
+**Visuals > Compact Window** and in the corresponding surface's context menus. Classic resolves
+both modes to Off.
 
 Implementation rules:
 - `ModernLibraryBrowserWindowController` installs a clear container as the window content view.
-  `CompactBackdropView` and `ModernLibraryBrowserView` are siblings, with the backdrop positioned
-  below the browser. Do not make the backdrop a child of the browser; the browser's layer clipping
-  and redraw behavior would clip or erase it.
+  `CompactBackdropView` and `ModernLibraryBrowserView` are siblings in both regular and Compact
+  presentations, with the backdrop positioned below the browser. Do not make the backdrop a child
+  of the browser; the browser's layer clipping and redraw behavior would clip or erase it.
 - Size the backdrop from the content container's `bounds` on creation and every layout pass. Do not
   copy the browser's `frame`: an offset or partially sized browser frame can restrict Cava or album
   art to one side of the compact window. Keep the backdrop autoresizing in width and height.
@@ -835,12 +837,16 @@ Implementation rules:
   interactive. `CompactBackdropView.hitTest` returns `nil`.
 - Album Art follows the playing track, not the selected browser row. Keep current-track artwork and
   its load task separate from selection-driven browser artwork; cancel both paths during UI teardown.
-- Cava uses `CavaPresenter(scope: .compactWindow)` and draws into the backdrop's complete `bounds`.
-  Its first-use defaults are Mono and Smooth (`noiseReduction = 0.80`); explicit Stereo remains
-  supported. Start its audio consumer only while Cava is selected and the compact window is visible,
-  non-miniaturized, and on-screen; stop it for Off, Album Art, hide, occlusion, and teardown.
-- The compact Cava menu omits standalone-only Transparency and Close actions. Compact tuning and
-  colors use `cava.compactWindow.*` keys and participate in visualization reset independently.
+- Cava uses `CavaPresenter(scope: .libraryWindow)` in the regular Library and
+  `CavaPresenter(scope: .compactWindow)` in Compact. It draws into the backdrop's complete `bounds`.
+  Library's first-use mode is Mono. Compact's first-use mode is Stereo and its smoothing is Smooth
+  (`noiseReduction = 0.80`). In backdrop Mono, mirror the combined spectrum center-out across both
+  horizontal halves; a one-way frequency sweep can look like half the surface is unused. Start the
+  audio consumer only while Cava is selected and the owning window is visible, non-miniaturized,
+  and on-screen; stop it for Off, Album Art, hide, occlusion, and teardown.
+- Backdrop Cava menus omit standalone-only Transparency and Close actions. Library and Compact
+  tuning/colors use `cava.libraryWindow.*` and `cava.compactWindow.*` keys and participate in
+  visualization reset independently.
 - Every Compact Window visuals menu entry point must check
   `AppCapabilities.supports(.compactWindowVisualsMenu)`: the top-level Visuals submenu, compact
   surface context-menu injection, the shared menu builder, and its selection action. This is a UI


### PR DESCRIPTION
## Summary
- add independently persisted Off, Cava, Art, and Cava + Art modes for Modern and Metal Library and Compact windows
- render Cava beneath the translucent browser surface with independent Library and Compact settings and lifecycle
- use the established legacy list-area artwork renderer for both Art and Cava + Art, with no second full-window artwork image
- mirror backdrop Mono center-out so the combined spectrum fills both horizontal halves
- force a complete sibling layout/redraw when Cava is first selected so cached opaque regions cannot cover Mono or Stereo
- default both windows to Cava + Art and 64 bars; Library Cava uses Mono, while Compact Cava uses Stereo with Smooth tuning; existing saved choices remain authoritative
- expose controls in the menu-bar Visuals menu and surface context menus, including the Compact menu capability seam
- update the Cava and UI technical guides with the modes, artwork geometry rule, defaults, scopes, layout, menus, and lifecycle

## Testing
- `swift test` (394 tests, 0 failures)
- focused mode-combination, raw-value compatibility, Cava settings/default/reset, mirrored-mono geometry, menu, and visualization-reset coverage
- `git diff --check`
