### PR TITLE
Fix local video add/drag and large-file cast crash (0.29.7)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,12 @@
 # Changelog
 
+## 0.29.7
+
+### Bug Fixes
+
+- **Adding and dragging local video files now works everywhere** — Dropping a video onto the main player window (Modern or Classic skin) now starts it in the video player; dropping a video onto the Library window adds it to Movies and switches to that tab; and **Add Video Files…** jumps to the Movies tab so the import is actually visible, with a file picker that no longer greys out `.mkv`/`.avi`/`.webm`/`.ts`. Local video is now recognized by file extension as well as by probing the container, so formats AVFoundation cannot parse (`.mkv`, `.avi`, `.webm`) are no longer misrouted to the audio engine and silently dropped.
+- **Casting large local media no longer crashes the app** — the built-in media server served files by reading the entire file into memory, so casting a multi-gigabyte movie (a Chromecast requests the whole file up front) exhausted memory and the process was killed the instant playback started. Local files are now streamed to cast devices in bounded 256 KB chunks for both full and range (seek) requests, so memory stays flat regardless of file size.
+
 ## 0.29.6
 
 ### New Features

--- a/Sources/NullPlayer/Casting/LocalMediaServer.swift
+++ b/Sources/NullPlayer/Casting/LocalMediaServer.swift
@@ -188,38 +188,39 @@ class LocalMediaServer {
     private struct FileByteStream: AsyncBufferedSequence, @unchecked Sendable {
         typealias Element = UInt8
 
-        let fileURL: URL
-        let startOffset: UInt64
+        let fileHandle: FileHandle
         let length: Int64
         static let chunkSize = 256 * 1024
 
+        init(fileURL: URL, startOffset: UInt64, length: Int64) throws {
+            let fileHandle = try FileHandle(forReadingFrom: fileURL)
+            do {
+                try fileHandle.seek(toOffset: startOffset)
+            } catch {
+                try? fileHandle.close()
+                throw error
+            }
+            self.fileHandle = fileHandle
+            self.length = length
+        }
+
         func makeAsyncIterator() -> Iterator {
-            Iterator(fileURL: fileURL, startOffset: startOffset, length: length)
+            Iterator(fileHandle: fileHandle, length: length)
         }
 
         struct Iterator: AsyncBufferedIteratorProtocol {
-            private let fileHandle: FileHandle?
-            private let startOffset: UInt64
+            private let fileHandle: FileHandle
             private var remaining: Int64
-            private var didSeek = false
             private var leftover: [UInt8] = []
             private var leftoverIndex = 0
 
-            init(fileURL: URL, startOffset: UInt64, length: Int64) {
-                self.fileHandle = try? FileHandle(forReadingFrom: fileURL)
-                self.startOffset = startOffset
+            init(fileHandle: FileHandle, length: Int64) {
+                self.fileHandle = fileHandle
                 self.remaining = length
             }
 
-            private mutating func seekIfNeeded() {
-                guard !didSeek else { return }
-                didSeek = true
-                try? fileHandle?.seek(toOffset: startOffset)
-            }
-
             mutating func nextBuffer(suggested count: Int) async throws -> [UInt8]? {
-                guard let fileHandle, remaining > 0 else { return nil }
-                seekIfNeeded()
+                guard remaining > 0 else { return nil }
                 let cap = Swift.max(1, Swift.min(count, FileByteStream.chunkSize))
                 let toRead = Int(Swift.min(Int64(cap), remaining))
                 guard let data = try fileHandle.read(upToCount: toRead), !data.isEmpty else {
@@ -896,7 +897,13 @@ class LocalMediaServer {
         // OOM-killed with no crash log.
         NSLog("LocalMediaServer: Serving full file %@ (%lld bytes)", url.lastPathComponent, fileSize)
 
-        let stream = FileByteStream(fileURL: url, startOffset: 0, length: fileSize)
+        let stream: FileByteStream
+        do {
+            stream = try FileByteStream(fileURL: url, startOffset: 0, length: fileSize)
+        } catch {
+            NSLog("LocalMediaServer: Failed to open file stream for %@: %@", url.path, error.localizedDescription)
+            return HTTPResponse(statusCode: .internalServerError)
+        }
         return HTTPResponse(
             statusCode: .ok,
             headers: [
@@ -904,7 +911,11 @@ class LocalMediaServer {
                 HTTPHeader("Content-Length"): String(fileSize),
                 HTTPHeader("Accept-Ranges"): "bytes"
             ],
-            body: HTTPBodySequence(from: stream, count: Int(fileSize))
+            body: HTTPBodySequence(
+                from: stream,
+                count: Int(fileSize),
+                suggestedBufferSize: FileByteStream.chunkSize
+            )
         )
     }
     
@@ -944,7 +955,14 @@ class LocalMediaServer {
         // Stream the requested range in bounded chunks rather than reading it all at
         // once — a client opening with `Range: bytes=0-` asks for the whole file, so
         // readData(ofLength:) would allocate the entire movie in memory and OOM-kill us.
-        let stream = FileByteStream(fileURL: fileURL, startOffset: UInt64(start), length: length)
+        let stream: FileByteStream
+        do {
+            stream = try FileByteStream(fileURL: fileURL, startOffset: UInt64(start), length: length)
+        } catch {
+            NSLog("LocalMediaServer: Failed to open or seek file stream for %@: %@",
+                  fileURL.path, error.localizedDescription)
+            return HTTPResponse(statusCode: .internalServerError)
+        }
         return HTTPResponse(
             statusCode: .partialContent,
             headers: [
@@ -953,7 +971,11 @@ class LocalMediaServer {
                 HTTPHeader("Content-Range"): "bytes \(start)-\(clampedEnd)/\(fileSize)",
                 HTTPHeader("Accept-Ranges"): "bytes"
             ],
-            body: HTTPBodySequence(from: stream, count: Int(length))
+            body: HTTPBodySequence(
+                from: stream,
+                count: Int(length),
+                suggestedBufferSize: FileByteStream.chunkSize
+            )
         )
     }
     

--- a/Sources/NullPlayer/Casting/LocalMediaServer.swift
+++ b/Sources/NullPlayer/Casting/LocalMediaServer.swift
@@ -180,7 +180,72 @@ class LocalMediaServer {
             }
         }
     }
-    
+
+    /// Streams a local file (or a byte range of it) to the HTTP client in bounded
+    /// chunks. Reading the whole body into a single `Data` OOM-kills the process for
+    /// large media (an 18 GB movie), which looks like a silent crash right as the cast
+    /// starts — Chromecast opens playback with `Range: bytes=0-`, i.e. the entire file.
+    private struct FileByteStream: AsyncBufferedSequence, @unchecked Sendable {
+        typealias Element = UInt8
+
+        let fileURL: URL
+        let startOffset: UInt64
+        let length: Int64
+        static let chunkSize = 256 * 1024
+
+        func makeAsyncIterator() -> Iterator {
+            Iterator(fileURL: fileURL, startOffset: startOffset, length: length)
+        }
+
+        struct Iterator: AsyncBufferedIteratorProtocol {
+            private let fileHandle: FileHandle?
+            private let startOffset: UInt64
+            private var remaining: Int64
+            private var didSeek = false
+            private var leftover: [UInt8] = []
+            private var leftoverIndex = 0
+
+            init(fileURL: URL, startOffset: UInt64, length: Int64) {
+                self.fileHandle = try? FileHandle(forReadingFrom: fileURL)
+                self.startOffset = startOffset
+                self.remaining = length
+            }
+
+            private mutating func seekIfNeeded() {
+                guard !didSeek else { return }
+                didSeek = true
+                try? fileHandle?.seek(toOffset: startOffset)
+            }
+
+            mutating func nextBuffer(suggested count: Int) async throws -> [UInt8]? {
+                guard let fileHandle, remaining > 0 else { return nil }
+                seekIfNeeded()
+                let cap = Swift.max(1, Swift.min(count, FileByteStream.chunkSize))
+                let toRead = Int(Swift.min(Int64(cap), remaining))
+                guard let data = try fileHandle.read(upToCount: toRead), !data.isEmpty else {
+                    remaining = 0
+                    return nil
+                }
+                remaining -= Int64(data.count)
+                return [UInt8](data)
+            }
+
+            mutating func next() async throws -> UInt8? {
+                if leftoverIndex < leftover.count {
+                    defer { leftoverIndex += 1 }
+                    return leftover[leftoverIndex]
+                }
+                guard let buffer = try await nextBuffer(suggested: FileByteStream.chunkSize),
+                      !buffer.isEmpty else {
+                    return nil
+                }
+                leftover = buffer
+                leftoverIndex = 1
+                return buffer[0]
+            }
+        }
+    }
+
     // MARK: - Initialization
     
     private init() {}
@@ -826,14 +891,12 @@ class LocalMediaServer {
             return handleRangeRequest(rangeHeader, fileURL: url, fileSize: fileSize, contentType: contentType)
         }
         
-        // Full file response
-        guard let data = try? Data(contentsOf: url) else {
-            NSLog("LocalMediaServer: Failed to read file data for %@", url.path)
-            return HTTPResponse(statusCode: .internalServerError)
-        }
-        
+        // Full file response — stream in bounded chunks. Never buffer the whole file
+        // into a single Data; a large movie would exhaust memory and get the process
+        // OOM-killed with no crash log.
         NSLog("LocalMediaServer: Serving full file %@ (%lld bytes)", url.lastPathComponent, fileSize)
-        
+
+        let stream = FileByteStream(fileURL: url, startOffset: 0, length: fileSize)
         return HTTPResponse(
             statusCode: .ok,
             headers: [
@@ -841,7 +904,7 @@ class LocalMediaServer {
                 HTTPHeader("Content-Length"): String(fileSize),
                 HTTPHeader("Accept-Ranges"): "bytes"
             ],
-            body: data
+            body: HTTPBodySequence(from: stream, count: Int(fileSize))
         )
     }
     
@@ -874,26 +937,14 @@ class LocalMediaServer {
         
         let clampedEnd = min(end, fileSize - 1)
         let length = clampedEnd - start + 1
-        
-        // Read the requested range
-        guard let fileHandle = try? FileHandle(forReadingFrom: fileURL) else {
-            NSLog("LocalMediaServer: Failed to open file handle for %@", fileURL.path)
-            return HTTPResponse(statusCode: .internalServerError)
-        }
-        defer { try? fileHandle.close() }
-        
-        do {
-            try fileHandle.seek(toOffset: UInt64(start))
-        } catch {
-            NSLog("LocalMediaServer: Failed to seek to offset %lld: %@", start, error.localizedDescription)
-            return HTTPResponse(statusCode: .internalServerError)
-        }
-        
-        let data = fileHandle.readData(ofLength: Int(length))
-        
+
         NSLog("LocalMediaServer: Serving range %lld-%lld/%lld (%lld bytes) for %@",
               start, clampedEnd, fileSize, length, fileURL.lastPathComponent)
-        
+
+        // Stream the requested range in bounded chunks rather than reading it all at
+        // once — a client opening with `Range: bytes=0-` asks for the whole file, so
+        // readData(ofLength:) would allocate the entire movie in memory and OOM-kill us.
+        let stream = FileByteStream(fileURL: fileURL, startOffset: UInt64(start), length: length)
         return HTTPResponse(
             statusCode: .partialContent,
             headers: [
@@ -902,7 +953,7 @@ class LocalMediaServer {
                 HTTPHeader("Content-Range"): "bytes \(start)-\(clampedEnd)/\(fileSize)",
                 HTTPHeader("Accept-Ranges"): "bytes"
             ],
-            body: data
+            body: HTTPBodySequence(from: stream, count: Int(length))
         )
     }
     

--- a/Sources/NullPlayer/Data/Models/Track.swift
+++ b/Sources/NullPlayer/Data/Models/Track.swift
@@ -230,9 +230,12 @@ struct Track: Identifiable, Equatable {
         self.embyServerId = nil
         self.artworkThumb = nil   // Local files use embedded artwork
         
-        // Detect media type by checking for video tracks in the asset
+        // Detect media type by checking for video tracks in the asset, falling back to the
+        // file extension. AVFoundation can't parse containers like .mkv/.avi/.webm (the reason
+        // the app uses VLCKit for playback), so asset.tracks(withMediaType:) returns empty for
+        // them — without the extension fallback those files get misrouted to the audio engine.
         let videoTracks = asset.tracks(withMediaType: .video)
-        self.mediaType = videoTracks.isEmpty ? .audio : .video
+        self.mediaType = (!videoTracks.isEmpty || AudioFileValidator.isVideoFile(url: url)) ? .video : .audio
         self.genre = extractedGenre
         self.playHistoryContentTypeOverride = nil
         self.contentType = nil  // Local files use URL extension detection

--- a/Sources/NullPlayer/Resources/Info.plist
+++ b/Sources/NullPlayer/Resources/Info.plist
@@ -36,7 +36,7 @@
 	<key>CFBundlePackageType</key>
 	<string>APPL</string>
 	<key>CFBundleShortVersionString</key>
-	<string>0.29.6</string>
+	<string>0.29.7</string>
 	<key>CFBundleVersion</key>
 	<string>1</string>
 	<key>ITSAppUsesNonExemptEncryption</key>

--- a/Sources/NullPlayer/Resources/ThirdPartyLicenses/ThirdPartyNotices.txt
+++ b/Sources/NullPlayer/Resources/ThirdPartyLicenses/ThirdPartyNotices.txt
@@ -4294,3 +4294,4 @@ terms of the GPL-3.0. Only the meter template assets carry this license; the
 NullPlayer PeppyMeter rendering engine (Sources/NullPlayer/PeppyMeter/) is an
 independent Swift implementation.
 
+

--- a/Sources/NullPlayer/Windows/MainWindow/MainWindowView.swift
+++ b/Sources/NullPlayer/Windows/MainWindow/MainWindowView.swift
@@ -2004,7 +2004,7 @@ class MainWindowView: NSView {
 
         // Check if any items are .cue files or supported audio/video
         let hasCue = items.contains { $0.pathExtension.lowercased() == "cue" }
-        let hasOtherContent = LocalFileDiscovery.hasSupportedDropContent(items, includeVideo: false)
+        let hasOtherContent = LocalFileDiscovery.hasSupportedDropContent(items, includeVideo: true)
 
         guard hasCue || hasOtherContent else {
             return false
@@ -2045,7 +2045,7 @@ class MainWindowView: NSView {
         // For non-cue items, use normal discovery (directories, playlists, etc.)
         let nonCueItems = items.filter { $0.pathExtension.lowercased() != "cue" }
         if !nonCueItems.isEmpty {
-            LocalFileDiscovery.discoverMediaURLsAsync(from: nonCueItems, includeVideo: false) { mediaURLs in
+            LocalFileDiscovery.discoverMediaURLsAsync(from: nonCueItems, includeVideo: true) { mediaURLs in
                 // Filter out items already added via cue expansion
                 let cueURLs = tracksToAdd.map { $0.url }
                 let newMediaURLs = mediaURLs.filter { !cueURLs.contains($0) }

--- a/Sources/NullPlayer/Windows/ModernLibraryBrowser/ModernLibraryBrowserView.swift
+++ b/Sources/NullPlayer/Windows/ModernLibraryBrowser/ModernLibraryBrowserView.swift
@@ -4425,12 +4425,13 @@ class ModernLibraryBrowserView: NSView {
     
     override func draggingEntered(_ sender: NSDraggingInfo) -> NSDragOperation {
         guard let items = sender.draggingPasteboard.readObjects(forClasses: [NSURL.self]) as? [URL] else { return [] }
-        return LocalFileDiscovery.hasSupportedDropContent(items, includeVideo: false, includePlaylists: true) ? .copy : []
+        return LocalFileDiscovery.hasSupportedDropContent(items, includeVideo: true, includePlaylists: true) ? .copy : []
     }
-    
+
     override func performDragOperation(_ sender: NSDraggingInfo) -> Bool {
         guard let items = sender.draggingPasteboard.readObjects(forClasses: [NSURL.self]) as? [URL] else { return false }
-        var fileURLs: [URL] = []
+        var audioURLs: [URL] = []
+        var videoURLs: [URL] = []
         var processedDirectories = false
         for url in items {
             if LocalFileDiscovery.isDirectory(url) {
@@ -4438,14 +4439,20 @@ class ModernLibraryBrowserView: NSView {
                 MediaLibrary.shared.scanFolder(url)
                 processedDirectories = true
             } else if LocalFileDiscovery.isSupportedAudioFile(url) {
-                fileURLs.append(url)
+                audioURLs.append(url)
+            } else if LocalFileDiscovery.isSupportedVideoFile(url) {
+                videoURLs.append(url)
             }
         }
-        if !fileURLs.isEmpty {
-            MediaLibrary.shared.addTracks(urls: fileURLs)
+        if !audioURLs.isEmpty {
+            MediaLibrary.shared.addTracks(urls: audioURLs)
             if case .plex = currentSource { currentSource = .local }
         }
-        return !fileURLs.isEmpty || processedDirectories
+        if !videoURLs.isEmpty {
+            MediaLibrary.shared.addVideoFiles(urls: videoURLs)
+            revealLocalVideoCategory()
+        }
+        return !audioURLs.isEmpty || !videoURLs.isEmpty || processedDirectories
     }
     
     // MARK: - Server Bar Click Handling
@@ -5889,12 +5896,32 @@ class ModernLibraryBrowserView: NSView {
         let panel = NSOpenPanel()
         panel.canChooseFiles = true
         panel.allowsMultipleSelection = true
-        panel.allowedContentTypes = [.movie, .video, .mpeg4Movie, .quickTimeMovie]
+        // Build the allowed types from every container we actually support so
+        // formats like .mkv/.avi/.webm aren't greyed out in the panel.
+        var videoTypes: [UTType] = [.movie, .video]
+        for ext in AudioFileValidator.supportedVideoExtensions {
+            if let type = UTType(filenameExtension: ext) { videoTypes.append(type) }
+        }
+        panel.allowedContentTypes = videoTypes
         panel.message = "Select video files to add to your library"
         if panel.runModal() == .OK {
             MediaLibrary.shared.addVideoFiles(urls: panel.urls)
-            loadLocalData()
+            revealLocalVideoCategory()
         }
+    }
+
+    /// Switch the browser to the local Movies category and reload so freshly-added
+    /// videos are actually visible. Without this the add succeeds but the user stays
+    /// on whatever tab they were on (e.g. Artists), so nothing appears to happen.
+    private func revealLocalVideoCategory() {
+        if case .local = currentSource {} else { currentSource = .local }
+        if !browseMode.isVideoMode {
+            browseMode = .movies
+            selectedIndices.removeAll()
+            scrollOffset = 0
+        }
+        loadDataForCurrentMode()
+        needsDisplay = true
     }
     @objc private func addWatchFolder() {
         let panel = NSOpenPanel()

--- a/Sources/NullPlayer/Windows/ModernLibraryBrowser/ModernLibraryBrowserView.swift
+++ b/Sources/NullPlayer/Windows/ModernLibraryBrowser/ModernLibraryBrowserView.swift
@@ -5915,7 +5915,7 @@ class ModernLibraryBrowserView: NSView {
     /// on whatever tab they were on (e.g. Artists), so nothing appears to happen.
     private func revealLocalVideoCategory() {
         if case .local = currentSource {} else { currentSource = .local }
-        if !browseMode.isVideoMode {
+        if browseMode != .movies {
             browseMode = .movies
             selectedIndices.removeAll()
             scrollOffset = 0

--- a/Sources/NullPlayer/Windows/ModernMainWindow/ModernMainWindowView.swift
+++ b/Sources/NullPlayer/Windows/ModernMainWindow/ModernMainWindowView.swift
@@ -1851,9 +1851,9 @@ class ModernMainWindowView: NSView {
             return false
         }
 
-        // Check if any items are .cue files or supported audio
+        // Check if any items are .cue files or supported audio/video
         let hasCue = items.contains { $0.pathExtension.lowercased() == "cue" }
-        let hasOtherContent = LocalFileDiscovery.hasSupportedDropContent(items, includeVideo: false)
+        let hasOtherContent = LocalFileDiscovery.hasSupportedDropContent(items, includeVideo: true)
 
         guard hasCue || hasOtherContent else {
             return false
@@ -1894,12 +1894,12 @@ class ModernMainWindowView: NSView {
         // For non-cue items, use normal discovery (directories, playlists, etc.)
         let nonCueItems = items.filter { $0.pathExtension.lowercased() != "cue" }
         if !nonCueItems.isEmpty {
-            LocalFileDiscovery.discoverMediaURLsAsync(from: nonCueItems, includeVideo: false) { audioURLs in
+            LocalFileDiscovery.discoverMediaURLsAsync(from: nonCueItems, includeVideo: true) { mediaURLs in
                 // Filter out items already added via cue expansion
                 let cueURLs = tracksToLoad.map { $0.url }
-                let newAudioURLs = audioURLs.filter { !cueURLs.contains($0) }
+                let newMediaURLs = mediaURLs.filter { !cueURLs.contains($0) }
 
-                let allTracks = tracksToLoad + newAudioURLs.map { Track(url: $0) }
+                let allTracks = tracksToLoad + newMediaURLs.map { Track(url: $0) }
                 WindowManager.shared.audioEngine.loadTracks(allTracks)
                 WindowManager.shared.audioEngine.play()
             }

--- a/Sources/NullPlayer/Windows/PlexBrowser/PlexBrowserView.swift
+++ b/Sources/NullPlayer/Windows/PlexBrowser/PlexBrowserView.swift
@@ -9032,12 +9032,27 @@ class PlexBrowserView: NSView {
         let panel = NSOpenPanel()
         panel.canChooseFiles = true
         panel.allowsMultipleSelection = true
-        panel.allowedContentTypes = [.movie, .video, .mpeg4Movie, .quickTimeMovie]
+        var videoTypes: [UTType] = [.movie, .video]
+        for ext in AudioFileValidator.supportedVideoExtensions {
+            if let type = UTType(filenameExtension: ext) { videoTypes.append(type) }
+        }
+        panel.allowedContentTypes = videoTypes
         panel.message = "Select video files to add to your library"
         if panel.runModal() == .OK {
             MediaLibrary.shared.addVideoFiles(urls: panel.urls)
-            loadLocalData()
+            revealLocalVideoCategory()
         }
+    }
+
+    private func revealLocalVideoCategory() {
+        if case .local = currentSource {} else { currentSource = .local }
+        if browseMode != .movies {
+            browseMode = .movies
+            selectedIndices.removeAll()
+            scrollOffset = 0
+        }
+        loadDataForCurrentMode()
+        needsDisplay = true
     }
 
     @objc private func selectLocalSource() {
@@ -9605,7 +9620,7 @@ class PlexBrowserView: NSView {
         guard let items = sender.draggingPasteboard.readObjects(forClasses: [NSURL.self]) as? [URL] else {
             return []
         }
-        return LocalFileDiscovery.hasSupportedDropContent(items, includeVideo: false, includePlaylists: true) ? .copy : []
+        return LocalFileDiscovery.hasSupportedDropContent(items, includeVideo: true, includePlaylists: true) ? .copy : []
     }
     
     override func performDragOperation(_ sender: NSDraggingInfo) -> Bool {
@@ -9613,7 +9628,8 @@ class PlexBrowserView: NSView {
             return false
         }
         
-        var fileURLs: [URL] = []
+        var audioURLs: [URL] = []
+        var videoURLs: [URL] = []
         var playlistURLs: [URL] = []
         var processedDirectories = false
         
@@ -9628,7 +9644,9 @@ class PlexBrowserView: NSView {
                 playlistURLs.append(url)
             } else if LocalFileDiscovery.isSupportedAudioFile(url) {
                 // Audio file
-                fileURLs.append(url)
+                audioURLs.append(url)
+            } else if LocalFileDiscovery.isSupportedVideoFile(url) {
+                videoURLs.append(url)
             }
         }
         
@@ -9665,16 +9683,21 @@ class PlexBrowserView: NSView {
         }
         
         // Handle audio files
-        if !fileURLs.isEmpty {
-            MediaLibrary.shared.addTracks(urls: fileURLs)
+        if !audioURLs.isEmpty {
+            MediaLibrary.shared.addTracks(urls: audioURLs)
             
             // Switch to local source to show added content
             if case .plex = currentSource {
                 currentSource = .local
             }
         }
+
+        if !videoURLs.isEmpty {
+            MediaLibrary.shared.addVideoFiles(urls: videoURLs)
+            revealLocalVideoCategory()
+        }
         
-        return !fileURLs.isEmpty || !playlistURLs.isEmpty || processedDirectories
+        return !audioURLs.isEmpty || !videoURLs.isEmpty || !playlistURLs.isEmpty || processedDirectories
     }
     
     // MARK: - Right-Click Context Menu (for list items)

--- a/skills/chromecast-casting/SKILL.md
+++ b/skills/chromecast-casting/SKILL.md
@@ -300,6 +300,11 @@ the range handler and the full-file handler must stream.
   `FileHandle`, 256 KB chunks) wrapped in `HTTPBodySequence(from:count:)`. This mirrors the
   `URLSessionByteStream` used for the Subsonic/Jellyfin proxy path. Memory stays flat regardless of
   file size, and `Content-Length`/`Content-Range` still describe the exact byte count so seeking works.
+- Open and initial seek must succeed before returning `200`/`206`; otherwise return `500`. Do not
+  suppress those errors with `try?`, because a response that advertises `Content-Length` and then
+  yields no bytes leaves the cast client waiting for a body that will never arrive. Subsequent read
+  errors propagate through the body sequence so the connection fails instead of ending as a false
+  successful short response.
 
 ## Key Implementation Gotcha: Data Slice Indexing
 

--- a/skills/chromecast-casting/SKILL.md
+++ b/skills/chromecast-casting/SKILL.md
@@ -285,6 +285,22 @@ To close the Default Media Receiver app (dismiss from TV screen), send STOP to `
 {"type":"SET_VOLUME","volume":{"muted":true},"requestId":N}
 ```
 
+## Serving Local Files (`LocalMediaServer`) — Stream, Never Buffer
+
+`LocalMediaServer` serves registered local files over HTTP for cast devices. **Never load a whole
+file into memory to serve it.** A cast device (Chromecast especially) opens playback with
+`Range: bytes=0-`, i.e. it asks for the entire file, and it also issues plain full-file `GET`s. Both
+the range handler and the full-file handler must stream.
+
+- Serving with `Data(contentsOf:)` (full file) or `FileHandle.readData(ofLength: Int(length))` (a
+  `bytes=0-` range spans the whole file) allocates the entire media in RAM. For a multi-GB movie the
+  OS OOM-kills the process with **no crash log** — it looks like the app silently vanishes the instant
+  the cast starts. Small files fit in RAM, so the bug only shows on large media.
+- Both handlers stream via `FileByteStream` (a `AsyncBufferedSequence` of `UInt8` backed by a
+  `FileHandle`, 256 KB chunks) wrapped in `HTTPBodySequence(from:count:)`. This mirrors the
+  `URLSessionByteStream` used for the Subsonic/Jellyfin proxy path. Memory stays flat regardless of
+  file size, and `Content-Length`/`Content-Range` still describe the exact byte count so seeking works.
+
 ## Key Implementation Gotcha: Data Slice Indexing
 
 Swift `Data` slices maintain original indices. When processing a receive buffer:

--- a/skills/local-library/SKILL.md
+++ b/skills/local-library/SKILL.md
@@ -168,10 +168,12 @@ they are not shared. When adding a new one (or debugging "dragging a video does 
   `performDragOperation`s. Both must pass `includeVideo: true` to `hasSupportedDropContent` and
   `discoverMediaURLsAsync`; the discovered video `Track` then routes to the video player via the
   `mediaType == .video` branch in `AudioEngine.loadTrack`/`playTrack`.
-- `ModernLibraryBrowserView.performDragOperation` — routes audio to `MediaLibrary.addTracks(...)` and
-  video to `MediaLibrary.addVideoFiles(...)`; `draggingEntered` must also allow video
-  (`includeVideo: true`).
-- `addVideoFiles()` (the `+ADD` menu) — after `MediaLibrary.addVideoFiles`, call
+- `ModernLibraryBrowserView.performDragOperation` **and** `PlexBrowserView.performDragOperation` —
+  Modern and Classic have separate Library drop handlers. Both route audio to
+  `MediaLibrary.addTracks(...)` and video to `MediaLibrary.addVideoFiles(...)`; both
+  `draggingEntered` implementations must allow video (`includeVideo: true`).
+- `addVideoFiles()` (the `+ADD` menu) exists in both Library browser implementations — after
+  `MediaLibrary.addVideoFiles`, call
   `revealLocalVideoCategory()` to switch to local → Movies and reload, or the import succeeds but stays
   hidden on whatever tab is showing. The `NSOpenPanel` allowed types are built from
   `AudioFileValidator.supportedVideoExtensions` so `.mkv`/`.avi`/`.webm`/`.ts` aren't greyed out.

--- a/skills/local-library/SKILL.md
+++ b/skills/local-library/SKILL.md
@@ -159,6 +159,30 @@ Both `ModernLibraryBrowserView` and `PlexBrowserView` debounce `MediaLibraryDidC
 - Deduplication by normalized path; one-pass `isRegularFile`, `fileSize`, `contentModificationDate` resource-key reads.
 - `includePlaylists: Bool = false` (on both `discoverMedia` and `discoverMediaStreaming`) — when true, `.m3u`/`.pls`/`.m3u8` files are collected into `LocalFileDiscoveryResult.playlistFiles`. Only the library scan (`importMedia`) passes `true`. Playlists are a **third** classification: the early `guard isAudio || isVideo || isPlaylist` includes them, but they do **not** flow through the audio batch flush (`onAudioBatch`) and are **not** in the `allURLs` computed property (callers treat `allURLs` as importable audio/video — a `.m3u` must never be imported as a track).
 
+## Video Drop / Add Routing (per-surface, easy to miss)
+
+Video files must be handled explicitly at every drop/add surface — each has its **own** handler and
+they are not shared. When adding a new one (or debugging "dragging a video does nothing"), check all of:
+
+- `ModernMainWindowView` **and** `MainWindowView` — the Modern and Classic skins have *separate*
+  `performDragOperation`s. Both must pass `includeVideo: true` to `hasSupportedDropContent` and
+  `discoverMediaURLsAsync`; the discovered video `Track` then routes to the video player via the
+  `mediaType == .video` branch in `AudioEngine.loadTrack`/`playTrack`.
+- `ModernLibraryBrowserView.performDragOperation` — routes audio to `MediaLibrary.addTracks(...)` and
+  video to `MediaLibrary.addVideoFiles(...)`; `draggingEntered` must also allow video
+  (`includeVideo: true`).
+- `addVideoFiles()` (the `+ADD` menu) — after `MediaLibrary.addVideoFiles`, call
+  `revealLocalVideoCategory()` to switch to local → Movies and reload, or the import succeeds but stays
+  hidden on whatever tab is showing. The `NSOpenPanel` allowed types are built from
+  `AudioFileValidator.supportedVideoExtensions` so `.mkv`/`.avi`/`.webm`/`.ts` aren't greyed out.
+
+**`Track` media-type detection uses an extension fallback.** `Track(url:)` first checks
+`asset.tracks(withMediaType: .video)`, but AVFoundation cannot parse `.mkv`/`.avi`/`.webm`/`.flv`/`.ts`
+(the reason playback uses VLCKit), so that probe returns empty for them. It then falls back to
+`AudioFileValidator.isVideoFile(url:)` (extension), so those containers still classify as `.video`
+instead of being misrouted to the audio engine. Audio extensions are never in the video set, so real
+audio can't be misclassified.
+
 ## NAS Responsiveness
 
 All local `AVAudioFile(forReading:)` calls are async on `deferredIOQueue` (background serial queue in `AudioEngine`).


### PR DESCRIPTION
## Summary

Fixes several local-video handling gaps and a crash when casting large media. Ships as **0.29.7**.

### Local video add / drag / drop
Each drop/add surface has its own handler, and most silently excluded video:

- **Main player window drop** — Modern (`ModernMainWindowView`) *and* Classic (`MainWindowView`) skins have separate handlers; both passed `includeVideo: false`, so dropping a video did nothing. Now accepted and routed to the video player.
- **Library window drop** — only appended audio; video now routes to `MediaLibrary.addVideoFiles` and reveals the Movies tab.
- **"Add Video Files…" menu** — added the movie but never switched to Movies, so it looked like a no-op. Now reveals Movies; the file picker no longer greys out `.mkv`/`.avi`/`.webm`/`.ts`.
- **`Track(url:)` detection** — relied on AVFoundation track probing, which returns empty for `.mkv`/`.avi`/`.webm` (the formats VLCKit was adopted for), misclassifying them as audio. Added an extension fallback.

### Large-file cast crash (OOM)
`LocalMediaServer` served files by reading the whole file into memory (`Data(contentsOf:)`, and `readData(ofLength:)` for the `bytes=0-` full-file range a Chromecast requests). Casting a multi-GB movie exhausted memory and the OS killed the process with no crash log. Both handlers now stream via a `FileByteStream` (256 KB chunks) through `HTTPBodySequence(from:count:)`; memory stays flat and seeking still works.

## Testing
- Build: `swift build` clean.
- Manually verified by the user: drag-to-play on the main window, Add Video Files, library drop, and casting an 18 GB file (previously crashed instantly, now plays).
- Note: drag/drop, menu actions, and real Chromecast casting can't be driven from CI/CLI.

## Docs
- `CHANGELOG.md` — 0.29.7 entries.
- `skills/local-library/SKILL.md` — per-surface video drop/add routing + `Track` extension fallback.
- `skills/chromecast-casting/SKILL.md` — `LocalMediaServer` must stream, never buffer.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added support for importing and dragging supported video files across player and Library workflows.
  - Added video file extensions and improved handling of playlists and directories containing videos.
  - Added Movies category visibility after importing local videos.

- **Bug Fixes**
  - Improved casting of large local files and range requests to prevent failures and excessive memory use.
  - Fixed video detection for additional container formats.

- **Documentation**
  - Updated version 0.29.7 release notes and documentation for video handling and local media casting.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->