### PR TITLE
Compact window: Library ↔ Playlist toggle

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,10 @@
 
 - **Compact window can now show the playlist** — a Library | Playlist toggle at the bottom of the Compact window switches its content between the library browser and the current playlist, so you can view and edit what's playing without opening the full Playlist window. Double-click a track to play it; selection, scrolling, and live now-playing highlight all work in place. The choice is remembered across launches and is available in all three skin families (Modern, Metal, Classic). In Modern/Metal the playlist is translucent so the Cava/art backdrop shows through it just like the library list.
 
+### Bug Fixes
+
+- **Restored local videos play again instead of erroring** — a video file left in the playlist from a previous session was rebuilt on launch as an audio track (the saved state doesn't record media type), so playing it routed to the audio engine and failed to decode the video container. Restored local files now re-derive their media type from the file extension, so videos correctly open in the video player.
+
 ### Changes
 
 - **Removed the Met Museum Art visualization** — the rotating public-domain artwork engine has been retired and no longer appears in the visualization engine picker. Any saved preference for it falls back to the default engine.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## Unreleased
 
+### New Features
+
+- **Compact window can now show the playlist** — a Library | Playlist toggle at the bottom of the Compact window switches its content between the library browser and the current playlist, so you can view and edit what's playing without opening the full Playlist window. Double-click a track to play it; selection, scrolling, and live now-playing highlight all work in place. The choice is remembered across launches and is available in all three skin families (Modern, Metal, Classic). In Modern/Metal the playlist is translucent so the Cava/art backdrop shows through it just like the library list.
+
 ### Changes
 
 - **Removed the Met Museum Art visualization** — the rotating public-domain artwork engine has been retired and no longer appears in the visualization engine picker. Any saved preference for it falls back to the default engine.

--- a/Sources/NullPlayer/App/AppDelegate.swift
+++ b/Sources/NullPlayer/App/AppDelegate.swift
@@ -567,7 +567,7 @@ extension AppDelegate: AudioEngineDelegate {
     }
     
     func audioEngineDidChangePlaylist() {
-        windowManager.playlistWindowController?.reloadPlaylist()
+        windowManager.reloadPlaylistViews()
     }
     
     func audioEngineDidFailToLoadTrack(_ track: Track, error: Error) {

--- a/Sources/NullPlayer/App/AppStateManager.swift
+++ b/Sources/NullPlayer/App/AppStateManager.swift
@@ -996,6 +996,11 @@ class AppStateManager {
                         artist: savedTrack.artist,
                         album: savedTrack.album,
                         duration: savedTrack.duration,
+                        // SavedTrack doesn't persist mediaType and this initializer defaults it
+                        // to .audio, so re-derive it from the file extension (cheap, no file I/O)
+                        // — otherwise restored local videos come back as audio and misroute to
+                        // the audio engine (AVAudioFile fails to decode the video container).
+                        mediaType: AudioFileValidator.isVideoFile(url: url) ? .video : .audio,
                         contentType: savedTrack.contentType,
                         isYouTubeOrigin: savedTrack.isYouTubeOrigin ?? false
                     ))

--- a/Sources/NullPlayer/App/WindowManager.swift
+++ b/Sources/NullPlayer/App/WindowManager.swift
@@ -1755,6 +1755,14 @@ class WindowManager {
         compactWindowController?.updatePlaybackState()
     }
 
+    /// Keep every playlist presentation synchronized with the shared audio-engine queue.
+    /// Compact Mode owns a private browser controller, so it cannot be reached through the
+    /// standalone `playlistWindowController` channel used before the embedded queue existed.
+    func reloadPlaylistViews() {
+        playlistWindowController?.reloadPlaylist()
+        compactWindowController?.reloadPlaylist()
+    }
+
     // MARK: - Library History
 
     func showLibraryHistory() {
@@ -5627,7 +5635,7 @@ class WindowManager {
         mainWindowController?.updateTime(current: audioEngine.currentTime, duration: audioEngine.duration)
         updateWaveformTrack(track)
         updateWaveformTime(current: audioEngine.currentTime, duration: audioEngine.duration)
-        playlistWindowController?.reloadPlaylist()
+        reloadPlaylistViews()
 
         // If a video session is active, the video player survived teardown — restore its
         // title/state on the new main window instead of the audio track display.

--- a/Sources/NullPlayer/Windows/CompactMode/CompactModeWindowController.swift
+++ b/Sources/NullPlayer/Windows/CompactMode/CompactModeWindowController.swift
@@ -8,6 +8,7 @@ private protocol CompactModeBrowserSurface: AnyObject {
     func updateCompactBarTime(current: TimeInterval, duration: TimeInterval)
     func updateCompactBarTrack(_ track: Track?)
     func updateCompactBarPlaybackState()
+    func reloadCompactPlaylist()
     var compactBackdropPresenter: CavaPresenter? { get }
     func refreshCompactBackdrop()
     func skinDidChange()
@@ -151,6 +152,10 @@ final class CompactModeWindowController: NSWindowController {
         browserController.updateCompactBarTrack(engine.currentTrack)
         browserController.updateCompactBarTime(current: engine.currentTime, duration: engine.duration)
         browserController.updateCompactBarPlaybackState()
+    }
+
+    func reloadPlaylist() {
+        browserController.reloadCompactPlaylist()
     }
 
     func skinDidChange() {

--- a/Sources/NullPlayer/Windows/ModernLibraryBrowser/ModernLibraryBrowserView.swift
+++ b/Sources/NullPlayer/Windows/ModernLibraryBrowser/ModernLibraryBrowserView.swift
@@ -217,6 +217,13 @@ class ModernLibraryBrowserView: NSView {
     private var topChromeBottomY: CGFloat {
         bounds.height - Layout.titleBarHeight - compactPlayerBarHeight
     }
+
+    /// Y coordinate of the bottom of the scrollable content region. Content measures up from
+    /// here, so reserving the compact footer band shifts the list / alphabet / server bar up
+    /// without any other layout math changing (mirrors `topChromeBottomY` for the bottom).
+    private var contentRegionBottomY: CGFloat {
+        Layout.statusBarHeight + compactFooterHeight
+    }
     
     // Browse state
     private var currentSource: ModernBrowserSource = .local {
@@ -371,6 +378,31 @@ class ModernLibraryBrowserView: NSView {
     // Offline volume state (populated by loadLocalData)
     private var offlineWatchFolders: [WatchFolderSummary] = []
     private var offlineVolumePrefixes: Set<String> = []
+
+    /// Content shown below the compact player bar: the library browser or the play queue.
+    /// Only consulted when `compactMode == true`; the full library window is unaffected.
+    enum CompactContentMode: Int { case library = 0, queue = 1 }
+
+    private var compactContentMode: CompactContentMode {
+        get { CompactContentMode(rawValue: UserDefaults.standard.integer(forKey: "compactContentMode")) ?? .library }
+        set {
+            UserDefaults.standard.set(newValue.rawValue, forKey: "compactContentMode")
+            updateCompactPlaylistFrame()   // show/hide + size the embedded queue
+            // Hand keyboard focus to whichever view is now visible.
+            window?.makeFirstResponder(newValue == .queue ? (compactPlaylistView ?? self) : self)
+            needsLayout = true
+            needsDisplay = true
+        }
+    }
+
+    /// Height of the Library|Playlist toggle footer at the bottom of the compact window
+    /// (0 outside compact mode).
+    private var compactFooterHeight: CGFloat {
+        compactMode ? 24 * ModernSkinElements.sizeMultiplier : 0
+    }
+
+    /// Embedded compact-sized play queue, shown in place of the library chrome in queue mode.
+    private var compactPlaylistView: ModernPlaylistView?
 
     // Local Plists slot toggle state (switch between Plists and Folders)
     private var localPlistsSlotShowsFolders: Bool {
@@ -1032,7 +1064,10 @@ class ModernLibraryBrowserView: NSView {
         if browseMode.isHistoryMode {
             ensureHistoryHostingView()
         }
-        let isVisible = browseMode.isHistoryMode && !isArtOnlyMode
+        // The embedded queue covers the content region in Playlist mode, so the SwiftUI
+        // history subview must stay hidden there regardless of browseMode.
+        let inQueueMode = compactMode && compactContentMode == .queue
+        let isVisible = browseMode.isHistoryMode && !isArtOnlyMode && !inQueueMode
         historyHostingView?.isHidden = !isVisible
         updateEmbeddedSubviewFrames()
     }
@@ -1040,12 +1075,12 @@ class ModernLibraryBrowserView: NSView {
     private func embeddedHistoryContentRect() -> NSRect {
         var contentTopY = topChromeBottomY - Layout.serverBarHeight - Layout.tabBarHeight
         if browseMode == .search { contentTopY -= Layout.searchBarHeight }
-        let statusBarHeight = Layout.statusBarHeight
+        let contentBottomY = contentRegionBottomY
         return NSRect(
             x: Layout.borderWidth,
-            y: statusBarHeight,
+            y: contentBottomY,
             width: bounds.width - Layout.borderWidth * 2,
-            height: max(0, contentTopY - statusBarHeight)
+            height: max(0, contentTopY - contentBottomY)
         )
     }
 
@@ -1055,6 +1090,7 @@ class ModernLibraryBrowserView: NSView {
             ratingOverlay.frame = bounds
         }
         updateCompactPlayerBarFrame()
+        updateCompactPlaylistFrame()
         updateBackdropFrame()
     }
 
@@ -1154,6 +1190,32 @@ class ModernLibraryBrowserView: NSView {
         bar.frame = NSRect(x: Layout.borderWidth, y: topChromeBottomY,
                            width: bounds.width - Layout.borderWidth * 2,
                            height: compactPlayerBarHeight)
+    }
+
+    /// Create/position/remove the embedded compact play queue to match the current mode.
+    /// It fills the content region below the toggle strip and covers the library chrome
+    /// (server bar / tabs / alphabet index) when shown, so queue mode hides library chrome.
+    private func updateCompactPlaylistFrame() {
+        guard compactMode else {
+            compactPlaylistView?.removeFromSuperview()
+            compactPlaylistView = nil
+            return
+        }
+        let queue: ModernPlaylistView
+        if let existing = compactPlaylistView {
+            queue = existing
+        } else {
+            queue = ModernPlaylistView(frame: .zero)
+            queue.isEmbedded = true
+            // Render above the library chrome and the Cava/art backdrop.
+            addSubview(queue)
+            compactPlaylistView = queue
+        }
+        let border = Layout.borderWidth
+        queue.frame = NSRect(x: border, y: contentRegionBottomY,
+                             width: bounds.width - border * 2,
+                             height: max(0, topChromeBottomY - contentRegionBottomY))
+        queue.isHidden = (compactContentMode != .queue)
     }
 
     /// Seed the bar with the engine's current state so it isn't blank until the next update tick.
@@ -1293,60 +1355,74 @@ class ModernLibraryBrowserView: NSView {
             renderer.drawWindowControlButton("library_btn_close", state: closeState, in: closeBtnRect, context: context)
         }
         
-        // Server bar (below title bar in screen coords)
-        drawServerBar(in: context, serverBarY: serverBarY, skin: skin)
-        
-        // Tab bar (below server bar)
-        let tabBarY = serverBarY - Layout.tabBarHeight
-        drawTabBar(in: context, tabBarY: tabBarY, skin: skin)
-        
-        // Search bar (below tab bar, only in search mode)
-        var contentTopY = tabBarY
-        if browseMode == .search {
-            contentTopY -= Layout.searchBarHeight
-            drawSearchBar(in: context, searchBarY: contentTopY, skin: skin)
-        }
-        
-        // Status bar at bottom
-        let statusBarHeight = Layout.statusBarHeight
-
-        // Offline volume banner (local source only, above list content)
-        let showOfflineBanner = isLocalSource && !offlineWatchFolders.isEmpty
-        let bannerHeight = showOfflineBanner ? Layout.offlineBannerHeight : 0
-
-        // List area (between content top and status bar bottom)
-        let listAreaY = statusBarHeight + bannerHeight
-        let listAreaHeight = contentTopY - statusBarHeight - bannerHeight
-        let listRect = NSRect(x: Layout.borderWidth, y: listAreaY,
-                              width: bounds.width - Layout.borderWidth * 2, height: listAreaHeight)
-
         updateHistoryHostingVisibility()
 
-        if showOfflineBanner {
-            let bannerRect = NSRect(x: Layout.borderWidth, y: statusBarHeight,
-                                   width: bounds.width - Layout.borderWidth * 2, height: bannerHeight)
-            drawOfflineBanner(in: context, rect: bannerRect, skin: skin)
+        // In the compact window's Playlist mode the embedded queue subview fills the content
+        // region, so skip drawing the library chrome (server bar / tabs / search / list /
+        // alphabet) behind it — the shared Cava/art backdrop then shows through the queue,
+        // matching how it shows behind the library list.
+        let showLibraryContent = !(compactMode && compactContentMode == .queue)
+
+        if showLibraryContent {
+            // Server bar (below title bar in screen coords)
+            drawServerBar(in: context, serverBarY: serverBarY, skin: skin)
+
+            // Tab bar (below server bar)
+            let tabBarY = serverBarY - Layout.tabBarHeight
+            drawTabBar(in: context, tabBarY: tabBarY, skin: skin)
+
+            // Search bar (below tab bar, only in search mode)
+            var contentTopY = tabBarY
+            if browseMode == .search {
+                contentTopY -= Layout.searchBarHeight
+                drawSearchBar(in: context, searchBarY: contentTopY, skin: skin)
+            }
+
+            // Content bottom: status-bar margin plus the compact footer band.
+            let contentBottomY = contentRegionBottomY
+
+            // Offline volume banner (local source only, above list content)
+            let showOfflineBanner = isLocalSource && !offlineWatchFolders.isEmpty
+            let bannerHeight = showOfflineBanner ? Layout.offlineBannerHeight : 0
+
+            // List area (between content top and content bottom)
+            let listAreaY = contentBottomY + bannerHeight
+            let listAreaHeight = contentTopY - contentBottomY - bannerHeight
+            let listRect = NSRect(x: Layout.borderWidth, y: listAreaY,
+                                  width: bounds.width - Layout.borderWidth * 2, height: listAreaHeight)
+
+            if showOfflineBanner {
+                let bannerRect = NSRect(x: Layout.borderWidth, y: contentBottomY,
+                                       width: bounds.width - Layout.borderWidth * 2, height: bannerHeight)
+                drawOfflineBanner(in: context, rect: bannerRect, skin: skin)
+            }
+
+            if browseMode.isHistoryMode {
+                drawArtworkBackground(in: context, listRect: listRect, artwork: capturedArtwork)
+                // SwiftUI-hosted history content is rendered via an embedded subview.
+            } else if isArtOnlyMode {
+                // Art-only mode takes precedence over loading/error states (matches PlexBrowserView)
+                // so that visualization continues uninterrupted during data refreshes
+                drawArtOnlyArea(in: context, contentRect: listRect, skin: skin, artwork: capturedArtwork)
+            } else if currentSource.isPlex && !PlexManager.shared.isLinked {
+                drawNotLinkedState(in: context, listRect: listRect, skin: skin)
+            } else if isLoading {
+                drawLoadingState(in: context, listRect: listRect, skin: skin)
+            } else if let error = errorMessage {
+                drawErrorState(in: context, message: error, listRect: listRect, skin: skin)
+            } else {
+                drawListArea(in: context, listAreaY: listAreaY, listAreaHeight: listAreaHeight, skin: skin, artwork: capturedArtwork)
+            }
+
+            // Status bar text
+            drawStatusBarText(in: context, skin: skin)
         }
 
-        if browseMode.isHistoryMode {
-            drawArtworkBackground(in: context, listRect: listRect, artwork: capturedArtwork)
-            // SwiftUI-hosted history content is rendered via an embedded subview.
-        } else if isArtOnlyMode {
-            // Art-only mode takes precedence over loading/error states (matches PlexBrowserView)
-            // so that visualization continues uninterrupted during data refreshes
-            drawArtOnlyArea(in: context, contentRect: listRect, skin: skin, artwork: capturedArtwork)
-        } else if currentSource.isPlex && !PlexManager.shared.isLinked {
-            drawNotLinkedState(in: context, listRect: listRect, skin: skin)
-        } else if isLoading {
-            drawLoadingState(in: context, listRect: listRect, skin: skin)
-        } else if let error = errorMessage {
-            drawErrorState(in: context, message: error, listRect: listRect, skin: skin)
-        } else {
-            drawListArea(in: context, listAreaY: listAreaY, listAreaHeight: listAreaHeight, skin: skin, artwork: capturedArtwork)
+        // Library | Playlist toggle footer at the bottom (compact window only).
+        if compactMode {
+            drawCompactFooter(in: context, skin: skin)
         }
-        
-        // Status bar text
-        drawStatusBarText(in: context, skin: skin)
+
         context.restoreGState()
 
         if isHighlighted {
@@ -1591,6 +1667,47 @@ class ModernLibraryBrowserView: NSView {
     }
     
     /// Draw a modern boxed toggle button
+    /// Full band of the Library|Playlist toggle footer at the bottom (compact window only),
+    /// sitting just above the thin status-bar margin.
+    private var compactFooterRect: NSRect {
+        NSRect(x: Layout.borderWidth, y: Layout.statusBarHeight,
+               width: bounds.width - Layout.borderWidth * 2,
+               height: compactFooterHeight)
+    }
+
+    /// The two full-width halves of the footer band — (.library, .queue) — used for both
+    /// hit-testing and (after insetting to the tab-box size) drawing, mirroring the tab bar.
+    private func compactToggleSegmentRects() -> (library: NSRect, queue: NSRect) {
+        let strip = compactFooterRect
+        let halfWidth = (strip.width / 2).rounded()
+        let library = NSRect(x: strip.minX, y: strip.minY, width: halfWidth, height: strip.height)
+        let queue = NSRect(x: strip.minX + halfWidth, y: strip.minY,
+                           width: strip.width - halfWidth, height: strip.height)
+        return (library, queue)
+    }
+
+    private func drawCompactFooter(in context: CGContext, skin: ModernSkin) {
+        guard compactFooterHeight > 0 else { return }
+
+        // Fill the band to match the tab-bar row so the footer reads as part of the chrome.
+        contentFill(isMetalRenderStyle ? metalControlBandFill : skin.surfaceColor.withAlphaComponent(0.4)).setFill()
+        context.fill(compactFooterRect)
+
+        let chromeScale = topChromeScale(for: skin)
+        let font = skin.libraryFont(size: (compactMode ? 11 : 12) * chromeScale)
+        let m = ModernSkinElements.sizeMultiplier
+        // Same box insets the tab bar uses (drawTabBar), so the toggle boxes match the tabs.
+        let insetX = 2 * m * chromeScale
+        let insetY = 2 * m
+        let segments = compactToggleSegmentRects()
+        drawToggleTab(label: "Library", isActive: compactContentMode == .library,
+                      rect: segments.library.insetBy(dx: insetX, dy: insetY),
+                      font: font, skin: skin, context: context)
+        drawToggleTab(label: "Playlist", isActive: compactContentMode == .queue,
+                      rect: segments.queue.insetBy(dx: insetX, dy: insetY),
+                      font: font, skin: skin, context: context)
+    }
+
     private func drawToggleTab(label: String, isActive: Bool, rect: NSRect,
                                font: NSFont, skin: ModernSkin, context: CGContext) {
         let scale = ModernSkinElements.scaleFactor
@@ -3655,7 +3772,7 @@ class ModernLibraryBrowserView: NSView {
         let hasColumns = displayItems.contains { columnsForItem($0) != nil }
         if hasColumns { contentTopY -= columnHeaderHeight }
         
-        let contentBottomY = Layout.statusBarHeight
+        let contentBottomY = contentRegionBottomY
         let contentHeight = contentTopY - contentBottomY
         
         let alphabetWidth = Layout.alphabetWidth
@@ -3685,7 +3802,7 @@ class ModernLibraryBrowserView: NSView {
         let hasColumns = displayItems.contains { columnsForItem($0) != nil }
         if hasColumns { contentTopY -= columnHeaderHeight }
 
-        let contentBottomY = Layout.statusBarHeight
+        let contentBottomY = contentRegionBottomY
         let alphabetWidth = Layout.alphabetWidth
         let listRect = NSRect(
             x: Layout.borderWidth,
@@ -3731,8 +3848,8 @@ class ModernLibraryBrowserView: NSView {
         let showOfflineBanner = isLocalSource && !offlineWatchFolders.isEmpty
         let bannerHeight = showOfflineBanner ? Layout.offlineBannerHeight : 0
 
-        let listAreaY = Layout.statusBarHeight + bannerHeight
-        let listAreaHeight = contentTopY - Layout.statusBarHeight - bannerHeight
+        let listAreaY = contentRegionBottomY + bannerHeight
+        let listAreaHeight = contentTopY - contentRegionBottomY - bannerHeight
 
         let hasColumns = headerColumnsForCurrentContent() != nil
         let alphabetHeight = listAreaHeight - (hasColumns ? columnHeaderHeight : 0)
@@ -3747,7 +3864,7 @@ class ModernLibraryBrowserView: NSView {
     
     private func hitTestContentArea(at point: NSPoint) -> Bool {
         let contentTopY = topChromeBottomY - Layout.serverBarHeight
-        let contentBottomY = Layout.statusBarHeight
+        let contentBottomY = contentRegionBottomY
         let contentRect = NSRect(x: Layout.borderWidth, y: contentBottomY,
                                  width: bounds.width - Layout.borderWidth * 2 - Layout.scrollbarWidth,
                                  height: contentTopY - contentBottomY)
@@ -3896,7 +4013,22 @@ class ModernLibraryBrowserView: NSView {
         if !WindowManager.shared.hideTitleBars {
             if hitTestCloseButton(at: point) { pressedButton = .close; needsDisplay = true; return }
         }
-        
+
+        // Library | Playlist toggle footer (compact window only). The footer band sits below
+        // the content region, outside the embedded queue subview's frame, so its clicks
+        // always reach the parent regardless of z-order.
+        if compactMode, compactFooterHeight > 0 {
+            let segments = compactToggleSegmentRects()
+            if segments.library.contains(point) {
+                if compactContentMode != .library { compactContentMode = .library }
+                return
+            }
+            if segments.queue.contains(point) {
+                if compactContentMode != .queue { compactContentMode = .queue }
+                return
+            }
+        }
+
         // Server bar (check before content area so ART/VIS/source buttons work)
         if hitTestServerBar(at: point) {
             if case .plex = currentSource, !PlexManager.shared.isLinked {
@@ -4102,14 +4234,14 @@ class ModernLibraryBrowserView: NSView {
         }
         var contentTopY = topChromeBottomY - Layout.serverBarHeight - Layout.tabBarHeight
         if browseMode == .search { contentTopY -= Layout.searchBarHeight }
-        let listHeight = contentTopY - Layout.statusBarHeight
+        let listHeight = contentTopY - contentRegionBottomY
         let totalHeight = CGFloat(displayItems.count) * itemHeight
         let verticalDelta = verticalScrollDelta(from: event)
 
         if totalHeight > listHeight && verticalDelta != 0 {
             scrollOffset = max(0, min(totalHeight - listHeight, scrollOffset - verticalDelta))
 
-            let listRect = NSRect(x: 0, y: Layout.statusBarHeight, width: bounds.width, height: listHeight)
+            let listRect = NSRect(x: 0, y: contentRegionBottomY, width: bounds.width, height: listHeight)
             setNeedsDisplay(listRect)
         }
 
@@ -4122,7 +4254,7 @@ class ModernLibraryBrowserView: NSView {
             let maxOffset = max(0, totalWidth - availableWidth)
             if maxOffset > 0 {
                 horizontalScrollOffset = max(0, min(maxOffset, horizontalScrollOffset - horizontalDelta))
-                let listRect = NSRect(x: 0, y: Layout.statusBarHeight, width: bounds.width, height: listHeight)
+                let listRect = NSRect(x: 0, y: contentRegionBottomY, width: bounds.width, height: listHeight)
                 setNeedsDisplay(listRect)
             }
         }
@@ -4347,7 +4479,7 @@ class ModernLibraryBrowserView: NSView {
     private func ensureVisible(index: Int) {
         var contentTopY = topChromeBottomY - Layout.serverBarHeight - Layout.tabBarHeight
         if browseMode == .search { contentTopY -= Layout.searchBarHeight }
-        let listHeight = contentTopY - Layout.statusBarHeight
+        let listHeight = contentTopY - contentRegionBottomY
         let hasColumns = displayItems.contains { columnsForItem($0) != nil }
         let effectiveHeight = listHeight - (hasColumns ? columnHeaderHeight : 0)
 
@@ -4650,7 +4782,7 @@ class ModernLibraryBrowserView: NSView {
             if effectiveSortLetter(for: item) == letter {
                 var contentTopY = topChromeBottomY - Layout.serverBarHeight - Layout.tabBarHeight
                 if browseMode == .search { contentTopY -= Layout.searchBarHeight }
-                let listHeight = contentTopY - Layout.statusBarHeight
+                let listHeight = contentTopY - contentRegionBottomY
                 let hasColumns = displayItems.contains { columnsForItem($0) != nil }
                 let effectiveHeight = listHeight - (hasColumns ? columnHeaderHeight : 0)
                 let maxScroll = max(0, CGFloat(displayItems.count) * itemHeight - effectiveHeight)

--- a/Sources/NullPlayer/Windows/ModernLibraryBrowser/ModernLibraryBrowserView.swift
+++ b/Sources/NullPlayer/Windows/ModernLibraryBrowser/ModernLibraryBrowserView.swift
@@ -1202,20 +1202,35 @@ class ModernLibraryBrowserView: NSView {
             return
         }
         let queue: ModernPlaylistView
+        let didCreateQueue: Bool
         if let existing = compactPlaylistView {
             queue = existing
+            didCreateQueue = false
         } else {
             queue = ModernPlaylistView(frame: .zero)
             queue.isEmbedded = true
             // Render above the library chrome and the Cava/art backdrop.
             addSubview(queue)
             compactPlaylistView = queue
+            didCreateQueue = true
         }
         let border = Layout.borderWidth
         queue.frame = NSRect(x: border, y: contentRegionBottomY,
                              width: bounds.width - border * 2,
                              height: max(0, topChromeBottomY - contentRegionBottomY))
         queue.isHidden = (compactContentMode != .queue)
+        if didCreateQueue {
+            // `reloadData()` needs the final frame so it can scroll the current track into view.
+            queue.reloadData()
+            if compactContentMode == .queue {
+                window?.makeFirstResponder(queue)
+            }
+        }
+    }
+
+    /// Refresh the private playlist presentation after the shared audio-engine queue mutates.
+    func reloadCompactPlaylist() {
+        compactPlaylistView?.reloadData()
     }
 
     /// Seed the bar with the engine's current state so it isn't blank until the next update tick.
@@ -1289,13 +1304,14 @@ class ModernLibraryBrowserView: NSView {
         let backgroundOpacity = backdropActive
             ? mainOpacity.background * backdropScrimAlpha
             : mainOpacity.background
+        let isShowingCompactPlaylist = compactMode && compactContentMode == .queue
 
         // Fast path: scroll timer marks only server bar dirty — skip full window redraw.
         // Always fill the full background first (copy blend mode) so the layer is never
         // left partially transparent from accumulated alpha on repeated scroll-tick draws.
         let serverBarY = topChromeBottomY - Layout.serverBarHeight
         let sbRect = NSRect(x: 0, y: serverBarY, width: bounds.width, height: Layout.serverBarHeight)
-        if sbRect.contains(dirtyRect) {
+        if !isShowingCompactPlaylist, sbRect.contains(dirtyRect) {
             // Build the renderer from the current skin (not the cached instance) so the
             // background can't lag a skin swap and render the wrong surface under the bands.
             let renderer = ModernSkinRenderer(skin: skin)
@@ -1361,7 +1377,7 @@ class ModernLibraryBrowserView: NSView {
         // region, so skip drawing the library chrome (server bar / tabs / search / list /
         // alphabet) behind it — the shared Cava/art backdrop then shows through the queue,
         // matching how it shows behind the library list.
-        let showLibraryContent = !(compactMode && compactContentMode == .queue)
+        let showLibraryContent = !isShowingCompactPlaylist
 
         if showLibraryContent {
             // Server bar (below title bar in screen coords)

--- a/Sources/NullPlayer/Windows/ModernLibraryBrowser/ModernLibraryBrowserWindowController.swift
+++ b/Sources/NullPlayer/Windows/ModernLibraryBrowser/ModernLibraryBrowserWindowController.swift
@@ -151,6 +151,10 @@ class ModernLibraryBrowserWindowController: NSWindowController, LibraryBrowserWi
         browserView.compactBarUpdatePlaybackState()
     }
 
+    func reloadCompactPlaylist() {
+        browserView.reloadCompactPlaylist()
+    }
+
     var compactBackdropPresenter: CavaPresenter? {
         browserView.backdropPresenter
     }

--- a/Sources/NullPlayer/Windows/ModernPlaylist/ModernPlaylistView.swift
+++ b/Sources/NullPlayer/Windows/ModernPlaylist/ModernPlaylistView.swift
@@ -33,6 +33,13 @@ class ModernPlaylistView: NSView {
     /// Button being pressed (for visual feedback)
     private var pressedButton: String?
     
+    /// When true this playlist is embedded inside another window's content region
+    /// (the compact library window's Queue mode) rather than being its own standalone
+    /// window. Forces the standalone title bar/close button hidden AND disables all
+    /// window-drag/undock/close behavior, so body clicks route to track selection and
+    /// the host window is dragged by its own title bar.
+    var isEmbedded = false
+
     /// Window dragging state
     private var isDraggingWindow = false
     private var windowDragStartPoint: NSPoint = .zero
@@ -64,7 +71,7 @@ class ModernPlaylistView: NSView {
     // MARK: - Layout Constants
     
     private var titleBarHeight: CGFloat {
-        let hide = WindowManager.shared.effectiveHideTitleBars(for: self.window)
+        let hide = isEmbedded || WindowManager.shared.effectiveHideTitleBars(for: self.window)
         return hide ? borderWidth : ModernSkinElements.playlistTitleBarHeight
     }
     private var bottomBarHeight: CGFloat { ModernSkinElements.playlistBottomBarHeight }
@@ -360,14 +367,18 @@ class ModernPlaylistView: NSView {
     override func draw(_ dirtyRect: NSRect) {
         guard let context = NSGraphicsContext.current?.cgContext else { return }
         
-        // Draw window background
-        renderer.drawWindowBackground(in: bounds, context: context, adjacentEdges: adjacentEdges, sharpCorners: sharpCorners)
+        // Draw window background. When embedded in the compact window we stay transparent so
+        // the host library view's translucent background — and the shared Cava/art backdrop
+        // behind it — show through the queue exactly as they do behind the library list.
+        if !isEmbedded {
+            renderer.drawWindowBackground(in: bounds, context: context, adjacentEdges: adjacentEdges, sharpCorners: sharpCorners)
 
-        // Draw window border with glow (seamless docking suppresses adjacent edges)
-        renderer.drawWindowBorder(in: bounds, context: context, adjacentEdges: adjacentEdges, sharpCorners: sharpCorners, occlusionSegments: edgeOcclusionSegments)
+            // Draw window border with glow (seamless docking suppresses adjacent edges).
+            renderer.drawWindowBorder(in: bounds, context: context, adjacentEdges: adjacentEdges, sharpCorners: sharpCorners, occlusionSegments: edgeOcclusionSegments)
+        }
 
-        // Draw title bar (unless hidden by docking)
-        if !WindowManager.shared.effectiveHideTitleBars(for: self.window) {
+        // Draw title bar (unless hidden by docking, or embedded in the compact window)
+        if !isEmbedded && !WindowManager.shared.effectiveHideTitleBars(for: self.window) {
             renderer.drawTitleBar(in: titleBarBaseRect, title: "NULLPLAYER PLAYLIST", prefix: "playlist_", context: context)
             
             // Draw close button
@@ -410,9 +421,12 @@ class ModernPlaylistView: NSView {
         
         context.saveGState()
         context.clip(to: listRect)
-        
-        // Draw album art background behind tracks
-        drawArtworkBackground(in: listRect, context: context)
+
+        // Draw album art background behind tracks. Skipped when embedded so the compact
+        // window's shared backdrop shows through instead of a second art layer.
+        if !isEmbedded {
+            drawArtworkBackground(in: listRect, context: context)
+        }
         
         let engine = WindowManager.shared.audioEngine
         let tracks = engine.playlist
@@ -829,6 +843,7 @@ class ModernPlaylistView: NSView {
     // MARK: - Hit Testing
     
     private func hitTestTitleBar(at point: NSPoint) -> Bool {
+        if isEmbedded { return false }  // embedded: not draggable, no title bar
         if WindowManager.shared.effectiveHideTitleBars(for: self.window) {
             return point.y >= bounds.height - 6  // invisible drag zone
         }
@@ -838,6 +853,7 @@ class ModernPlaylistView: NSView {
     }
     
     private func hitTestCloseButton(at point: NSPoint) -> Bool {
+        if isEmbedded { return false }  // embedded: no close button
         if WindowManager.shared.effectiveHideTitleBars(for: self.window) { return false }
         let scale = ModernSkinElements.scaleFactor
         let closeRect = NSRect(x: bounds.width - 16 * scale, y: bounds.height - titleBarHeight + 2 * scale,
@@ -902,7 +918,7 @@ class ModernPlaylistView: NSView {
 
         // Track list
         if let trackIndex = hitTestTrackList(at: point) {
-            if WindowManager.shared.effectiveHideTitleBars(for: self.window) {
+            if !isEmbedded && WindowManager.shared.effectiveHideTitleBars(for: self.window) {
                 // Defer the click so the user can drag to undock; commit on mouseUp if no drag
                 pendingTrackClick = (trackIndex, event)
                 hasDraggedWindow = false
@@ -912,11 +928,14 @@ class ModernPlaylistView: NSView {
                     WindowManager.shared.windowWillStartDragging(window, fromTitleBar: true)
                 }
             } else {
+                // Embedded queue: keep keyboard focus on this view so arrow-key nav
+                // moves selection here rather than the hidden host library list.
+                if isEmbedded { window?.makeFirstResponder(self) }
                 handleTrackClick(index: trackIndex, event: event)
             }
             return
         }
-        
+
         // Title bar → window drag
         if hitTestTitleBar(at: point) {
             isDraggingWindow = true
@@ -927,8 +946,9 @@ class ModernPlaylistView: NSView {
             return
         }
 
-        // When title bar is hidden (docked + HT on), allow dragging from anywhere
-        if WindowManager.shared.effectiveHideTitleBars(for: self.window) {
+        // When title bar is hidden (docked + HT on), allow dragging from anywhere.
+        // Embedded queue never drags its host window from the body.
+        if !isEmbedded && WindowManager.shared.effectiveHideTitleBars(for: self.window) {
             isDraggingWindow = true
             windowDragStartPoint = event.locationInWindow
             if let window = window {

--- a/Sources/NullPlayer/Windows/Playlist/PlaylistView.swift
+++ b/Sources/NullPlayer/Windows/Playlist/PlaylistView.swift
@@ -46,7 +46,9 @@ class PlaylistView: NSView {
     /// How far (in view points) the host must extend this view's frame up behind the compact
     /// player bar so the drawn title bar is hidden. Equals the title-bar height at this view's
     /// current scale.
-    var embeddedTopInset: CGFloat { Layout.titleBarHeight * scaleFactor }
+    var embeddedTopInset: CGFloat {
+        isEmbedded ? Layout.titleBarHeight * scaleFactor : 0
+    }
 
     /// Window dragging state
     private var isDraggingWindow = false

--- a/Sources/NullPlayer/Windows/Playlist/PlaylistView.swift
+++ b/Sources/NullPlayer/Windows/Playlist/PlaylistView.swift
@@ -36,6 +36,18 @@ class PlaylistView: NSView {
     /// Button being pressed (for visual feedback)
     private var pressedButton: SkinRenderer.PlaylistButtonType?
 
+    /// When true this playlist is embedded inside the classic compact library window rather
+    /// than being its own standalone window. It draws normally (title bar at the top), and the
+    /// host tucks that title bar up behind the compact player bar by extending the view's frame
+    /// (see `embeddedTopInset`) — the same gap-free mechanism the browser uses. Window
+    /// drag/close is disabled so body clicks route to track selection.
+    var isEmbedded = false
+
+    /// How far (in view points) the host must extend this view's frame up behind the compact
+    /// player bar so the drawn title bar is hidden. Equals the title-bar height at this view's
+    /// current scale.
+    var embeddedTopInset: CGFloat { Layout.titleBarHeight * scaleFactor }
+
     /// Window dragging state
     private var isDraggingWindow = false
     private var windowDragStartPoint: NSPoint = .zero
@@ -1002,6 +1014,7 @@ class PlaylistView: NSView {
 
     /// Check if point hits title bar (for dragging)
     private func hitTestTitleBar(at skinPoint: NSPoint) -> Bool {
+        if isEmbedded { return false }  // embedded: not draggable, no title bar
         if WindowManager.shared.hideTitleBars {
             // Use view-space drag zone: skinPoint.y near the top = small y value
             // With the offset applied, skin y = titleBarHeight corresponds to the top of the visible window
@@ -1014,7 +1027,7 @@ class PlaylistView: NSView {
 
     /// Check if point hits close button (enlarged hit area extends to right edge and top)
     private func hitTestCloseButton(at skinPoint: NSPoint) -> Bool {
-        if WindowManager.shared.hideTitleBars { return false }
+        if isEmbedded || WindowManager.shared.hideTitleBars { return false }  // embedded/docked-hidden: no close button
         let effectiveSize = effectiveWindowSize
         let closeRect = NSRect(x: effectiveSize.width - 20, y: 0, width: 20, height: 14)
         return closeRect.contains(skinPoint)

--- a/Sources/NullPlayer/Windows/PlexBrowser/ClassicCompactContainerView.swift
+++ b/Sources/NullPlayer/Windows/PlexBrowser/ClassicCompactContainerView.swift
@@ -2,19 +2,28 @@ import AppKit
 
 /// Content view used while the classic library browser is in Compact Mode.
 ///
-/// Lays out two children deterministically on every resize (rather than relying on
+/// Lays out its children deterministically on every resize (rather than relying on
 /// autoresizing masks, which proved fragile and let the browser occasionally cover the
 /// player bar's SOURCE row):
 ///   • `playerBar` — pinned across the top, fixed `barHeight`.
-///   • `browser`   — fills the rest, but is extended *up behind* the player bar by
-///                   `titleBarHeight` so the browser's own "LIBRARY" title bar is tucked
-///                   out of sight under the (opaque) player bar.
+///   • `footer`    — pinned across the bottom, fixed `footerHeight`: the Library|Playlist toggle.
+///   • `browser` / `playlist` — fill the region between footer and player bar. Exactly one is
+///                   visible at a time (chosen by the footer toggle). The browser is extended
+///                   *up behind* the player bar by `titleBarHeight` so its own "LIBRARY" title
+///                   bar is tucked out of sight under the (opaque) player bar; the embedded
+///                   playlist tucks its own title bar internally, so it uses the plain region.
 final class ClassicCompactContainerView: NSView {
 
     weak var playerBar: NSView?
+    weak var footer: NSView?
     weak var browser: NSView?
+    weak var playlist: NSView?
     var barHeight: CGFloat = 0
+    var footerHeight: CGFloat = 0
+    /// How far the browser's frame extends up behind the player bar to hide its title bar.
     var titleBarHeight: CGFloat = 0
+    /// Same, for the embedded playlist — sized to the playlist's own (scaled) title bar.
+    var playlistTitleInset: CGFloat = 0
 
     override init(frame frameRect: NSRect) {
         super.init(frame: frameRect)
@@ -39,7 +48,14 @@ final class ClassicCompactContainerView: NSView {
     func layoutChildren() {
         let w = bounds.width
         let h = bounds.height
-        browser?.frame = NSRect(x: 0, y: 0, width: w, height: max(0, h - barHeight + titleBarHeight))
+        // Visible content region between the footer (bottom) and the player bar (top).
+        let contentBottom = footerHeight
+        let contentHeight = max(0, h - barHeight - footerHeight)
+        // Browser and embedded playlist are each extended up behind the player bar by their own
+        // title-bar height so the title bar is hidden and the visible content fills to the footer.
+        browser?.frame = NSRect(x: 0, y: contentBottom, width: w, height: contentHeight + titleBarHeight)
+        playlist?.frame = NSRect(x: 0, y: contentBottom, width: w, height: contentHeight + playlistTitleInset)
+        footer?.frame = NSRect(x: 0, y: 0, width: w, height: footerHeight)
         playerBar?.frame = NSRect(x: 0, y: h - barHeight, width: w, height: barHeight)
     }
 }

--- a/Sources/NullPlayer/Windows/PlexBrowser/ClassicCompactFooterView.swift
+++ b/Sources/NullPlayer/Windows/PlexBrowser/ClassicCompactFooterView.swift
@@ -82,7 +82,7 @@ final class ClassicCompactFooterView: NSView {
         guard let context = NSGraphicsContext.current?.cgContext else { return }
         let skin = currentSkin()
         let renderer = SkinRenderer(skin: skin)
-        let colors = skin.playlistColors ?? .default
+        let colors = skin.playlistColors
         let scale = nativeScale
 
         // Flip to top-left origin, then scale into native units (matches the player bar).

--- a/Sources/NullPlayer/Windows/PlexBrowser/ClassicCompactFooterView.swift
+++ b/Sources/NullPlayer/Windows/PlexBrowser/ClassicCompactFooterView.swift
@@ -1,0 +1,147 @@
+import AppKit
+
+/// A classic-skin footer pinned across the bottom of the library browser in Compact Mode
+/// (classic UI). Renders a two-segment "Library | Playlist" toggle that switches the compact
+/// window's content region between the library browser and the embedded play queue.
+///
+/// This is the classic-UI analogue of the modern library window's compact footer toggle. It
+/// draws with authentic classic skin colors and the classic bitmap font (via `SkinRenderer`),
+/// mirroring the browser's own tab-bar styling, and has ZERO dependency on the modern skin
+/// system.
+///
+/// Coordinate note: like `ClassicCompactPlayerBarView`, everything is laid out in classic
+/// *native* pixel units (top-left origin, y grows downward) and a single uniform scale
+/// transform fills the on-screen frame. Hit-testing converts mouse points back into that space.
+final class ClassicCompactFooterView: NSView {
+
+    /// Native design height — matches the classic browser tab-bar row.
+    private let designHeight: CGFloat = SkinElements.PlexBrowser.Layout.tabBarHeight
+    /// Small margin from the window edge; the two segments fill the rest edge-to-edge so they
+    /// take up the whole footer width (matching the modern library window's toggle).
+    private let sideInset: CGFloat = 2
+
+    /// Whether the Playlist segment is the active one (else Library).
+    var showingPlaylist = false {
+        didSet { if showingPlaylist != oldValue { needsDisplay = true } }
+    }
+
+    /// Invoked when the user picks a segment; `true` = Playlist, `false` = Library.
+    var onSelect: ((_ showPlaylist: Bool) -> Void)?
+
+    /// Suggested on-screen footer height. Matches the compact player bar's scale convention so
+    /// the bitmap chrome is not resampled at a footer-only scale.
+    static func preferredHeight() -> CGFloat {
+        SkinElements.PlexBrowser.Layout.tabBarHeight * Skin.scaleFactor
+    }
+
+    override init(frame frameRect: NSRect) {
+        super.init(frame: frameRect)
+        wantsLayer = true
+    }
+
+    required init?(coder: NSCoder) {
+        super.init(coder: coder)
+        wantsLayer = true
+    }
+
+    func skinDidChange() { needsDisplay = true }
+
+    // MARK: - Coordinate helpers
+
+    /// Uniform scale from native units → view points.
+    private var nativeScale: CGFloat {
+        guard designHeight > 0 else { return 1 }
+        return bounds.height / designHeight
+    }
+
+    /// Footer width in native units.
+    private var designWidth: CGFloat {
+        let s = nativeScale
+        return s > 0 ? bounds.width / s : bounds.width
+    }
+
+    private func currentSkin() -> Skin {
+        WindowManager.shared.currentSkin ?? SkinLoader.shared.loadDefault()
+    }
+
+    /// The two segment rects in native units (top-left origin) — (.library, .playlist).
+    private func segmentRects() -> (library: NSRect, playlist: NSRect) {
+        let barRect = NSRect(x: sideInset, y: 0,
+                             width: max(0, designWidth - sideInset * 2),
+                             height: designHeight)
+        let half = (barRect.width / 2).rounded()
+        let library = NSRect(x: barRect.minX, y: 0, width: half, height: designHeight)
+        let playlist = NSRect(x: barRect.minX + half, y: 0,
+                              width: barRect.width - half, height: designHeight)
+        return (library, playlist)
+    }
+
+    // MARK: - Drawing
+
+    override func draw(_ dirtyRect: NSRect) {
+        guard let context = NSGraphicsContext.current?.cgContext else { return }
+        let skin = currentSkin()
+        let renderer = SkinRenderer(skin: skin)
+        let colors = skin.playlistColors ?? .default
+        let scale = nativeScale
+
+        // Flip to top-left origin, then scale into native units (matches the player bar).
+        context.saveGState()
+        context.translateBy(x: 0, y: bounds.height)
+        context.scaleBy(x: 1, y: -1)
+        context.scaleBy(x: scale, y: scale)
+
+        // Band background — same treatment as the browser's tab bar row.
+        colors.normalBackground.setFill()
+        context.fill(NSRect(x: 0, y: 0, width: designWidth, height: designHeight))
+
+        let segments = segmentRects()
+        drawSegment("Library", rect: segments.library, isActive: !showingPlaylist,
+                    colors: colors, renderer: renderer, context: context)
+        drawSegment("Playlist", rect: segments.playlist, isActive: showingPlaylist,
+                    colors: colors, renderer: renderer, context: context)
+
+        context.restoreGState()
+    }
+
+    private func drawSegment(_ label: String, rect: NSRect, isActive: Bool,
+                             colors: PlaylistColors, renderer: SkinRenderer, context: CGContext) {
+        // Boxed toggle outline, mirroring the classic browser's tabs (drawTabBar).
+        let boxRect = rect.insetBy(dx: 2, dy: 3)
+        let boxPath = NSBezierPath(roundedRect: boxRect, xRadius: 3, yRadius: 3)
+        boxPath.lineWidth = 1
+        if isActive {
+            colors.currentText.withAlphaComponent(0.12).setFill()
+            boxPath.fill()
+            colors.currentText.withAlphaComponent(0.8).setStroke()
+        } else {
+            colors.normalText.withAlphaComponent(0.4).setStroke()
+        }
+        boxPath.stroke()
+
+        // Centered classic bitmap text — white when active, green otherwise.
+        let charWidth = SkinElements.TextFont.charWidth
+        let charHeight = SkinElements.TextFont.charHeight
+        let textWidth = CGFloat(label.count) * charWidth
+        let textX = (rect.midX - textWidth / 2).rounded()
+        let textY = (rect.midY - charHeight / 2).rounded()
+        if isActive {
+            _ = renderer.drawSkinTextWhite(label, at: NSPoint(x: textX, y: textY), in: context)
+        } else {
+            _ = renderer.drawSkinText(label, at: NSPoint(x: textX, y: textY), in: context)
+        }
+    }
+
+    // MARK: - Mouse
+
+    override func mouseDown(with event: NSEvent) {
+        let point = convert(event.locationInWindow, from: nil)
+        let scale = nativeScale
+        guard scale > 0 else { return }
+        // View point (bottom-left origin) → native units (top-left origin).
+        let nativeX = point.x / scale
+        let segments = segmentRects()
+        // Split at the divider so the entire footer width is clickable (incl. the thin margins).
+        onSelect?(nativeX >= segments.playlist.minX)
+    }
+}

--- a/Sources/NullPlayer/Windows/PlexBrowser/PlexBrowserWindowController.swift
+++ b/Sources/NullPlayer/Windows/PlexBrowser/PlexBrowserWindowController.swift
@@ -23,7 +23,17 @@ class PlexBrowserWindowController: NSWindowController, LibraryBrowserWindowProvi
     /// embedded `ClassicCompactPlayerBarView` pinned across the top.
     private(set) var isCompactMode = false
     private var compactBar: ClassicCompactPlayerBarView?
-    private var compactContainer: NSView?
+    private var compactContainer: ClassicCompactContainerView?
+    private var compactFooter: ClassicCompactFooterView?
+    private var compactPlaylist: PlaylistView?
+
+    /// Persisted content choice for the compact window's Library|Playlist toggle. Shares the
+    /// `compactContentMode` key with the modern library window so the choice is consistent
+    /// across UI families (0 = library, 1 = playlist).
+    private var compactShowsPlaylist: Bool {
+        get { UserDefaults.standard.integer(forKey: "compactContentMode") == 1 }
+        set { UserDefaults.standard.set(newValue ? 1 : 0, forKey: "compactContentMode") }
+    }
 
     // MARK: - Initialization
     
@@ -131,6 +141,8 @@ class PlexBrowserWindowController: NSWindowController, LibraryBrowserWindowProvi
     func skinDidChange() {
         browserView.skinDidChange()
         compactBar?.skinDidChange()
+        compactFooter?.skinDidChange()
+        compactPlaylist?.needsDisplay = true
     }
 
     /// Mode-dependent teardown: forward to the view so it cancels its in-flight tasks/timers
@@ -159,31 +171,80 @@ class PlexBrowserWindowController: NSWindowController, LibraryBrowserWindowProvi
             let container = ClassicCompactContainerView(frame: NSRect(origin: .zero, size: size))
             container.autoresizingMask = [.width, .height]
             container.barHeight = ClassicCompactPlayerBarView.preferredHeight()
+            container.footerHeight = ClassicCompactFooterView.preferredHeight()
             container.titleBarHeight = SkinElements.PlexBrowser.Layout.titleBarHeight
 
             browserView.autoresizingMask = []
             let bar = ClassicCompactPlayerBarView(frame: .zero)
             bar.autoresizingMask = []
 
+            // Embedded play queue, shown in place of the browser in Playlist mode.
+            let playlist = PlaylistView(frame: .zero)
+            playlist.isEmbedded = true
+            playlist.autoresizingMask = []
+            container.playlistTitleInset = playlist.embeddedTopInset
+
+            // Library | Playlist toggle footer across the bottom.
+            let footer = ClassicCompactFooterView(frame: .zero)
+            footer.autoresizingMask = []
+            footer.onSelect = { [weak self] showPlaylist in
+                self?.setCompactShowsPlaylist(showPlaylist)
+            }
+
             container.addSubview(browserView)
+            container.addSubview(playlist)
             container.addSubview(bar)
+            container.addSubview(footer)
             container.browser = browserView
+            container.playlist = playlist
             container.playerBar = bar
+            container.footer = footer
             window.contentView = container
             container.layoutChildren()
+
             compactContainer = container
             compactBar = bar
+            compactFooter = footer
+            compactPlaylist = playlist
             seedCompactBar(bar)
+            applyCompactContentMode()
         } else {
             let size = (window.contentView?.frame.size) ?? browserView.frame.size
             compactBar?.removeFromSuperview()
+            compactFooter?.removeFromSuperview()
+            compactPlaylist?.removeFromSuperview()
             compactBar = nil
+            compactFooter = nil
+            compactPlaylist = nil
             compactContainer = nil
+            browserView.isHidden = false
             browserView.frame = NSRect(origin: .zero, size: size)
             browserView.autoresizingMask = [.width, .height]
             window.contentView = browserView
         }
         browserView.needsDisplay = true
+    }
+
+    /// Flip the compact window between the library browser and the embedded play queue,
+    /// persisting the choice, then apply the new visibility.
+    private func setCompactShowsPlaylist(_ showPlaylist: Bool) {
+        guard compactShowsPlaylist != showPlaylist else { return }
+        compactShowsPlaylist = showPlaylist
+        applyCompactContentMode()
+    }
+
+    /// Show the browser XOR the embedded playlist to match the persisted mode, and hand
+    /// keyboard focus to whichever view is now visible.
+    private func applyCompactContentMode() {
+        let showPlaylist = compactShowsPlaylist
+        compactFooter?.showingPlaylist = showPlaylist
+        browserView.isHidden = showPlaylist
+        compactPlaylist?.isHidden = !showPlaylist
+        compactPlaylist?.needsDisplay = true
+        browserView.needsDisplay = true
+        if let target: NSView = showPlaylist ? compactPlaylist : browserView {
+            window?.makeFirstResponder(target)
+        }
     }
 
     /// Seed the bar with the engine's current state so it isn't blank until the next tick.

--- a/Sources/NullPlayer/Windows/PlexBrowser/PlexBrowserWindowController.swift
+++ b/Sources/NullPlayer/Windows/PlexBrowser/PlexBrowserWindowController.swift
@@ -201,6 +201,8 @@ class PlexBrowserWindowController: NSWindowController, LibraryBrowserWindowProvi
             container.footer = footer
             window.contentView = container
             container.layoutChildren()
+            // Initialize selection and scroll only after layout establishes the final list area.
+            playlist.reloadData()
 
             compactContainer = container
             compactBar = bar
@@ -265,6 +267,10 @@ class PlexBrowserWindowController: NSWindowController, LibraryBrowserWindowProvi
 
     func updateCompactBarPlaybackState() {
         compactBar?.updatePlaybackState()
+    }
+
+    func reloadCompactPlaylist() {
+        compactPlaylist?.reloadData()
     }
     
     func reloadData() {


### PR DESCRIPTION
## Summary

Adds a **Library | Playlist** toggle to the Compact window so users can view and edit the current playlist without opening the full Playlist window. Available in all three skin families (Modern, Metal, Classic). Also fixes a pre-existing bug found while testing.

## Compact window toggle

- A footer toggle at the bottom of the Compact window swaps its content region between the library browser and an embedded playlist.
- Double-click a track to play it; selection, scrolling, and live now-playing highlight work in place.
- The choice persists across launches (shared `compactContentMode` key across UI families).
- **Modern/Metal**: the embedded playlist draws translucently so the Cava/art backdrop shows through it, matching the library list. Content-region bottom is threaded through a single `contentRegionBottomY` lever (status bar + footer), mirroring `topChromeBottomY` for the top, so the list/alphabet/hit-testing/scroll all reserve footer space.
- **Classic**: managed in the container/controller rather than editing `PlexBrowserView`'s internals. New `ClassicCompactFooterView` renders the toggle in authentic classic skin style; `ClassicCompactContainerView` lays out footer + browser/playlist (one visible at a time). Classic compact has no backdrop, so the embedded playlist stays opaque.
- Both playlist views gained an `isEmbedded` flag (hides standalone title bar/close, disables window drag, routes body clicks to selection). The classic playlist hides its title bar via frame-extension behind the player bar (the browser's gap-free mechanism), sized to its own scale.

## Bug fix (pre-existing)

- **Restored local videos misrouted to the audio engine.** `SavedTrack` doesn't persist `mediaType`, so a video left in the playlist from a previous session was rebuilt as an audio track and failed to decode (`kAudioFileInvalidFile`). Restore now re-derives `mediaType` from the file extension (no file I/O), so videos open in the video player.

## Testing

- `swift build` clean.
- Manual: toggle both modes in Modern/Metal/Classic compact windows; verified footer fills the width, backdrop shows through in Modern/Metal, no title-bar gap in Classic, playback/selection/scroll/persistence work.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Compact Window can switch between Library and Playlist views using a skin-aware footer.
  * The selected Compact Window view is remembered between sessions.
  * Embedded playlists integrate smoothly with Compact Window controls, layout, and focus behavior.
  * Playlist updates are now reflected consistently in both standalone and Compact Window views.

* **Bug Fixes**
  * Restored local video files are correctly recognized and opened in the video player.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->