### PR TITLE
Avoid VLCKit volume deadlock before playback

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,11 @@
 # Changelog
 
+## 0.29.8
+
+### Bug Fixes
+
+- **Video playback no longer freezes on startup, and starts at the right volume** — writing the audio volume after the media was assigned but before the player started could enter libVLC's configuration lock while its event thread held the opposing lock, permanently hanging the main thread. The volume is now applied once the audio pipeline exists (as soon as the player begins buffering, before the first sample renders), so playback starts reliably and at the user's volume instead of briefly blasting at full volume. Dragging the volume slider during playback now writes only the volume, without re-running audio-track selection or unmuting on every tick.
+
 ## 0.29.7
 
 ### Bug Fixes

--- a/Sources/NullPlayer/Resources/Info.plist
+++ b/Sources/NullPlayer/Resources/Info.plist
@@ -36,7 +36,7 @@
 	<key>CFBundlePackageType</key>
 	<string>APPL</string>
 	<key>CFBundleShortVersionString</key>
-	<string>0.29.7</string>
+	<string>0.29.8</string>
 	<key>CFBundleVersion</key>
 	<string>1</string>
 	<key>ITSAppUsesNonExemptEncryption</key>

--- a/Sources/NullPlayer/Windows/VideoPlayer/VideoPlayerView.swift
+++ b/Sources/NullPlayer/Windows/VideoPlayer/VideoPlayerView.swift
@@ -108,8 +108,13 @@ class VideoPlayerView: NSView {
     /// Volume level (0.0 - 1.0)
     var volume: Float = 1.0 {
         didSet {
-            // VLCKit expresses volume as 0–100 (up to 200 for boost).
-            mediaPlayer?.audio?.volume = Int32(max(0, min(1, volume)) * 100)
+            // Before playback starts, VLCKit can route a volume write through
+            // its global configuration lock while its event thread holds the
+            // matching read lock. Defer the write until the player has reported
+            // that its playback pipeline is active.
+            if isActivelyPlaying {
+                applyAudioOutput()
+            }
         }
     }
     
@@ -758,7 +763,6 @@ class VideoPlayerView: NSView {
         player.drawable = playerHostView
         player.delegate = self
         player.media = media
-        player.audio?.volume = Int32(max(0, min(1, volume)) * 100)
         mediaPlayer = player
         player.play()
 

--- a/Sources/NullPlayer/Windows/VideoPlayer/VideoPlayerView.swift
+++ b/Sources/NullPlayer/Windows/VideoPlayer/VideoPlayerView.swift
@@ -108,12 +108,16 @@ class VideoPlayerView: NSView {
     /// Volume level (0.0 - 1.0)
     var volume: Float = 1.0 {
         didSet {
-            // Before playback starts, VLCKit can route a volume write through
-            // its global configuration lock while its event thread holds the
-            // matching read lock. Defer the write until the player has reported
-            // that its playback pipeline is active.
+            // Before the playback pipeline is active, VLCKit can route a volume
+            // write through its global configuration lock while its event thread
+            // holds the matching read lock — a lock inversion that hangs the main
+            // thread. Defer the write until the player reports it is playing; the
+            // deferred value is picked up by the state callbacks (see
+            // `applyAudioOutput()`). Once playing, only the volume is written —
+            // not the track-selection / unmute work — so dragging the slider
+            // stays cheap and free of side effects.
             if isActivelyPlaying {
-                applyAudioOutput()
+                applyVolume()
             }
         }
     }
@@ -796,8 +800,19 @@ class VideoPlayerView: NSView {
         }
         if let audio = player.audio {
             audio.isMuted = false
-            audio.volume = Int32(max(0, min(1, volume)) * 100)
         }
+        applyVolume()
+    }
+
+    /// Write the current `volume` to VLCKit's audio output and nothing else.
+    /// Split from `applyAudioOutput()` so user-driven volume changes don't also
+    /// re-run audio-track selection and unmuting on every slider tick. No-op
+    /// until the audio output exists (`audio` is nil until the pipeline is up),
+    /// which is also why the initial volume is applied from the state callbacks
+    /// rather than before `play()`.
+    private func applyVolume() {
+        guard let audio = mediaPlayer?.audio else { return }
+        audio.volume = Int32(max(0, min(1, volume)) * 100)
     }
 
     /// Handle the player actually running. VLCKit reports either `.playing` or
@@ -1154,6 +1169,11 @@ extension VideoPlayerView: VLCMediaPlayerDelegate {
                 NSLog("VideoPlayerView: Opening")
                 self.showLoading(true)
             case .buffering:
+                // Apply audio output as soon as the pipeline exists so the
+                // user's volume is in place before the first sample renders —
+                // otherwise VLCKit's default (100) plays briefly at startup.
+                // No-op while `audio` is still nil.
+                self.applyAudioOutput()
                 // VLCKit reports `.buffering` during smooth playback in this
                 // build (not only while pre-buffering), so gate on whether
                 // libVLC is actually playing rather than on the state alone.


### PR DESCRIPTION
## Summary

- Defer VLCKit audio-volume writes until the playback pipeline is active.
- Apply the pending volume when playback starts or an audio elementary stream is added.
- Remove the redundant pre-play volume write that can freeze video startup.

## Diagnosis

Writing the audio volume after assigning media but before starting the player can enter libVLC configuration locking while its event thread holds the opposing lock. That lock inversion leaves the main thread permanently blocked. The write is unnecessary because the existing playback and elementary-stream callbacks already apply audio output once the pipeline is ready.

## Testing

- Full Swift test suite: 402 tests passed, 0 failures.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved video startup volume handling to prevent playback issues.
  * Volume changes now apply correctly during active playback.
  * Adjusting the volume no longer unintentionally changes audio tracks or unmutes playback.

* **Chores**
  * Updated the macOS app version to 0.29.8.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->