### PR TITLE
Add dockable Sonos room mixer with per-room volume

### DIFF
--- a/Sources/NullPlayer/App/AppStateManager.swift
+++ b/Sources/NullPlayer/App/AppStateManager.swift
@@ -220,6 +220,7 @@ class AppStateManager {
         var isPeppyMeterVisible: Bool = false
         var isNetworkMonitorVisible: Bool = false
         var isCavaVisible: Bool = false
+        var isSonosVisible: Bool = false
         var isWaveformVisible: Bool = false
 
         // Window frames (as strings for NSRect compatibility)
@@ -258,6 +259,7 @@ class AppStateManager {
         var peppyMeterWindowFrame: String?
         var networkMonitorWindowFrame: String?
         var cavaWindowFrame: String?
+        var sonosWindowFrame: String?
         var waveformWindowFrame: String?
         var isProjectMFullscreen: Bool = false
         
@@ -325,8 +327,8 @@ class AppStateManager {
         // MARK: - Custom Decoding for Backward Compatibility
         
         enum CodingKeys: String, CodingKey {
-            case isPlaylistVisible, isEqualizerVisible, isPlexBrowserVisible, isProjectMVisible, isSpectrumVisible, isAudioAnalysisVisible, isPeppyMeterVisible, isNetworkMonitorVisible, isCavaVisible, isWaveformVisible
-            case mainWindowFrame, playlistWindowFrame, equalizerWindowFrame, plexBrowserWindowFrame, projectMWindowFrame, spectrumWindowFrame, audioAnalysisWindowFrame, peppyMeterWindowFrame, networkMonitorWindowFrame, cavaWindowFrame, waveformWindowFrame, isProjectMFullscreen
+            case isPlaylistVisible, isEqualizerVisible, isPlexBrowserVisible, isProjectMVisible, isSpectrumVisible, isAudioAnalysisVisible, isPeppyMeterVisible, isNetworkMonitorVisible, isCavaVisible, isSonosVisible, isWaveformVisible
+            case mainWindowFrame, playlistWindowFrame, equalizerWindowFrame, plexBrowserWindowFrame, projectMWindowFrame, spectrumWindowFrame, audioAnalysisWindowFrame, peppyMeterWindowFrame, networkMonitorWindowFrame, cavaWindowFrame, sonosWindowFrame, waveformWindowFrame, isProjectMFullscreen
             case volume, balance, shuffleEnabled, repeatEnabled, gaplessPlaybackEnabled, volumeNormalizationEnabled
             case sweetFadeEnabled, sweetFadeDuration
             case eqEnabled, eqAutoEnabled, eqPreamp, eqBands
@@ -362,6 +364,7 @@ class AppStateManager {
             isPeppyMeterVisible = try container.decodeIfPresent(Bool.self, forKey: .isPeppyMeterVisible) ?? false
             isNetworkMonitorVisible = try container.decodeIfPresent(Bool.self, forKey: .isNetworkMonitorVisible) ?? false
             isCavaVisible = try container.decodeIfPresent(Bool.self, forKey: .isCavaVisible) ?? false
+            isSonosVisible = try container.decodeIfPresent(Bool.self, forKey: .isSonosVisible) ?? false
             isWaveformVisible = try container.decodeIfPresent(Bool.self, forKey: .isWaveformVisible) ?? false
             
             // Window frames
@@ -380,6 +383,7 @@ class AppStateManager {
             peppyMeterWindowFrame = try container.decodeIfPresent(String.self, forKey: .peppyMeterWindowFrame)
             networkMonitorWindowFrame = try container.decodeIfPresent(String.self, forKey: .networkMonitorWindowFrame)
             cavaWindowFrame = try container.decodeIfPresent(String.self, forKey: .cavaWindowFrame)
+            sonosWindowFrame = try container.decodeIfPresent(String.self, forKey: .sonosWindowFrame)
             waveformWindowFrame = try container.decodeIfPresent(String.self, forKey: .waveformWindowFrame)
             isProjectMFullscreen = try container.decodeIfPresent(Bool.self, forKey: .isProjectMFullscreen) ?? false
             
@@ -457,6 +461,7 @@ class AppStateManager {
             isPeppyMeterVisible: Bool = false,
             isNetworkMonitorVisible: Bool = false,
             isCavaVisible: Bool = false,
+            isSonosVisible: Bool = false,
             isWaveformVisible: Bool = false,
             mainWindowFrame: String?,
             mainScreenVisibleFrame: String? = nil,
@@ -469,6 +474,7 @@ class AppStateManager {
             peppyMeterWindowFrame: String? = nil,
             networkMonitorWindowFrame: String? = nil,
             cavaWindowFrame: String? = nil,
+            sonosWindowFrame: String? = nil,
             waveformWindowFrame: String? = nil,
             isProjectMFullscreen: Bool = false,
             volume: Float,
@@ -511,6 +517,7 @@ class AppStateManager {
             self.isPeppyMeterVisible = isPeppyMeterVisible
             self.isNetworkMonitorVisible = isNetworkMonitorVisible
             self.isCavaVisible = isCavaVisible
+            self.isSonosVisible = isSonosVisible
             self.isWaveformVisible = isWaveformVisible
             self.mainWindowFrame = mainWindowFrame
             self.mainScreenVisibleFrame = mainScreenVisibleFrame
@@ -524,6 +531,7 @@ class AppStateManager {
             self.peppyMeterWindowFrame = peppyMeterWindowFrame
             self.networkMonitorWindowFrame = networkMonitorWindowFrame
             self.cavaWindowFrame = cavaWindowFrame
+            self.sonosWindowFrame = sonosWindowFrame
             self.waveformWindowFrame = waveformWindowFrame
             self.isProjectMFullscreen = isProjectMFullscreen
             self.volume = volume
@@ -620,6 +628,7 @@ class AppStateManager {
             isPeppyMeterVisible: visibility("peppyMeter", wm.isPeppyMeterVisible),
             isNetworkMonitorVisible: visibility("networkMonitor", wm.isNetworkMonitorVisible),
             isCavaVisible: visibility("cava", wm.isCavaVisible),
+            isSonosVisible: visibility("sonos", wm.isSonosVisible),
             isWaveformVisible: visibility("waveform", wm.isWaveformVisible),
             
             // Window frames
@@ -636,6 +645,7 @@ class AppStateManager {
             peppyMeterWindowFrame: wm.peppyMeterWindowFrame.map { NSStringFromRect($0) },
             networkMonitorWindowFrame: wm.networkMonitorWindowFrame.map { NSStringFromRect($0) },
             cavaWindowFrame: wm.cavaWindowFrame.map { NSStringFromRect($0) },
+            sonosWindowFrame: wm.sonosWindowFrame.map { NSStringFromRect($0) },
             waveformWindowFrame: wm.waveformWindowFrame.map { NSStringFromRect($0) },
             isProjectMFullscreen: wm.isProjectMFullscreen,
             
@@ -906,6 +916,7 @@ class AppStateManager {
                 ("peppyMeter", state.peppyMeterWindowFrame),
                 ("networkMonitor", state.networkMonitorWindowFrame),
                 ("cava", state.cavaWindowFrame),
+                ("sonos", state.sonosWindowFrame),
                 ("waveform", state.waveformWindowFrame)
             ]
             for (key, string) in sources {
@@ -951,6 +962,7 @@ class AppStateManager {
         let peppyMeterFrame = restoredFrames["peppyMeter"]
         let networkMonitorFrame = restoredFrames["networkMonitor"]
         let cavaFrame = restoredFrames["cava"]
+        let sonosFrame = restoredFrames["sonos"]
         let waveformFrame = restoredFrames["waveform"]
         let projectMPresetIndex = state.projectMPresetIndex
         let visualizationEngineType = UserDefaults.standard.string(forKey: "visualizationEngineType")
@@ -989,6 +1001,9 @@ class AppStateManager {
             }
             if state.isCavaVisible {
                 wm.showCava(at: cavaFrame)
+            }
+            if state.isSonosVisible {
+                wm.showSonos(at: sonosFrame)
             }
             if state.isWaveformVisible {
                 wm.showWaveform(at: waveformFrame)
@@ -1386,6 +1401,7 @@ class AppStateManager {
         let peppyMeterFrame: NSRect?
         let networkMonitorFrame: NSRect?
         let cavaFrame: NSRect?
+        let sonosFrame: NSRect?
         let repaired: Bool
     }
 
@@ -1403,6 +1419,7 @@ class AppStateManager {
         peppyMeterFrame: NSRect?,
         networkMonitorFrame: NSRect?,
         cavaFrame: NSRect? = nil,
+        sonosFrame: NSRect? = nil,
         scale: CGFloat
     ) -> ClassicCenterStackRepairResult {
         let widthEpsilon: CGFloat = 0.5
@@ -1484,6 +1501,7 @@ class AppStateManager {
         )
         let adjustedNetworkMonitor = repairCandidate(networkMonitorFrame, preserveWidth: true)
         let adjustedCava = repairCandidate(cavaFrame, preserveWidth: true)
+        let adjustedSonos = repairCandidate(sonosFrame, preserveWidth: true)
 
         return ClassicCenterStackRepairResult(
             mainFrame: adjustedMain,
@@ -1495,6 +1513,7 @@ class AppStateManager {
             peppyMeterFrame: adjustedPeppyMeter,
             networkMonitorFrame: adjustedNetworkMonitor,
             cavaFrame: adjustedCava,
+            sonosFrame: adjustedSonos,
             repaired: repaired
         )
     }
@@ -1515,6 +1534,7 @@ class AppStateManager {
         let peppyMeterWindow = wm.peppyMeterWindow
         let networkMonitorWindow = wm.networkMonitorWindow
         let cavaWindow = wm.cavaWindow
+        let sonosWindow = wm.sonosWindow
 
         let equalizerFrame: NSRect?
         if let equalizerWindow, equalizerWindow.isVisible {
@@ -1571,6 +1591,12 @@ class AppStateManager {
         } else {
             cavaFrame = nil
         }
+        let sonosFrame: NSRect?
+        if let sonosWindow, sonosWindow.isVisible {
+            sonosFrame = sonosWindow.frame
+        } else {
+            sonosFrame = nil
+        }
 
         let repairedFrames = Self.repairClassicCenterStackFrames(
             mainFrame: mainWindow.frame,
@@ -1582,6 +1608,7 @@ class AppStateManager {
             peppyMeterFrame: peppyMeterFrame,
             networkMonitorFrame: networkMonitorFrame,
             cavaFrame: cavaFrame,
+            sonosFrame: sonosFrame,
             scale: scale
         )
 
@@ -1635,6 +1662,12 @@ class AppStateManager {
            let repairedFrame = repairedFrames.cavaFrame,
            repairedFrame != cavaWindow.frame {
             cavaWindow.setFrame(repairedFrame, display: true)
+        }
+        if let sonosWindow,
+           sonosWindow.isVisible,
+           let repairedFrame = repairedFrames.sonosFrame,
+           repairedFrame != sonosWindow.frame {
+            sonosWindow.setFrame(repairedFrame, display: true)
         }
 
         if repairedFrames.repaired {

--- a/Sources/NullPlayer/App/ContextMenuBuilder.swift
+++ b/Sources/NullPlayer/App/ContextMenuBuilder.swift
@@ -3095,7 +3095,7 @@ class ContextMenuBuilder {
             let sonosItem = NSMenuItem(title: "Sonos", action: nil, keyEquivalent: "")
             let sonosMenu = NSMenu()
             sonosMenu.autoenablesItems = false
-            let windowItem = NSMenuItem(title: "Rooms & Volume…", action: #selector(MenuActions.showSonos), keyEquivalent: "")
+            let windowItem = NSMenuItem(title: "Sonos Rooms…", action: #selector(MenuActions.showSonos), keyEquivalent: "")
             windowItem.target = MenuActions.shared
             sonosMenu.addItem(windowItem)
             sonosMenu.addItem(.separator())
@@ -3335,7 +3335,7 @@ class ContextMenuBuilder {
             let sonosItem = NSMenuItem(title: "Sonos", action: nil, keyEquivalent: "")
             let sonosMenu = NSMenu()
             sonosMenu.autoenablesItems = false
-            let windowItem = NSMenuItem(title: "Rooms & Volume…", action: #selector(MenuActions.showSonos), keyEquivalent: "")
+            let windowItem = NSMenuItem(title: "Sonos Rooms…", action: #selector(MenuActions.showSonos), keyEquivalent: "")
             windowItem.target = MenuActions.shared
             sonosMenu.addItem(windowItem)
             sonosMenu.addItem(.separator())

--- a/Sources/NullPlayer/App/ContextMenuBuilder.swift
+++ b/Sources/NullPlayer/App/ContextMenuBuilder.swift
@@ -3520,7 +3520,7 @@ class SonosRoomCheckboxView: NSView {
             defer { sender.isEnabled = true }
             do {
                 try await SonosRoomMixer.shared.selectRoom(info.roomUDN, selected: selected)
-                if info.roomUDN == info.coordinatorUDN && !selected {
+                if !selected, info.roomUDN == CastManager.shared.activeSession?.device.id {
                     parentMenu?.cancelTracking()
                 }
             } catch {

--- a/Sources/NullPlayer/App/ContextMenuBuilder.swift
+++ b/Sources/NullPlayer/App/ContextMenuBuilder.swift
@@ -169,6 +169,7 @@ class ContextMenuBuilder {
         menu.addItem(buildWindowItem("PeppyMeter", visible: wm.isPeppyMeterVisible, action: #selector(MenuActions.togglePeppyMeter)))
         menu.addItem(buildWindowItem("Flow", visible: wm.isNetworkMonitorVisible, action: #selector(MenuActions.toggleNetworkMonitor)))
         menu.addItem(buildWindowItem("Cava", visible: wm.isCavaVisible, action: #selector(MenuActions.toggleCava)))
+        menu.addItem(buildWindowItem("Sonos Rooms", visible: wm.isSonosVisible, action: #selector(MenuActions.toggleSonos)))
         menu.addItem(buildWindowItem("Waveform", visible: wm.isWaveformVisible, action: #selector(MenuActions.toggleWaveform)))
         menu.addItem(buildWindowItem("Library Browser", visible: wm.isPlexBrowserVisible, action: #selector(MenuActions.togglePlexBrowser)))
         if wm.isRunningModernUI {
@@ -3088,12 +3089,16 @@ class ContextMenuBuilder {
 
         // Sonos
         let sonosRooms = castManager.sonosRooms
-        if !sonosRooms.isEmpty {
+        do {
             outputMenu.addItem(NSMenuItem.separator())
 
             let sonosItem = NSMenuItem(title: "Sonos", action: nil, keyEquivalent: "")
             let sonosMenu = NSMenu()
             sonosMenu.autoenablesItems = false
+            let windowItem = NSMenuItem(title: "Rooms & Volume…", action: #selector(MenuActions.showSonos), keyEquivalent: "")
+            windowItem.target = MenuActions.shared
+            sonosMenu.addItem(windowItem)
+            sonosMenu.addItem(.separator())
 
             let castTargetUDN = castManager.activeSession?.device.id
             let isCastingToSonos = castManager.activeSession?.device.type == .sonos
@@ -3324,12 +3329,16 @@ class ContextMenuBuilder {
         for room in rooms {
             NSLog("ContextMenuBuilder: Room '%@' isCoord=%d isInGroup=%d", room.name, room.isGroupCoordinator ? 1 : 0, room.isInGroup ? 1 : 0)
         }
-        if !rooms.isEmpty {
+        do {
             outputMenu.addItem(NSMenuItem.separator())
             
             let sonosItem = NSMenuItem(title: "Sonos", action: nil, keyEquivalent: "")
             let sonosMenu = NSMenu()
             sonosMenu.autoenablesItems = false
+            let windowItem = NSMenuItem(title: "Rooms & Volume…", action: #selector(MenuActions.showSonos), keyEquivalent: "")
+            windowItem.target = MenuActions.shared
+            sonosMenu.addItem(windowItem)
+            sonosMenu.addItem(.separator())
             
             // Determine checkbox state based on whether we're casting
             let castTargetUDN = castManager.activeSession?.device.id
@@ -3505,99 +3514,24 @@ class SonosRoomCheckboxView: NSView {
     }
     
     @objc private func checkboxClicked(_ sender: NSButton) {
-        let isNowChecked = sender.state == .on
-        
-        // Toggle the selection state
-        let castManager = CastManager.shared
-        let isCastingToSonos = castManager.activeSession?.device.type == .sonos
-        
-        NSLog("SonosRoomCheckboxView: Toggled '%@' to %d, isCasting=%d", 
-              info.roomName, isNowChecked ? 1 : 0, isCastingToSonos ? 1 : 0)
-        
-        if isCastingToSonos {
-            // WHILE CASTING: toggle actually joins/unjoins the Sonos group
-            Task {
-                do {
-                    if !isNowChecked {
-                        // Check if we're unchecking the current coordinator
-                        let isCoordinator = info.roomUDN == castManager.activeSession?.device.id
-                        
-                        if isCoordinator {
-                            // Unchecking the coordinator - check if other rooms remain
-                            let groupRooms = castManager.getRoomsInActiveCastGroup()
-                            let otherRooms = groupRooms.filter { $0 != info.roomUDN }
-                            
-                            if otherRooms.isEmpty {
-                                // Only room in group - just stop casting
-                                NSLog("SonosRoomCheckboxView: Unchecking sole coordinator '%@' - stopping cast", info.roomName)
-                                await castManager.stopCasting()
-                            } else {
-                                // Transfer playback to next remaining room
-                                let newCoordinator = otherRooms[0]
-                                let remainingOthers = Array(otherRooms.dropFirst())
-                                NSLog("SonosRoomCheckboxView: Transferring cast from '%@' to room %@ (+%d others)",
-                                      info.roomName, newCoordinator, remainingOthers.count)
-                                try await castManager.transferSonosCast(
-                                    fromCoordinator: info.roomUDN,
-                                    toRoom: newCoordinator,
-                                    otherRooms: remainingOthers
-                                )
-                            }
-                            // Close menu after coordinator change to force UI refresh on next open
-                            await MainActor.run {
-                                self.parentMenu?.cancelTracking()
-                            }
-                            return
-                        }
-                        
-                        // Not the coordinator - just unjoin this room from the group
-                        NSLog("SonosRoomCheckboxView: Removing '%@' from cast group", info.roomName)
-                        try await castManager.unjoinSonos(zoneUDN: info.roomUDN)
-                    } else {
-                        // Was unchecked, now checked - join to active cast
-                        if let coordinatorUDN = castManager.activeSession?.device.id {
-                            NSLog("SonosRoomCheckboxView: Adding '%@' to cast group", info.roomName)
-                            try await castManager.joinSonosToGroup(
-                                zoneUDN: info.roomUDN,
-                                coordinatorUDN: coordinatorUDN
-                            )
-                        }
-                    }
-                    
-                    // Refresh topology to update UI
-                    await castManager.refreshSonosGroups()
-                    NSLog("SonosRoomCheckboxView: Toggle complete for '%@'", info.roomName)
-                    
-                } catch {
-                    NSLog("SonosRoomCheckboxView: Toggle failed for '%@': %@", info.roomName, error.localizedDescription)
-                    // Revert checkbox state on error
-                    await MainActor.run {
-                        sender.state = isNowChecked ? .off : .on
-                    }
-                    // If we can't control the Sonos, the session is effectively broken
-                    // Clean up to prevent local+cast conflict and show error
-                    await castManager.stopCasting()
-                    await MainActor.run {
-                        let alert = NSAlert()
-                        alert.messageText = "Sonos Unavailable"
-                        alert.informativeText = "Lost connection to Sonos: \(error.localizedDescription)"
-                        alert.alertStyle = .warning
-                        alert.runModal()
-                    }
+        let selected = sender.state == .on
+        sender.isEnabled = false
+        Task { @MainActor in
+            defer { sender.isEnabled = true }
+            do {
+                try await SonosRoomMixer.shared.selectRoom(info.roomUDN, selected: selected)
+                if info.roomUDN == info.coordinatorUDN && !selected {
+                    parentMenu?.cancelTracking()
                 }
-            }
-        } else {
-            // NOT CASTING: just toggle selection state (stored locally)
-            if isNowChecked {
-                castManager.selectedSonosRooms.insert(info.roomUDN)
-                NSLog("SonosRoomCheckboxView: Selected '%@' for casting", info.roomName)
-            } else {
-                castManager.selectedSonosRooms.remove(info.roomUDN)
-                NSLog("SonosRoomCheckboxView: Deselected '%@' for casting", info.roomName)
+            } catch {
+                sender.state = selected ? .off : .on
+                let alert = NSAlert()
+                alert.messageText = "Sonos Room Update Failed"
+                alert.informativeText = error.localizedDescription
+                alert.alertStyle = .warning
+                alert.runModal()
             }
         }
-        
-        // Keep menu open by canceling the close - the menu stays open because we're in a custom view
     }
 
 }
@@ -3694,6 +3628,9 @@ class MenuActions: NSObject {
     @objc func toggleCava() {
         WindowManager.shared.toggleCava()
     }
+
+    @objc func showSonos() { WindowManager.shared.showSonos() }
+    @objc func toggleSonos() { WindowManager.shared.toggleSonos() }
 
     @objc func toggleWaveform() {
         WindowManager.shared.toggleWaveform()
@@ -6022,6 +5959,7 @@ class MenuActions: NSObject {
     }
     
     @objc func refreshSonosRooms() {
+        CastManager.shared.refreshDevices()
         Task {
             await CastManager.shared.refreshSonosGroups()
             NSLog("MenuActions: Refreshed Sonos rooms")
@@ -6033,128 +5971,14 @@ class MenuActions: NSObject {
     }
 
     @objc func castToSonosRoom(_ sender: NSMenuItem) {
-        let castManager = CastManager.shared
-        
-        // Check if music is loaded
-        guard WindowManager.shared.audioEngine.currentTrack != nil else {
-            NSLog("MenuActions: Cannot cast - no music loaded")
-            Task { @MainActor in
+        Task { @MainActor in
+            do { try await SonosRoomMixer.shared.startCasting() }
+            catch {
                 let alert = NSAlert()
-                alert.messageText = "No Music"
-                alert.informativeText = "Load a track before casting."
+                alert.messageText = "Cast Failed"
+                alert.informativeText = error.localizedDescription
                 alert.alertStyle = .warning
                 alert.runModal()
-            }
-            return
-        }
-        
-        // Get selected rooms
-        let selectedUDNs = castManager.selectedSonosRooms
-        
-        // If no rooms selected, show error
-        if selectedUDNs.isEmpty {
-            NSLog("MenuActions: Cannot cast - no rooms selected")
-            Task { @MainActor in
-                let alert = NSAlert()
-                alert.messageText = "No Room Selected"
-                alert.informativeText = "Select a room first by checking it in the Sonos menu."
-                alert.alertStyle = .warning
-                alert.runModal()
-            }
-            return
-        }
-        
-        // Find a device to cast to
-        // sonosRooms has room UDNs, but sonosDevices only has group coordinator devices
-        // We need to find a device that matches one of our selected rooms
-        let rooms = castManager.sonosRooms
-        let devices = castManager.sonosDevices
-        
-        NSLog("MenuActions: Selected UDNs: %@", selectedUDNs.joined(separator: ", "))
-        NSLog("MenuActions: Available devices: %@", devices.map { "\($0.name):\($0.id)" }.joined(separator: ", "))
-        NSLog("MenuActions: Available rooms: %@", rooms.map { "\($0.name):\($0.id)" }.joined(separator: ", "))
-        
-        // Find the first device that matches a selected room
-        var targetDevice: CastDevice?
-        var targetRoomUDN: String?
-        
-        for udn in selectedUDNs {
-            // First try direct match (room is a coordinator)
-            if let device = devices.first(where: { $0.id == udn }) {
-                targetDevice = device
-                targetRoomUDN = udn
-                break
-            }
-            
-            // If no direct match, find by room name
-            if let room = rooms.first(where: { $0.id == udn }) {
-                if let device = devices.first(where: { $0.name.hasPrefix(room.name) }) {
-                    targetDevice = device
-                    targetRoomUDN = udn
-                    break
-                }
-            }
-        }
-        
-        // If still no match, just use the first available Sonos device
-        // IMPORTANT: Set targetRoomUDN to the device we're actually casting to, not a selected room.
-        // This ensures all selected rooms get joined to the group in the loop below.
-        // (Previously this was set to selectedUDNs.first, which caused that room to be
-        // incorrectly filtered out of the join loop even though it wasn't receiving audio.)
-        if targetDevice == nil, let firstDevice = devices.first {
-            NSLog("MenuActions: No exact match, using first available device: %@", firstDevice.name)
-            targetDevice = firstDevice
-            targetRoomUDN = firstDevice.id
-        }
-        
-        guard let device = targetDevice, let firstUDN = targetRoomUDN else {
-            NSLog("MenuActions: Could not find any Sonos device to cast to")
-            Task { @MainActor in
-                let alert = NSAlert()
-                alert.messageText = "No Device Found"
-                alert.informativeText = "Could not find a Sonos device to cast to. Try refreshing."
-                alert.alertStyle = .warning
-                alert.runModal()
-            }
-            return
-        }
-        
-        Task {
-            do {
-                // Start casting to first room
-                NSLog("MenuActions: Starting cast to '%@' (id: %@)", device.name, device.id)
-                try await castManager.castCurrentTrack(to: device)
-                guard let coordinatorUDN = castManager.activeSession?.device.id else {
-                    throw CastError.sessionNotActive
-                }
-                
-                // Join additional selected rooms to the group
-                let otherUDNs = selectedUDNs.filter { $0 != firstUDN }
-                if !otherUDNs.isEmpty {
-                    // Wait a moment for cast to establish
-                    try? await Task.sleep(nanoseconds: 500_000_000)
-                    
-                    for udn in otherUDNs {
-                        NSLog("MenuActions: Joining room %@ to cast group (coordinator: %@)", udn, coordinatorUDN)
-                        try await castManager.joinSonosToGroup(zoneUDN: udn, coordinatorUDN: coordinatorUDN)
-                        try? await Task.sleep(nanoseconds: 200_000_000)
-                    }
-                }
-                
-                // Refresh topology
-                await castManager.refreshSonosGroups()
-                
-            } catch {
-                NSLog("MenuActions: Cast to Sonos failed: %@", error.localizedDescription)
-                // Clean up any partial session state to prevent local+cast conflict
-                await castManager.stopCasting()
-                await MainActor.run {
-                    let alert = NSAlert()
-                    alert.messageText = "Cast Failed"
-                    alert.informativeText = error.localizedDescription
-                    alert.alertStyle = .warning
-                    alert.runModal()
-                }
             }
         }
     }

--- a/Sources/NullPlayer/App/WindowManager.swift
+++ b/Sources/NullPlayer/App/WindowManager.swift
@@ -211,6 +211,7 @@ private struct CompactWindowSnapshot {
     var peppyMeter: WindowSnapshot?
     var networkMonitor: WindowSnapshot?
     var cava: WindowSnapshot?
+    var sonos: WindowSnapshot?
     var waveform: WindowSnapshot?
     var projectM: WindowSnapshot?
     var library: WindowSnapshot?
@@ -613,6 +614,7 @@ class WindowManager {
 
     /// Cava spectrum analyzer window controller for the active UI mode, accessed via protocol.
     private var cavaWindowController: CavaWindowProviding?
+    private var sonosWindowController: SonosWindowController?
 
     /// Shared vis_classic bridge — created on first use, driven by audioWaveform576DataUpdated notifications.
     private(set) var sharedVisClassicBridge: VisClassicBridge?
@@ -660,6 +662,7 @@ class WindowManager {
         add(peppyMeterWindowController?.window, centerStack: true, snapTarget: true)
         add(networkMonitorWindowController?.window, centerStack: true, snapTarget: true)
         add(cavaWindowController?.window, centerStack: true, snapTarget: true)
+        add(sonosWindowController?.window, centerStack: true, snapTarget: true)
         add(waveformWindowController?.window, centerStack: true, snapTarget: true)
         add(plexBrowserWindowController?.window, snapTarget: true)
         add(projectMWindowController?.window, snapTarget: true)
@@ -1254,6 +1257,7 @@ class WindowManager {
         case .spectrum: return spectrumWindowController?.window
         case .equalizer: return equalizerWindowController?.window
         case .cava: return cavaWindowController?.window
+        case .sonos: return sonosWindowController?.window
         case .flow: return networkMonitorWindowController?.window
         case .peppyMeter: return peppyMeterWindowController?.window
         case .audioAnalysis: return audioAnalysisWindowController?.window
@@ -1310,6 +1314,7 @@ class WindowManager {
         case .spectrum: showOnly ? showSpectrum() : toggleSpectrum()
         case .equalizer: showOnly ? showEqualizer() : classicToggleEqualizer()
         case .cava: showOnly ? showCava() : toggleCava()
+        case .sonos: showOnly ? showSonos() : toggleSonos()
         case .flow: showOnly ? showNetworkMonitor() : toggleNetworkMonitor()
         case .peppyMeter: showOnly ? showPeppyMeter() : togglePeppyMeter()
         case .audioAnalysis: showOnly ? showAudioAnalysis() : toggleAudioAnalysis()
@@ -2258,6 +2263,7 @@ class WindowManager {
             peppyMeter: snapWindow(peppyMeterWindow, trackDetachedState: true),
             networkMonitor: snapWindow(networkMonitorWindow, trackDetachedState: true),
             cava: snapWindow(cavaWindow, trackDetachedState: true),
+            sonos: snapWindow(sonosWindow, trackDetachedState: true),
             waveform: snapWindow(waveformWindow, trackDetachedState: true),
             projectM: snap(projectMWindowController, trackDetachedState: true)
                 ?? snapWindow(winampModernHostedController?.hostedWindow(ifMaterialized: .projectM),
@@ -2413,6 +2419,8 @@ class WindowManager {
                                  window: networkMonitorWindow, show: showNetworkMonitor)
         restoreCentreStackWindow(snapshot.cava, controller: cavaWindowController,
                                  window: cavaWindow, show: showCava)
+        restoreCentreStackWindow(snapshot.sonos, controller: sonosWindowController,
+                                 window: sonosWindow, show: showSonos)
         restoreCentreStackWindow(snapshot.waveform, controller: waveformWindowController,
                                  window: waveformWindow, show: showWaveform)
         restore(snapshot.projectM, controller: projectMWindowController)
@@ -2449,6 +2457,7 @@ class WindowManager {
         case "peppyMeter": return snapshot.peppyMeter?.wasVisible ?? current
         case "networkMonitor": return snapshot.networkMonitor?.wasVisible ?? current
         case "cava": return snapshot.cava?.wasVisible ?? current
+        case "sonos": return snapshot.sonos?.wasVisible ?? current
         case "waveform": return snapshot.waveform?.wasVisible ?? current
         case "projectM": return snapshot.projectM?.wasVisible ?? current
         case "plexBrowser": return snapshot.library?.wasVisible ?? current
@@ -3792,6 +3801,59 @@ class WindowManager {
         updateDockedChildWindows()
     }
 
+    // MARK: - Sonos Rooms Window
+
+    var sonosWindow: NSWindow? {
+        if winampModernHostedController?.handlesHostedWindow(.sonos) == true {
+            return winampModernHostedController?.hostedWindow(ifMaterialized: .sonos)
+        }
+        return sonosWindowController?.window
+    }
+
+    var isSonosVisible: Bool { sonosWindow?.isVisible == true }
+    var sonosWindowFrame: NSRect? { sonosWindow?.frame }
+
+    func showSonos(at restoredFrame: NSRect? = nil) {
+        if routeWinampModernHostedWindow(.sonos, toggle: false, restoredFrame: restoredFrame) { return }
+        let created = sonosWindowController == nil
+        if created { sonosWindowController = SonosWindowController() }
+        guard let window = sonosWindowController?.window else { return }
+        markModeDependentWindow(window)
+        if !isRunningModernUI {
+            let scale = uiScaleLevel.scaleFactor
+            window.minSize = NSSize(width: 250 * scale, height: 160 * scale)
+        }
+        applyCenterStackSizingConstraints(window, kind: .sonos)
+        if let restoredFrame, restoredFrame != .zero {
+            applyRestoredCenterStackFrame(restoredFrame, to: window, kind: .sonos)
+        } else if created {
+            let width = mainWindowController?.window?.frame.width ?? 360
+            window.setContentSize(NSSize(width: width, height: 270 * uiScaleLevel.scaleFactor))
+            if isRunningModernUI { applyDefaultCenterStackFrameForCurrentHT(window, kind: .sonos) }
+            positionSubWindow(window)
+        } else if !window.isVisible, sonosWindowController?.wasDockedWhenHidden == true {
+            positionSubWindow(window)
+        }
+        sonosWindowController?.showWindow(nil)
+        applyAlwaysOnTopToWindow(window)
+        notifyMainWindowVisibilityChanged()
+        postLayoutChangeNotification()
+        updateDockedChildWindows()
+    }
+
+    func toggleSonos() {
+        if routeWinampModernHostedWindow(.sonos, toggle: true) { return }
+        if let window = sonosWindowController?.window, window.isVisible {
+            let frame = window.frame
+            sonosWindowController?.prepareForUITeardown()
+            window.orderOut(nil)
+            slideUpWindowsBelow(closingFrame: frame)
+        } else { showSonos() }
+        notifyMainWindowVisibilityChanged()
+        postLayoutChangeNotification()
+        updateDockedChildWindows()
+    }
+
     // MARK: - Cava Window
 
     func showCava(at restoredFrame: NSRect? = nil) {
@@ -4391,6 +4453,7 @@ class WindowManager {
         peppyMeterWindowController?.skinDidChange()
         networkMonitorWindowController?.skinDidChange()
         cavaWindowController?.skinDidChange()
+        sonosWindowController?.skinDidChange()
         waveformWindowController?.skinDidChange()
         compactWindowController?.skinDidChange()
     }
@@ -4790,6 +4853,37 @@ class WindowManager {
                 cavaWindow.setContentSize(NSSize(width: newWidth, height: newHeight))
             }
         }
+        if let sonosWindow = sonosWindowController?.window {
+            let baseMinSize: NSSize = runningModernMode
+                ? ModernSkinElements.spectrumMinSize
+                : SkinElements.SpectrumWindow.minSize
+            let heightMultiplier = centerStackHeightMultiplier(for: .sonos)
+            let minHeight = runningModernMode
+                ? expectedMainHeightForCurrentHT(mainWindowController?.window)
+                : baseMinSize.height * scale
+            let adjustedMinHeight = minHeight * heightMultiplier
+            let minWidth = runningModernMode
+                ? ModernSkinElements.spectrumMinSize.width
+                : baseMinSize.width * scale
+            sonosWindow.minSize = NSSize(width: minWidth, height: adjustedMinHeight)
+            sonosWindow.maxSize = NSSize(width: CGFloat.greatestFiniteMagnitude, height: CGFloat.greatestFiniteMagnitude)
+
+            let currentFrame = sonosWindow.frame
+            let newHeight = max(adjustedMinHeight, currentFrame.height * ratio)
+            let newWidth = max(minWidth, currentFrame.width * ratio)
+            if sonosWindow.isVisible {
+                let sonosFrame = NSRect(
+                    x: mainFrame.minX,
+                    y: nextY - newHeight,
+                    width: newWidth,
+                    height: newHeight
+                )
+                sonosWindow.setFrame(sonosFrame, display: true, animate: false)
+                nextY = sonosFrame.minY
+            } else {
+                sonosWindow.setContentSize(NSSize(width: newWidth, height: newHeight))
+            }
+        }
 
         // Side windows - match the vertical stack height and reposition
         let stackTopY = mainFrame.maxY
@@ -4828,6 +4922,7 @@ class WindowManager {
                            peppyMeterWindowController,
                            networkMonitorWindowController,
                            cavaWindowController,
+                           sonosWindowController,
                            plexBrowserWindowController, projectMWindowController] {
             guard let window = controller?.window, window.isVisible,
                   let contentView = window.contentView else { continue }
@@ -4874,6 +4969,7 @@ class WindowManager {
             peppyMeterWindowController?.window,
             networkMonitorWindowController?.window,
             cavaWindowController?.window,
+            sonosWindowController?.window,
             waveformWindowController?.window,
             videoPlayerWindowController?.window,
             projectMWindowController?.window,
@@ -4949,6 +5045,7 @@ class WindowManager {
     }
 
     enum CenterStackWindowKind {
+        case sonos
         case equalizer
         case playlist
         case spectrum
@@ -4964,6 +5061,7 @@ class WindowManager {
         case .spectrum: return .spectrum
         case .equalizer: return .equalizer
         case .cava: return .cava
+        case .sonos: return .sonos
         case .flow: return .networkMonitor
         case .peppyMeter: return .peppyMeter
         case .audioAnalysis: return .audioAnalysis
@@ -4981,6 +5079,7 @@ class WindowManager {
         if window === peppyMeterWindowController?.window { return .peppyMeter }
         if window === networkMonitorWindowController?.window { return .networkMonitor }
         if window === cavaWindowController?.window { return .cava }
+        if window === sonosWindowController?.window { return .sonos }
         if let hosted = winampModernHostedController?.materializedHostedWindows.first(where: {
             $0.window === window
         }) {
@@ -5082,7 +5181,11 @@ class WindowManager {
     /// Height multiplier for a center-stack window's default/minimum height.
     /// PeppyMeter is taller than single-height windows, but not double-height: its bundled assets are landscape.
     private func centerStackHeightMultiplier(for kind: CenterStackWindowKind) -> CGFloat {
-        kind == .peppyMeter ? 1.75 : 1
+        switch kind {
+        case .peppyMeter: return 1.75
+        case .sonos: return 2
+        default: return 1
+        }
     }
 
     private func peppyMeterHeight(for baseHeight: CGFloat) -> CGFloat {
@@ -5105,7 +5208,7 @@ class WindowManager {
         let target = kind == .peppyMeter
             ? peppyMeterHeight(for: baseTarget)
             : baseTarget * centerStackHeightMultiplier(for: kind)
-        guard kind == .playlist || kind == .waveform else { return target }
+        guard kind == .playlist || kind == .waveform || kind == .sonos else { return target }
         guard preservePlaylistContentHeight else { return target }
         let adjusted = hideTitleBars ? (currentHeight - titleBarDelta) : (currentHeight + titleBarDelta)
         return max(target, adjusted)
@@ -5116,6 +5219,9 @@ class WindowManager {
         let targetWidth = mainWindow.frame.width
         let targetHeight = expectedMainHeightForCurrentHT(mainWindow)
         switch kind {
+        case .sonos:
+            window.minSize = NSSize(width: ModernSkinElements.spectrumMinSize.width, height: targetHeight * 2)
+            window.maxSize = NSSize(width: CGFloat.greatestFiniteMagnitude, height: CGFloat.greatestFiniteMagnitude)
         case .equalizer:
             window.minSize = NSSize(width: targetWidth, height: targetHeight)
             window.maxSize = NSSize(width: targetWidth, height: targetHeight)
@@ -5177,7 +5283,7 @@ class WindowManager {
             return mainWindowController?.window?.frame.width ?? ModernSkinElements.mainWindowSize.width
         case .playlist:
             return ModernSkinElements.playlistMinSize.width
-        case .spectrum, .audioAnalysis, .peppyMeter, .networkMonitor, .cava:
+        case .spectrum, .audioAnalysis, .peppyMeter, .networkMonitor, .cava, .sonos:
             return ModernSkinElements.spectrumMinSize.width
         case .waveform:
             return ModernSkinElements.waveformMinSize.width
@@ -5202,6 +5308,8 @@ class WindowManager {
 
         let topY = normalized.maxY
         switch kind {
+        case .sonos:
+            normalized.size.height = max(targetHeight * 2, normalized.height)
         case .equalizer:
             normalized.size.height = targetHeight
         case .playlist, .spectrum, .waveform, .audioAnalysis, .networkMonitor, .cava:
@@ -5320,6 +5428,7 @@ class WindowManager {
         let peppyMeterWindow = peppyMeterWindowController?.window
         let networkMonitorWindow = networkMonitorWindowController?.window
         let cavaWindow = cavaWindowController?.window
+        let sonosWindow = sonosWindowController?.window
 
         let repaired = AppStateManager.repairClassicCenterStackFrames(
             mainFrame: mainWindow.frame,
@@ -5331,6 +5440,7 @@ class WindowManager {
             peppyMeterFrame: (peppyMeterWindow?.isVisible == true) ? peppyMeterWindow?.frame : nil,
             networkMonitorFrame: (networkMonitorWindow?.isVisible == true) ? networkMonitorWindow?.frame : nil,
             cavaFrame: (cavaWindow?.isVisible == true) ? cavaWindow?.frame : nil,
+            sonosFrame: (sonosWindow?.isVisible == true) ? sonosWindow?.frame : nil,
             scale: scale
         )
 
@@ -5394,6 +5504,12 @@ class WindowManager {
            let repairedFrame = repaired.cavaFrame,
            repairedFrame != cavaWindow.frame {
             cavaWindow.setFrame(repairedFrame, display: true, animate: false)
+        }
+        if let sonosWindow,
+           sonosWindow.isVisible,
+           let repairedFrame = repaired.sonosFrame,
+           repairedFrame != sonosWindow.frame {
+            sonosWindow.setFrame(repairedFrame, display: true, animate: false)
         }
 
         return true
@@ -5593,6 +5709,7 @@ class WindowManager {
         if let window = peppyMeterWindow, window.isVisible { height += window.frame.height }
         if let window = networkMonitorWindow, window.isVisible { height += window.frame.height }
         if let window = cavaWindow, window.isVisible { height += window.frame.height }
+        if let window = sonosWindow, window.isVisible { height += window.frame.height }
         return height
     }
 
@@ -5701,6 +5818,13 @@ class WindowManager {
             nextY -= h
             cavaFrame = NSRect(x: mainFrame.minX, y: nextY, width: w, height: h)
         }
+        var sonosFrame: NSRect?
+        if let sonosWindow, sonosWindow.isVisible {
+            let h = sonosWindow.frame.height
+            let w = sonosWindow.frame.width
+            nextY -= h
+            sonosFrame = NSRect(x: mainFrame.minX, y: nextY, width: w, height: h)
+        }
 
         // Side windows span the full stack height
         let stackTopY = mainFrame.maxY
@@ -5752,6 +5876,9 @@ class WindowManager {
             window.setFrame(frame, display: true, animate: false)
         }
         if let frame = cavaFrame, let window = cavaWindow {
+            window.setFrame(frame, display: true, animate: false)
+        }
+        if let frame = sonosFrame, let window = sonosWindow {
             window.setFrame(frame, display: true, animate: false)
         }
         if let frame = browserFrame, let window = plexBrowserWindowController?.window {
@@ -6753,6 +6880,7 @@ class WindowManager {
          peppyMeterWindowController,
          networkMonitorWindowController,
          cavaWindowController,
+         sonosWindowController,
          waveformWindowController].compactMap { $0 }
     }
 
@@ -6817,6 +6945,8 @@ class WindowManager {
         networkMonitorWindowController = nil
         cavaWindowController?.window?.close()
         cavaWindowController = nil
+        sonosWindowController?.window?.close()
+        sonosWindowController = nil
         waveformWindowController?.window?.close()
         waveformWindowController = nil
 
@@ -6862,6 +6992,7 @@ class WindowManager {
         var peppyMeter: UIWindowSnapshot?
         var networkMonitor: UIWindowSnapshot?
         var cava: UIWindowSnapshot?
+        var sonos: UIWindowSnapshot?
         var waveform: UIWindowSnapshot?
         /// Live ProjectM preset index, carried across the rebuild so the visualization stays on the
         /// exact preset the user was viewing rather than reverting to the saved startup default.
@@ -6894,6 +7025,7 @@ class WindowManager {
             peppyMeter: snapWindow(peppyMeterWindow),
             networkMonitor: snapWindow(networkMonitorWindow),
             cava: snapWindow(cavaWindow),
+            sonos: snapWindow(sonosWindow),
             waveform: snapWindow(waveformWindow),
             projectMPresetIndex: restorableProjectMPresetIndex()
         )
@@ -6966,6 +7098,7 @@ class WindowManager {
         if snapshot.peppyMeter?.visible == true { showPeppyMeter(at: snapshot.peppyMeter?.frame) }
         if snapshot.networkMonitor?.visible == true { showNetworkMonitor(at: snapshot.networkMonitor?.frame) }
         if snapshot.cava?.visible == true { showCava(at: snapshot.cava?.frame) }
+        if snapshot.sonos?.visible == true { showSonos(at: snapshot.sonos?.frame) }
         if let waveform = snapshot.waveform, waveform.visible {
             showWaveform(at: waveform.frame)
         }
@@ -7196,6 +7329,7 @@ class WindowManager {
         var peppyMeter: NSRect?
         var networkMonitor: NSRect?
         var cava: NSRect?
+        var sonos: NSRect?
         var library: NSRect?
         var projectM: NSRect?
     }
@@ -7240,6 +7374,7 @@ class WindowManager {
             peppyMeter: detachedFrame(peppyMeterWindow),
             networkMonitor: detachedFrame(networkMonitorWindow),
             cava: detachedFrame(cavaWindow),
+            sonos: detachedFrame(sonosWindow),
             library: detachedFrame(plexBrowserWindowController?.window),
             projectM: detachedFrame(projectMWindowController?.window
                 ?? winampModernHostedController?.hostedWindow(ifMaterialized: .projectM))
@@ -7281,6 +7416,7 @@ class WindowManager {
             peppyMeter: detachedFrame(snapshot.peppyMeter),
             networkMonitor: detachedFrame(snapshot.networkMonitor),
             cava: detachedFrame(snapshot.cava),
+            sonos: detachedFrame(snapshot.sonos),
             library: detachedFrame(snapshot.library),
             projectM: detachedFrame(snapshot.projectM)
         )
@@ -7296,6 +7432,7 @@ class WindowManager {
             (frames.peppyMeter, peppyMeterWindow),
             (frames.networkMonitor, networkMonitorWindow),
             (frames.cava, cavaWindow),
+            (frames.sonos, sonosWindow),
             (frames.library, plexBrowserWindowController?.window),
             (frames.projectM, projectMWindowController?.window),
         ]
@@ -7362,6 +7499,7 @@ class WindowManager {
             peppyMeter: convScaled(snapshot.peppyMeter),
             networkMonitor: convScaled(snapshot.networkMonitor),
             cava: convScaled(snapshot.cava),
+            sonos: convScaled(snapshot.sonos),
             waveform: convScaled(snapshot.waveform),
             projectMPresetIndex: restorableProjectMPresetIndex()
         )

--- a/Sources/NullPlayer/Casting/SonosRoomMixer.swift
+++ b/Sources/NullPlayer/Casting/SonosRoomMixer.swift
@@ -1,0 +1,131 @@
+import Foundation
+
+/// Window state is independent of skin recreation. Room writes are serialized per room;
+/// polling cannot replace a newer slider value with an older network response.
+@MainActor
+final class SonosRoomMixer {
+    static let shared = SonosRoomMixer()
+    private(set) var volumes: [String: Int] = [:]
+    private(set) var errors: [String: String] = [:]
+    private var pending: [String: Int] = [:]
+    private var writing: Set<String> = []
+    private var revisions: [String: UInt] = [:]
+    private var reading = false
+    private(set) var changingRooms = false
+    private let roomIDs: @MainActor () -> [String]
+    private let readVolume: @MainActor (String) async throws -> Int
+    private let writeVolume: @MainActor (Int, String) async throws -> Void
+
+    init(roomIDs: @escaping @MainActor () -> [String] = { CastManager.shared.sonosRooms.map(\.id) },
+         readVolume: @escaping @MainActor (String) async throws -> Int = {
+             try await UPnPManager.shared.getSonosRoomVolume(roomUDN: $0)
+         },
+         writeVolume: @escaping @MainActor (Int, String) async throws -> Void = {
+             try await UPnPManager.shared.setSonosRoomVolume($0, roomUDN: $1)
+         }) {
+        self.roomIDs = roomIDs
+        self.readVolume = readVolume
+        self.writeVolume = writeVolume
+    }
+
+    func setVolume(_ value: Int, room: String) {
+        let value = max(0, min(100, value))
+        revisions[room, default: 0] &+= 1
+        volumes[room] = value
+        errors[room] = nil
+        pending[room] = value
+        guard writing.insert(room).inserted else { return }
+        Task {
+            defer { writing.remove(room) }
+            while let next = pending.removeValue(forKey: room) {
+                do {
+                    try await writeVolume(next, room)
+                    errors[room] = nil
+                } catch {
+                    errors[room] = error.localizedDescription
+                    if pending[room] == nil { volumes[room] = nil }
+                }
+            }
+        }
+    }
+
+    func refreshVolumes() async {
+        guard !reading else { return }
+        reading = true
+        defer { reading = false }
+        let candidates = roomIDs().filter { !writing.contains($0) }.map { ($0, revisions[$0, default: 0]) }
+        var remaining = candidates.makeIterator()
+        let read = readVolume
+        await withTaskGroup(of: (String, UInt, Result<Int, Error>).self) { group in
+            func enqueue(_ candidate: (String, UInt)) {
+                let (id, revision) = candidate
+                group.addTask { @MainActor in
+                    do { return (id, revision, .success(try await read(id))) }
+                    catch { return (id, revision, .failure(error)) }
+                }
+            }
+            for _ in 0..<4 { if let id = remaining.next() { enqueue(id) } }
+            for await (id, revision, result) in group {
+                if !Task.isCancelled, revision == revisions[id, default: 0], !writing.contains(id) {
+                    switch result {
+                    case .success(let value): volumes[id] = value; errors[id] = nil
+                    case .failure(let error): volumes[id] = nil; errors[id] = error.localizedDescription
+                    }
+                }
+                if Task.isCancelled { group.cancelAll() }
+                else if let id = remaining.next() { enqueue(id) }
+            }
+        }
+    }
+
+    func selectRoom(_ id: String, selected: Bool) async throws {
+        guard !changingRooms else { throw CastError.operationInProgress }
+        let manager = CastManager.shared
+        guard manager.activeSession?.device.type == .sonos else {
+            if selected { manager.selectedSonosRooms.insert(id) }
+            else { manager.selectedSonosRooms.remove(id) }
+            return
+        }
+        changingRooms = true
+        defer { changingRooms = false }
+        if selected, let coordinator = manager.activeSession?.device.id {
+            try await manager.joinSonosToGroup(zoneUDN: id, coordinatorUDN: coordinator)
+        } else if id == manager.activeSession?.device.id {
+            let others = manager.getRoomsInActiveCastGroup().filter { $0 != id }.sorted()
+            if let next = others.first {
+                try await manager.transferSonosCast(fromCoordinator: id, toRoom: next,
+                                                    otherRooms: Array(others.dropFirst()))
+            } else {
+                await manager.stopCasting()
+            }
+        } else {
+            try await manager.unjoinSonos(zoneUDN: id)
+        }
+        await manager.refreshSonosGroups()
+    }
+
+    func startCasting() async throws {
+        guard !changingRooms else { throw CastError.operationInProgress }
+        let manager = CastManager.shared
+        guard WindowManager.shared.audioEngine.currentTrack != nil else { throw CastError.noTrackPlaying }
+        let ids = manager.sonosRooms.map(\.id).filter { manager.selectedSonosRooms.contains($0) }
+        guard let first = ids.first,
+              let device = UPnPManager.shared.sonosCastDevice(forZoneUDN: first) else { throw CastError.deviceNotFound }
+        changingRooms = true
+        defer { changingRooms = false }
+        do {
+            // A selected member of an existing household group must become its own
+            // coordinator first, so unselected rooms are not accidentally included.
+            try await manager.unjoinSonos(zoneUDN: first)
+            try await manager.castCurrentTrack(to: device)
+            guard let coordinator = manager.activeSession?.device.id else { throw CastError.sessionNotActive }
+            for id in ids where id != coordinator {
+                try await manager.joinSonosToGroup(zoneUDN: id, coordinatorUDN: coordinator)
+            }
+            await manager.refreshSonosGroups()
+        } catch {
+            await manager.stopCasting()
+            throw error
+        }
+    }
+}

--- a/Sources/NullPlayer/Casting/UPnPManager.swift
+++ b/Sources/NullPlayer/Casting/UPnPManager.swift
@@ -2013,6 +2013,30 @@ class UPnPManager {
     }
     
     // MARK: - Volume Control
+
+    /// Room controls deliberately address the representative renderer, never the group.
+    /// This also works before NullPlayer starts a casting session.
+    func setSonosRoomVolume(_ volume: Int, roomUDN: String) async throws {
+        guard let device = sonosCastDevice(forZoneUDN: roomUDN) else { throw CastError.deviceNotFound }
+        try await sendRenderingControlAction(
+            controlURL: getRenderingControlURL(for: device), action: "SetVolume",
+            arguments: [("InstanceID", "0"), ("Channel", "Master"),
+                        ("DesiredVolume", "\(max(0, min(100, volume)))")], retries: 0
+        )
+    }
+
+    func getSonosRoomVolume(roomUDN: String) async throws -> Int {
+        guard let device = sonosCastDevice(forZoneUDN: roomUDN) else { throw CastError.deviceNotFound }
+        let response = try await sendRenderingControlAction(
+            controlURL: getRenderingControlURL(for: device), action: "GetVolume",
+            arguments: [("InstanceID", "0"), ("Channel", "Master")], retries: 0
+        )
+        guard let value = extractXMLValue(response, tag: "CurrentVolume"),
+              let volume = Int(value), (0...100).contains(volume) else {
+            throw CastError.playbackFailed("Invalid room volume response")
+        }
+        return volume
+    }
     
     /// Set volume on the connected device (0-100).
     /// `retries` overrides the default SOAP retry count (pass 0 for coalesced volume commands

--- a/Sources/NullPlayer/Casting/UPnPManager.swift
+++ b/Sources/NullPlayer/Casting/UPnPManager.swift
@@ -2017,22 +2017,18 @@ class UPnPManager {
     /// Room controls deliberately address the representative renderer, never the group.
     /// This also works before NullPlayer starts a casting session.
     func setSonosRoomVolume(_ volume: Int, roomUDN: String) async throws {
-        guard let controlURL = sonosRoomRenderingControlURL(forZoneUDN: roomUDN) else {
-            throw CastError.deviceNotFound
-        }
+        guard let device = sonosCastDevice(forZoneUDN: roomUDN) else { throw CastError.deviceNotFound }
         try await sendRenderingControlAction(
-            controlURL: controlURL, action: "SetVolume",
+            controlURL: getRenderingControlURL(for: device), action: "SetVolume",
             arguments: [("InstanceID", "0"), ("Channel", "Master"),
                         ("DesiredVolume", "\(max(0, min(100, volume)))")], retries: 0
         )
     }
 
     func getSonosRoomVolume(roomUDN: String) async throws -> Int {
-        guard let controlURL = sonosRoomRenderingControlURL(forZoneUDN: roomUDN) else {
-            throw CastError.deviceNotFound
-        }
+        guard let device = sonosCastDevice(forZoneUDN: roomUDN) else { throw CastError.deviceNotFound }
         let response = try await sendRenderingControlAction(
-            controlURL: controlURL, action: "GetVolume",
+            controlURL: getRenderingControlURL(for: device), action: "GetVolume",
             arguments: [("InstanceID", "0"), ("Channel", "Master")], retries: 0
         )
         guard let value = extractXMLValue(response, tag: "CurrentVolume"),
@@ -2040,20 +2036,6 @@ class UPnPManager {
             throw CastError.playbackFailed("Invalid room volume response")
         }
         return volume
-    }
-
-    /// Room-volume control only requires the representative's discovered address and port.
-    /// Unlike casting, RenderingControl does not depend on an AVTransport service URL.
-    private func sonosRoomRenderingControlURL(forZoneUDN udn: String) -> URL? {
-        stateQueue.sync {
-            guard let zone = sonosZones[udn] else { return nil }
-            var components = URLComponents()
-            components.scheme = "http"
-            components.host = zone.address
-            components.port = zone.port
-            components.path = "/MediaRenderer/RenderingControl/Control"
-            return components.url
-        }
     }
     
     /// Set volume on the connected device (0-100).

--- a/Sources/NullPlayer/Casting/UPnPManager.swift
+++ b/Sources/NullPlayer/Casting/UPnPManager.swift
@@ -2017,18 +2017,22 @@ class UPnPManager {
     /// Room controls deliberately address the representative renderer, never the group.
     /// This also works before NullPlayer starts a casting session.
     func setSonosRoomVolume(_ volume: Int, roomUDN: String) async throws {
-        guard let device = sonosCastDevice(forZoneUDN: roomUDN) else { throw CastError.deviceNotFound }
+        guard let controlURL = sonosRoomRenderingControlURL(forZoneUDN: roomUDN) else {
+            throw CastError.deviceNotFound
+        }
         try await sendRenderingControlAction(
-            controlURL: getRenderingControlURL(for: device), action: "SetVolume",
+            controlURL: controlURL, action: "SetVolume",
             arguments: [("InstanceID", "0"), ("Channel", "Master"),
                         ("DesiredVolume", "\(max(0, min(100, volume)))")], retries: 0
         )
     }
 
     func getSonosRoomVolume(roomUDN: String) async throws -> Int {
-        guard let device = sonosCastDevice(forZoneUDN: roomUDN) else { throw CastError.deviceNotFound }
+        guard let controlURL = sonosRoomRenderingControlURL(forZoneUDN: roomUDN) else {
+            throw CastError.deviceNotFound
+        }
         let response = try await sendRenderingControlAction(
-            controlURL: getRenderingControlURL(for: device), action: "GetVolume",
+            controlURL: controlURL, action: "GetVolume",
             arguments: [("InstanceID", "0"), ("Channel", "Master")], retries: 0
         )
         guard let value = extractXMLValue(response, tag: "CurrentVolume"),
@@ -2036,6 +2040,20 @@ class UPnPManager {
             throw CastError.playbackFailed("Invalid room volume response")
         }
         return volume
+    }
+
+    /// Room-volume control only requires the representative's discovered address and port.
+    /// Unlike casting, RenderingControl does not depend on an AVTransport service URL.
+    private func sonosRoomRenderingControlURL(forZoneUDN udn: String) -> URL? {
+        stateQueue.sync {
+            guard let zone = sonosZones[udn] else { return nil }
+            var components = URLComponents()
+            components.scheme = "http"
+            components.host = zone.address
+            components.port = zone.port
+            components.path = "/MediaRenderer/RenderingControl/Control"
+            return components.url
+        }
     }
     
     /// Set volume on the connected device (0-100).

--- a/Sources/NullPlayer/WinampModern/WinampModernHostedWindows.swift
+++ b/Sources/NullPlayer/WinampModern/WinampModernHostedWindows.swift
@@ -68,6 +68,7 @@ enum WinampModernSurfaceID: Hashable, CustomStringConvertible {
 }
 
 enum WinampModernHostedWindowID: String, CaseIterable {
+    case sonos
     case spectrum
     case equalizer
     case cava
@@ -99,6 +100,18 @@ struct WinampModernHostedWindowDefinition {
 
 enum WinampModernHostedWindowRegistry {
     static let all: [WinampModernHostedWindowDefinition] = [
+        WinampModernHostedWindowDefinition(
+            id: .sonos, title: "Sonos Rooms",
+            defaultSize: CGSize(width: 275, height: 250),
+            minimumSize: CGSize(width: 250, height: 160), maximumSize: nil,
+            stackPolicy: WinampModernHostedStackPolicy(participatesInCenterStack: true,
+                                                       preferredHeightMultiplier: 2),
+            makeSurface: { context in
+                let view = SonosWindowView(frame: NSRect(x: 0, y: 0, width: 275, height: 250))
+                view.configureForHostedSurface(context: context)
+                return view
+            }
+        ),
         WinampModernHostedWindowDefinition(
             id: .spectrum,
             title: "Spectrum Analyzer",

--- a/Sources/NullPlayer/Windows/ModernSonos/ModernSonosChrome.swift
+++ b/Sources/NullPlayer/Windows/ModernSonos/ModernSonosChrome.swift
@@ -1,0 +1,22 @@
+import AppKit
+
+enum ModernSonosChrome {
+    static func draw(in bounds: NSRect, window: NSWindow?, closePressed: Bool,
+                     titleHeight: CGFloat, closeRect: NSRect, context: CGContext) {
+        let skin = ModernSkinEngine.shared.currentSkin ?? ModernSkinLoader.shared.loadDefault()
+        let renderer = ModernSkinRenderer(skin: skin)
+        let edges = window.map { WindowManager.shared.computeAdjacentEdges(for: $0) } ?? []
+        let corners = window.map { WindowManager.shared.computeSharpCorners(for: $0) } ?? []
+        renderer.drawWindowBackground(in: bounds, context: context, adjacentEdges: edges, sharpCorners: corners)
+        renderer.drawWindowBorder(in: bounds, context: context, adjacentEdges: edges, sharpCorners: corners,
+                                  occlusionSegments: window.map { WindowManager.shared.computeEdgeOcclusionSegments(for: $0) } ?? .empty)
+        guard !WindowManager.shared.effectiveHideTitleBars(for: window) else { return }
+        let scale = ModernSkinElements.scaleFactor
+        renderer.drawTitleBar(in: NSRect(x: 0, y: (bounds.height - titleHeight) / scale,
+                                         width: bounds.width / scale, height: titleHeight / scale),
+                              title: "SONOS", prefix: "spectrum_", context: context)
+        renderer.drawWindowControlButton("spectrum_btn_close", state: closePressed ? "pressed" : "normal",
+            in: NSRect(x: closeRect.minX / scale, y: closeRect.minY / scale,
+                       width: closeRect.width / scale, height: closeRect.height / scale), context: context)
+    }
+}

--- a/Sources/NullPlayer/Windows/Sonos/SonosWindowChrome.swift
+++ b/Sources/NullPlayer/Windows/Sonos/SonosWindowChrome.swift
@@ -1,0 +1,66 @@
+import AppKit
+
+/// Selects the existing auxiliary-window renderer; room controls own no skin assets.
+struct SonosWindowChrome {
+    let window: NSWindow?
+    private var modern: Bool { WindowManager.shared.isModernUIEnabled }
+    private var classicScale: CGFloat { WindowManager.shared.playlistChromeScale }
+    var titleHeight: CGFloat {
+        if modern {
+            return WindowManager.shared.effectiveHideTitleBars(for: window)
+                ? ModernSkinElements.auxiliaryWindowBorderWidth
+                : ModernSkinElements.titleBarBaseHeight * ModernSkinElements.scaleFactor
+        }
+        return WindowManager.shared.hideTitleBars ? 0 : SkinElements.SpectrumWindow.Layout.titleBarHeight
+    }
+    var textColor: NSColor {
+        if modern { return ModernSkinEngine.shared.currentSkin?.textColor ?? .labelColor }
+        if let style = WindowManager.shared.winampModernSurfaceStyle { return style.text }
+        return WindowManager.shared.currentSkin?.playlistColors.normalText ?? .green
+    }
+    var backgroundColor: NSColor {
+        if modern { return ModernSkinEngine.shared.currentSkin?.backgroundColor ?? .black }
+        if let style = WindowManager.shared.winampModernSurfaceStyle { return style.background }
+        return WindowManager.shared.currentSkin?.playlistColors.normalBackground ?? .black
+    }
+    func contentRect(_ bounds: NSRect) -> NSRect {
+        let border = modern ? ModernSkinElements.auxiliaryWindowBorderWidth : SkinElements.SpectrumWindow.Layout.leftBorder
+        let bottom = modern ? border : SkinElements.SpectrumWindow.Layout.bottomBorder
+        return NSRect(x: border, y: bottom, width: max(0, bounds.width - 2 * border),
+                      height: max(0, bounds.height - titleHeight - bottom))
+    }
+    func closeRect(_ bounds: NSRect) -> NSRect {
+        guard titleHeight > 4 else { return .zero }
+        let size: CGFloat = modern ? 14 * ModernSkinElements.scaleFactor : 9 * classicScale
+        return NSRect(x: bounds.maxX - size - (modern ? 5 : 3) * (modern ? ModernSkinElements.scaleFactor : classicScale),
+                      y: bounds.maxY - titleHeight + (titleHeight - size) / 2, width: size, height: size)
+    }
+    func draw(_ bounds: NSRect, closePressed: Bool) {
+        guard let context = NSGraphicsContext.current?.cgContext else { return }
+        if modern {
+            ModernSonosChrome.draw(in: bounds, window: window, closePressed: closePressed,
+                                   titleHeight: titleHeight, closeRect: closeRect(bounds), context: context)
+            return
+        }
+        let skin = WindowManager.shared.currentSkin ?? SkinLoader.shared.loadDefault()
+        (WindowManager.shared.winampModernSurfaceStyle?.background ?? skin.playlistColors.normalBackground).setFill()
+        bounds.fill()
+        context.saveGState()
+        context.translateBy(x: 0, y: bounds.height)
+        context.scaleBy(x: 1, y: -1)
+        if WindowManager.shared.hideTitleBars {
+            context.translateBy(x: 0, y: -SkinElements.SpectrumWindow.Layout.titleBarHeight)
+        }
+        if let style = WindowManager.shared.winampModernSurfaceStyle {
+            WinampModernChrome(style: style).drawSpectrumFamilyWindow(
+                in: context, bounds: bounds, metrics: .spectrumFamily,
+                isActive: window?.isKeyWindow ?? false, isClosePressed: closePressed,
+                controlScale: classicScale, title: "SONOS", fillBackground: false)
+        } else {
+            SkinRenderer(skin: skin).drawSpectrumAnalyzerWindowChromeOverlay(
+                in: context, bounds: bounds, isActive: window?.isKeyWindow ?? false,
+                pressedButton: closePressed ? .close : nil, controlScale: classicScale, title: "SONOS")
+        }
+        context.restoreGState()
+    }
+}

--- a/Sources/NullPlayer/Windows/Sonos/SonosWindowController.swift
+++ b/Sources/NullPlayer/Windows/Sonos/SonosWindowController.swift
@@ -1,0 +1,426 @@
+import AppKit
+
+final class SonosWindowController: NSWindowController, ModeDependentWindow, NSWindowDelegate {
+    private(set) var mixerView: SonosWindowView!
+    private var observers: [NSObjectProtocol] = []
+    private(set) var wasDockedWhenHidden = false
+
+    convenience init() {
+        let window = BorderlessWindow(contentRect: NSRect(x: 0, y: 0, width: 360, height: 260),
+                                      styleMask: [.borderless], backing: .buffered, defer: false)
+        self.init(window: window)
+        window.title = "Sonos Rooms"
+        window.isReleasedWhenClosed = false
+        window.isMovableByWindowBackground = false
+        window.isOpaque = false
+        window.backgroundColor = .clear
+        window.hasShadow = true
+        window.minSize = NSSize(width: 250, height: 160)
+        window.allowedResizeEdges = [.bottom, .left, .right]
+        window.collectionBehavior = [.managed, .fullScreenPrimary]
+        window.delegate = self
+        window.setAccessibilityIdentifier("SonosRoomsWindow")
+        window.setAccessibilityLabel("Sonos rooms and volume")
+        mixerView = SonosWindowView(frame: NSRect(origin: .zero, size: window.frame.size))
+        mixerView.autoresizingMask = [.width, .height]
+        window.contentView = mixerView
+        for name in [NSWindow.didChangeOcclusionStateNotification, NSWindow.didMiniaturizeNotification,
+                     NSWindow.didDeminiaturizeNotification] {
+            observers.append(NotificationCenter.default.addObserver(forName: name, object: window, queue: .main) { [weak self] _ in
+                guard let self, let window = self.window else { return }
+                if window.isVisible, !window.isMiniaturized, window.occlusionState.contains(.visible) {
+                    self.mixerView.resume()
+                } else { self.mixerView.suspend() }
+            })
+        }
+    }
+
+    deinit { observers.forEach(NotificationCenter.default.removeObserver) }
+
+    override func showWindow(_ sender: Any?) {
+        super.showWindow(sender)
+        mixerView.needsLayout = true
+        mixerView.layoutSubtreeIfNeeded()
+        mixerView.refresh()
+        mixerView.resume()
+    }
+
+    func prepareForUITeardown() {
+        if let window, window.isVisible { wasDockedWhenHidden = WindowManager.shared.isWindowDocked(window) }
+        mixerView.suspend()
+    }
+
+    func skinDidChange() { mixerView.needsLayout = true; mixerView.needsDisplay = true }
+
+    func windowWillClose(_ notification: Notification) {
+        if let window { WindowManager.shared.handleCenterStackWindowWillClose(window) }
+        prepareForUITeardown()
+        WindowManager.shared.notifyMainWindowVisibilityChanged()
+    }
+
+    func windowDidResize(_ notification: Notification) {
+        mixerView.needsLayout = true
+        WindowManager.shared.postWindowLayoutDidChange()
+    }
+
+    func windowDidMove(_ notification: Notification) {
+        guard let window else { return }
+        let origin = WindowManager.shared.windowWillMove(window, to: window.frame.origin)
+        WindowManager.shared.applySnappedPosition(window, to: origin)
+    }
+
+    func windowDidBecomeKey(_ notification: Notification) {
+        mixerView.needsDisplay = true
+        WindowManager.shared.bringAllWindowsToFront(keepingWindowOnTop: window)
+    }
+
+    func windowDidResignKey(_ notification: Notification) { mixerView.needsDisplay = true }
+}
+
+/// Shared room controls. Skin-specific chrome is supplied by SonosWindowChrome.
+final class SonosWindowView: NSView {
+    private var refreshTimer: Timer?
+    private var pollTask: Task<Void, Never>?
+    private var hostedContext: WinampModernHostedSurfaceContext?
+    private var hostedDrag = WinampModernHostedWindowDrag()
+    private var hostedStyle: WinampModernSurfaceStyle?
+    private let scroll = NSScrollView()
+    private let document = SonosRoomDocumentView()
+    private let status = NSTextField(labelWithString: "Choose rooms to cast to")
+    private let castButton = NSButton(title: "Start Casting", target: nil, action: nil)
+    private let refreshButton = NSButton(title: "Refresh", target: nil, action: nil)
+    private var rows: [String: SonosRoomRow] = [:]
+    private var roomIDs: [String] = []
+    private var busy = false
+    private var message: String?
+    private var dragStart: NSPoint?
+    private var closePressed = false
+    private let mixer: SonosRoomMixer
+    private let roomSource: () -> [UPnPManager.SonosRoomSummary]
+    private var controlScale: CGFloat { WindowManager.shared.uiScaleLevel.scaleFactor }
+    private var chrome: SonosWindowChrome { SonosWindowChrome(window: window) }
+
+    override convenience init(frame: NSRect) {
+        self.init(frame: frame, mixer: .shared, rooms: { CastManager.shared.sonosRooms })
+    }
+
+    init(frame: NSRect, mixer: SonosRoomMixer, rooms: @escaping () -> [UPnPManager.SonosRoomSummary]) {
+        self.mixer = mixer
+        self.roomSource = rooms
+        super.init(frame: frame)
+        wantsLayer = true
+        needsLayout = true
+        scroll.drawsBackground = false
+        scroll.hasVerticalScroller = true
+        scroll.autohidesScrollers = true
+        scroll.documentView = document
+        addSubview(scroll)
+        for view in [status, castButton, refreshButton] { addSubview(view) }
+        status.font = .systemFont(ofSize: 10)
+        status.lineBreakMode = .byTruncatingTail
+        castButton.bezelStyle = .rounded
+        refreshButton.bezelStyle = .rounded
+        castButton.target = self
+        castButton.action = #selector(castClicked)
+        refreshButton.target = self
+        refreshButton.action = #selector(refreshClicked)
+        NotificationCenter.default.addObserver(self, selector: #selector(layoutChanged),
+                                               name: .windowLayoutDidChange, object: nil)
+        NotificationCenter.default.addObserver(self, selector: #selector(layoutChanged),
+                                               name: ModernSkinEngine.skinDidChangeNotification, object: nil)
+        NotificationCenter.default.addObserver(self, selector: #selector(layoutChanged),
+                                               name: .doubleSizeDidChange, object: nil)
+        NotificationCenter.default.addObserver(self, selector: #selector(layoutChanged),
+                                               name: .connectedWindowHighlightDidChange, object: nil)
+    }
+
+    required init?(coder: NSCoder) { fatalError("init(coder:) has not been implemented") }
+    deinit {
+        refreshTimer?.invalidate()
+        pollTask?.cancel()
+        NotificationCenter.default.removeObserver(self)
+    }
+
+    @objc private func layoutChanged() { needsLayout = true; needsDisplay = true }
+
+    override func setFrameSize(_ newSize: NSSize) {
+        super.setFrameSize(newSize)
+        needsLayout = true
+    }
+
+    override func layout() {
+        super.layout()
+        let area = hostedContext == nil ? chrome.contentRect(bounds) : bounds
+        let scale = controlScale
+        let padding: CGFloat = 10 * scale
+        let width = max(0, area.width - padding * 2)
+        status.frame = NSRect(x: area.minX + padding, y: area.maxY - 24 * scale, width: width, height: 15 * scale)
+        refreshButton.frame = NSRect(x: area.minX + padding, y: area.minY + 7 * scale, width: 76 * scale, height: 26 * scale)
+        castButton.frame = NSRect(x: area.maxX - padding - 116 * scale, y: area.minY + 7 * scale, width: 116 * scale, height: 26 * scale)
+        for control in [status, refreshButton, castButton] {
+            control.setBoundsSize(NSSize(width: control.frame.width / scale, height: control.frame.height / scale))
+        }
+        scroll.frame = NSRect(x: area.minX, y: area.minY + 40 * scale, width: area.width,
+                              height: max(0, area.height - 70 * scale))
+        let rowWidth = scroll.contentSize.width
+        document.frame = NSRect(x: 0, y: 0, width: rowWidth, height: CGFloat(roomIDs.count) * 65 * scale)
+        for (index, id) in roomIDs.enumerated() {
+            rows[id]?.frame = NSRect(x: 0, y: CGFloat(index) * 65 * scale, width: rowWidth, height: 65 * scale)
+            rows[id]?.setBoundsSize(NSSize(width: rowWidth / scale, height: 65))
+            rows[id]?.needsLayout = true
+        }
+        status.textColor = (hostedStyle?.text ?? chrome.textColor).withAlphaComponent(0.8)
+        if hostedContext == nil { (window as? BorderlessWindow)?.titleBarHeight = chrome.titleHeight }
+    }
+
+    override func draw(_ dirtyRect: NSRect) {
+        if let hostedStyle {
+            hostedStyle.background.setFill()
+            bounds.fill()
+        } else { chrome.draw(bounds, closePressed: closePressed) }
+    }
+
+    func refresh() {
+        let background = (hostedStyle?.background ?? chrome.backgroundColor).usingColorSpace(.deviceRGB) ?? .black
+        let brightness = 0.299 * background.redComponent + 0.587 * background.greenComponent + 0.114 * background.blueComponent
+        let appearanceName: NSAppearance.Name = brightness < 0.5 ? .darkAqua : .aqua
+        if appearance?.name != appearanceName { appearance = NSAppearance(named: appearanceName) }
+        let tint = hostedStyle?.text ?? chrome.textColor
+        refreshButton.contentTintColor = tint
+        castButton.contentTintColor = tint
+        let manager = CastManager.shared
+        let rooms = roomSource()
+        let ids = rooms.map(\.id)
+        if ids != roomIDs {
+            for row in rows.values { row.removeFromSuperview() }
+            rows.removeAll()
+            roomIDs = ids
+            for room in rooms {
+                let row = SonosRoomRow(id: room.id, mixer: mixer)
+                row.onSelection = { [weak self] selected in
+                    guard let self else { return }
+                    self.performOperation {
+                        try await self.mixer.selectRoom(room.id, selected: selected)
+                    }
+                }
+                rows[room.id] = row
+                document.addSubview(row)
+            }
+            needsLayout = true
+        }
+        let casting = manager.activeSession?.device.type == .sonos
+        let selected = (casting ? Set(manager.getRoomsInActiveCastGroup()) : manager.selectedSonosRooms).intersection(ids)
+        let changing = busy || mixer.changingRooms
+        for room in rooms {
+            rows[room.id]?.update(name: room.name, selected: selected.contains(room.id),
+                                  casting: casting, enabled: !changing, color: hostedStyle?.text ?? chrome.textColor)
+        }
+        castButton.title = casting ? "Stop Casting" : "Start Casting"
+        castButton.isEnabled = !changing && (casting || (!selected.isEmpty && WindowManager.shared.audioEngine.currentTrack != nil))
+        refreshButton.isEnabled = !changing
+        if let message { status.stringValue = message }
+        else if changing { status.stringValue = "Updating rooms…" }
+        else if rooms.isEmpty { status.stringValue = "No Sonos rooms found. Try Refresh." }
+        else if casting { status.stringValue = "Casting to \(selected.count) of \(rooms.count) rooms" }
+        else if WindowManager.shared.audioEngine.currentTrack == nil { status.stringValue = "Choose rooms, then load music to cast." }
+        else { status.stringValue = "\(selected.count) of \(rooms.count) rooms selected" }
+        status.toolTip = status.stringValue
+        needsDisplay = true
+    }
+
+    private func performOperation(_ operation: @escaping @MainActor () async throws -> Void) {
+        guard !busy else { return }
+        busy = true
+        message = nil
+        refresh()
+        Task { @MainActor [weak self] in
+            do { try await operation() }
+            catch { self?.message = error.localizedDescription }
+            self?.busy = false
+            self?.refresh()
+        }
+    }
+
+    @objc private func castClicked() {
+        performOperation {
+            if CastManager.shared.activeSession?.device.type == .sonos {
+                await CastManager.shared.stopCasting()
+            } else { try await self.mixer.startCasting() }
+        }
+    }
+
+    @objc private func refreshClicked() {
+        CastManager.shared.refreshDevices()
+        performOperation {
+            await CastManager.shared.refreshSonosGroups()
+            await self.mixer.refreshVolumes()
+        }
+    }
+
+    override func acceptsFirstMouse(for event: NSEvent?) -> Bool { true }
+    override func mouseDown(with event: NSEvent) {
+        if let hostedContext { hostedDrag.prime(event, context: hostedContext); return }
+        let point = convert(event.locationInWindow, from: nil)
+        if hostedContext == nil && chrome.closeRect(bounds).contains(point) { closePressed = true; needsDisplay = true; return }
+        dragStart = event.locationInWindow
+        if let window { WindowManager.shared.windowWillStartDragging(window, fromTitleBar: true) }
+    }
+    override func mouseDragged(with event: NSEvent) {
+        if hostedContext != nil { hostedDrag.drag(event); return }
+        guard let start = dragStart, let window else { return }
+        let mouse = NSEvent.mouseLocation
+        let origin = NSPoint(x: mouse.x - start.x, y: mouse.y - start.y)
+        window.setFrameOrigin(WindowManager.shared.windowWillMove(window, to: origin))
+    }
+    override func mouseUp(with event: NSEvent) {
+        if hostedContext != nil { hostedDrag.end(); return }
+        if closePressed && chrome.closeRect(bounds).contains(convert(event.locationInWindow, from: nil)) {
+            WindowManager.shared.toggleSonos()
+        }
+        closePressed = false
+        if dragStart != nil, let window { WindowManager.shared.windowDidFinishDragging(window) }
+        dragStart = nil
+        needsDisplay = true
+    }
+}
+
+extension SonosWindowView: WinampModernHostedSurface {
+    var view: NSView { self }
+    func configureForHostedSurface(context: WinampModernHostedSurfaceContext) {
+        hostedContext = context
+        autoresizingMask = [.width, .height]
+    }
+    func applyPalette(_ style: WinampModernSurfaceStyle) {
+        hostedStyle = style
+        needsLayout = true
+        refresh()
+    }
+    func applySkinScale(_ scale: CGFloat) { needsLayout = true; needsDisplay = true }
+    func resume() {
+        needsLayout = true
+        layoutSubtreeIfNeeded()
+        refresh()
+        guard refreshTimer == nil else { return }
+        refreshTimer = Timer.scheduledTimer(withTimeInterval: 0.5, repeats: true) { [weak self] _ in
+            guard let self, self.window?.isVisible == true else { return }
+            self.refresh()
+        }
+        pollTask = Task { @MainActor [weak self] in
+            while !Task.isCancelled {
+                guard self?.window != nil else { break }
+                await self?.mixer.refreshVolumes()
+                self?.refresh()
+                do { try await Task.sleep(nanoseconds: 4_000_000_000) } catch { break }
+            }
+        }
+    }
+    func suspend() {
+        refreshTimer?.invalidate()
+        refreshTimer = nil
+        pollTask?.cancel()
+        pollTask = nil
+    }
+    func unmountFromHolder() { suspend(); removeFromSuperview() }
+    func prepareForUITeardown() { suspend(); hostedContext = nil; removeFromSuperview() }
+}
+
+private final class SonosRoomDocumentView: NSView {
+    override var isFlipped: Bool { true }
+}
+
+private final class SonosRoomRow: NSView {
+    let id: String
+    private let mixer: SonosRoomMixer
+    var onSelection: ((Bool) -> Void)?
+    private let checkbox = NSButton(checkboxWithTitle: "", target: nil, action: nil)
+    private let subtitle = NSTextField(labelWithString: "")
+    private let slider = NSSlider(value: 0, minValue: 0, maxValue: 100, target: nil, action: nil)
+    private let value = NSTextField(labelWithString: "—")
+    private var accent = NSColor.controlAccentColor
+    private var selected = false
+    override var isFlipped: Bool { true }
+
+    init(id: String, mixer: SonosRoomMixer) {
+        self.id = id
+        self.mixer = mixer
+        super.init(frame: .zero)
+        for view in [checkbox, subtitle, slider, value] { addSubview(view) }
+        checkbox.target = self
+        checkbox.action = #selector(selectChanged)
+        checkbox.font = .systemFont(ofSize: 12, weight: .semibold)
+        checkbox.cell?.lineBreakMode = .byTruncatingTail
+        subtitle.font = .systemFont(ofSize: 9)
+        subtitle.lineBreakMode = .byTruncatingTail
+        value.font = .monospacedDigitSystemFont(ofSize: 11, weight: .medium)
+        value.alignment = .right
+        slider.isContinuous = true
+        slider.cell = SonosVolumeSliderCell()
+        slider.minValue = 0
+        slider.maxValue = 100
+        slider.controlSize = .small
+        slider.target = self
+        slider.action = #selector(volumeChanged)
+    }
+    required init?(coder: NSCoder) { fatalError("init(coder:) has not been implemented") }
+    override func layout() {
+        super.layout()
+        checkbox.frame = NSRect(x: 10, y: 6, width: max(0, bounds.width - 64), height: 20)
+        value.frame = NSRect(x: bounds.width - 47, y: 10, width: 34, height: 15)
+        subtitle.frame = NSRect(x: 30, y: 27, width: max(0, bounds.width - 40), height: 12)
+        slider.frame = NSRect(x: 28, y: 40, width: max(0, bounds.width - 40), height: 18)
+    }
+    func update(name: String, selected: Bool, casting: Bool, enabled: Bool, color: NSColor) {
+        self.selected = selected
+        accent = color
+        (slider.cell as? SonosVolumeSliderCell)?.accent = color
+        checkbox.title = name
+        checkbox.contentTintColor = color
+        checkbox.state = selected ? .on : .off
+        checkbox.isEnabled = enabled
+        value.textColor = color
+        subtitle.textColor = color.withAlphaComponent(0.65)
+        if let volume = mixer.volumes[id] {
+            slider.integerValue = volume
+            value.stringValue = "\(volume)"
+            slider.isEnabled = true
+        } else {
+            value.stringValue = "—"
+            slider.isEnabled = false
+        }
+        subtitle.stringValue = mixer.errors[id] != nil ? "Volume unavailable · Refresh to retry" :
+            (selected ? (casting ? "Receiving audio" : "Ready to cast") : "Not selected")
+        subtitle.toolTip = mixer.errors[id]
+        slider.setAccessibilityLabel("\(name) volume")
+        slider.toolTip = "\(name) volume (0–100)"
+        needsDisplay = true
+    }
+    override func draw(_ dirtyRect: NSRect) {
+        if selected { accent.withAlphaComponent(0.08).setFill(); bounds.fill() }
+        accent.withAlphaComponent(0.13).setFill()
+        NSRect(x: 10, y: bounds.height - 1, width: max(0, bounds.width - 20), height: 1).fill()
+    }
+    @objc private func selectChanged() { onSelection?(checkbox.state == .on) }
+    @objc private func volumeChanged() {
+        value.stringValue = "\(slider.integerValue)"
+        mixer.setVolume(slider.integerValue, room: id)
+    }
+}
+
+private final class SonosVolumeSliderCell: NSSliderCell {
+    var accent: NSColor = .controlAccentColor
+    override func drawBar(inside rect: NSRect, flipped: Bool) {
+        let track = NSRect(x: rect.minX, y: rect.midY - 1.5, width: rect.width, height: 3)
+        accent.withAlphaComponent(0.2).setFill()
+        NSBezierPath(roundedRect: track, xRadius: 1.5, yRadius: 1.5).fill()
+        guard isEnabled else { return }
+        let fraction = CGFloat((doubleValue - minValue) / max(1, maxValue - minValue))
+        accent.setFill()
+        NSBezierPath(roundedRect: NSRect(x: track.minX, y: track.minY, width: track.width * fraction, height: track.height),
+                     xRadius: 1.5, yRadius: 1.5).fill()
+    }
+    override func drawKnob(_ knobRect: NSRect) {
+        (isEnabled ? accent : accent.withAlphaComponent(0.3)).setFill()
+        let knob = NSRect(x: knobRect.midX - 5, y: knobRect.midY - 5, width: 10, height: 10)
+        NSBezierPath(ovalIn: knob).fill()
+    }
+}

--- a/Tests/NullPlayerAppTests/SonosRoomMixerTests.swift
+++ b/Tests/NullPlayerAppTests/SonosRoomMixerTests.swift
@@ -1,0 +1,159 @@
+import XCTest
+import AppKit
+@testable import NullPlayer
+
+@MainActor
+final class SonosRoomMixerTests: XCTestCase {
+    func testSonosMenuAlwaysIncludesRoomWindowAndRefresh() throws {
+        let output = ContextMenuBuilder.buildMenuBarOutputMenu()
+        let sonos = try XCTUnwrap(output.items.first { $0.title == "Sonos" }?.submenu)
+        XCTAssertEqual(sonos.items.first?.title, "Rooms & Volume…")
+        let refresh = try XCTUnwrap(sonos.items.first { $0.title == "Refresh" })
+        XCTAssertTrue(refresh.isEnabled)
+        XCTAssertEqual(refresh.action, #selector(MenuActions.refreshSonosRooms))
+    }
+
+    func testRoomWritesCoalesceIndependently() async {
+        let first = expectation(description: "First room send started")
+        let second = expectation(description: "Other room remains responsive")
+        let final = expectation(description: "Latest value delivered")
+        var gate: CheckedContinuation<Void, Never>?
+        var sent: [String: [Int]] = [:]
+        let mixer = SonosRoomMixer(roomIDs: { ["a", "b"] }, readVolume: { _ in 10 },
+            writeVolume: { value, id in
+                sent[id, default: []].append(value)
+                if id == "a", value == 20 {
+                    await withCheckedContinuation { gate = $0; first.fulfill() }
+                } else if id == "b" { second.fulfill() }
+                else if value == 80 { final.fulfill() }
+            })
+        mixer.setVolume(20, room: "a")
+        await fulfillment(of: [first], timeout: 2)
+        mixer.setVolume(40, room: "a")
+        mixer.setVolume(80, room: "a")
+        mixer.setVolume(30, room: "b")
+        await fulfillment(of: [second], timeout: 2)
+        gate?.resume()
+        await fulfillment(of: [final], timeout: 2)
+        XCTAssertEqual(sent["a"], [20, 80])
+        XCTAssertEqual(sent["b"], [30])
+        XCTAssertEqual(mixer.volumes["a"], 80)
+    }
+
+    func testOldPollCannotOverwriteNewSliderValue() async {
+        let reading = expectation(description: "Read began")
+        let written = expectation(description: "Write finished")
+        var gate: CheckedContinuation<Int, Never>?
+        let mixer = SonosRoomMixer(roomIDs: { ["kitchen"] }, readVolume: { _ in
+            await withCheckedContinuation { gate = $0; reading.fulfill() }
+        }, writeVolume: { _, _ in written.fulfill() })
+        let poll = Task { await mixer.refreshVolumes() }
+        await fulfillment(of: [reading], timeout: 2)
+        mixer.setVolume(67, room: "kitchen")
+        await fulfillment(of: [written], timeout: 2)
+        gate?.resume(returning: 12)
+        await poll.value
+        XCTAssertEqual(mixer.volumes["kitchen"], 67)
+    }
+
+    func testManyRoomsUseAtMostFourReadsAndKeepPerRoomErrors() async {
+        let ids = (0..<32).map { "room-\($0)" }
+        var active = 0
+        var maximum = 0
+        var read: Set<String> = []
+        let mixer = SonosRoomMixer(roomIDs: { ids }, readVolume: { id in
+            active += 1
+            maximum = max(maximum, active)
+            defer { active -= 1 }
+            await Task.yield()
+            read.insert(id)
+            if id == "room-5" { throw CastError.deviceOffline }
+            return 25
+        }, writeVolume: { _, _ in XCTFail("Polling must never change speaker volume") })
+        await mixer.refreshVolumes()
+        XCTAssertEqual(read, Set(ids))
+        XCTAssertLessThanOrEqual(maximum, 4)
+        XCTAssertGreaterThan(maximum, 1)
+        XCTAssertEqual(mixer.volumes.count, 31)
+        XCTAssertNotNil(mixer.errors["room-5"])
+        XCTAssertNil(mixer.volumes["room-5"])
+    }
+
+    func testManyRoomListScrollsAndKeepsFooterOutsideScrollView() async {
+        _ = NSApplication.shared
+        let rooms = (0..<32).map { index in
+            UPnPManager.SonosRoomSummary(id: "room-\(index)", name: "Room \(index)",
+                isGroupCoordinator: false, isInGroup: false, groupCoordinatorUDN: nil,
+                groupCoordinatorName: nil)
+        }
+        let mixer = SonosRoomMixer(roomIDs: { rooms.map(\.id) }, readVolume: { _ in 25 },
+                                    writeVolume: { _, _ in XCTFail("Rendering must never change volume") })
+        await mixer.refreshVolumes()
+        let view = SonosWindowView(frame: NSRect(x: 0, y: 0, width: 275, height: 270),
+                                   mixer: mixer, rooms: { rooms })
+        view.refresh()
+        view.layoutSubtreeIfNeeded()
+        guard let scroll = view.subviews.compactMap({ $0 as? NSScrollView }).first,
+              let document = scroll.documentView else { return XCTFail("Missing room list") }
+        XCTAssertEqual(document.subviews.count, 32)
+        XCTAssertGreaterThan(document.frame.height, scroll.contentSize.height)
+        XCTAssertTrue(scroll.hasVerticalScroller)
+        let footer = view.subviews.compactMap { $0 as? NSButton }
+        XCTAssertEqual(footer.count, 2)
+        for button in footer { XCTAssertFalse(button.frame.intersects(scroll.frame)) }
+        document.scroll(NSPoint(x: 0, y: document.bounds.maxY))
+        XCTAssertGreaterThan(scroll.contentView.bounds.minY, 0)
+        XCTAssertTrue(document.subviews.last!.frame.intersects(scroll.documentVisibleRect))
+    }
+
+    func testRestoredSonosWindowPreservesTallRoomListAndTopEdge() {
+        let frame = NSRect(x: 50, y: 100, width: 450, height: 700)
+        let restored = WindowManager.normalizedModernCenterStackRestoredFrame(frame, kind: .sonos,
+            mainWidth: 350, minimumWidth: 275, targetHeight: 116,
+            peppyMeterFloor: 203, peppyMeterLegacyDoubleHeight: 232)
+        XCTAssertEqual(restored, frame)
+        let short = NSRect(x: 50, y: 100, width: 200, height: 50)
+        let normalized = WindowManager.normalizedModernCenterStackRestoredFrame(short, kind: .sonos,
+            mainWidth: 350, minimumWidth: 275, targetHeight: 116,
+            peppyMeterFloor: 203, peppyMeterLegacyDoubleHeight: 232)
+        XCTAssertEqual(normalized.height, 232)
+        XCTAssertEqual(normalized.width, 275)
+        XCTAssertEqual(normalized.maxY, short.maxY)
+    }
+
+    func testEmptyWindowLaysOutRefreshAndRendersRoomFixtures() async throws {
+        _ = NSApplication.shared
+        let wm = WindowManager.shared
+        let oldMode = wm.uiMode
+        defer { wm.uiMode = oldMode }
+        for mode in [PlayerUIMode.classic, .modern, .metal] {
+            wm.uiMode = mode
+            if let family = mode.modernSkinFamily { ModernSkinEngine.shared.loadDefaultSkin(for: family) }
+            for count in [0, 32] {
+                let rooms = (0..<count).map { index in
+                    UPnPManager.SonosRoomSummary(id: "fixture-\(index)",
+                        name: ["Living Room", "Kitchen", "Dining Room", "Upstairs Bedroom", "Patio"][index % 5] + (index >= 5 ? " \(index)" : ""),
+                        isGroupCoordinator: false, isInGroup: false,
+                        groupCoordinatorUDN: nil, groupCoordinatorName: nil)
+                }
+                let mixer = SonosRoomMixer(roomIDs: { rooms.map(\.id) }, readVolume: { _ in 25 }, writeVolume: { _, _ in })
+                await mixer.refreshVolumes()
+                let view = SonosWindowView(frame: NSRect(x: 0, y: 0, width: 344, height: 360),
+                                           mixer: mixer, rooms: { rooms })
+                view.refresh()
+                view.layoutSubtreeIfNeeded()
+                let refresh = try XCTUnwrap(view.subviews.compactMap { $0 as? NSButton }.first { $0.title == "Refresh" })
+                XCTAssertGreaterThan(refresh.frame.width, 40)
+                XCTAssertGreaterThan(refresh.frame.height, 15)
+                XCTAssertTrue(view.bounds.contains(refresh.frame))
+                XCTAssertTrue(refresh.isEnabled)
+                if let directory = ProcessInfo.processInfo.environment["SONOS_RENDER_DUMP"] {
+                    let bitmap = try XCTUnwrap(view.bitmapImageRepForCachingDisplay(in: view.bounds))
+                    view.cacheDisplay(in: view.bounds, to: bitmap)
+                    let data = try XCTUnwrap(bitmap.representation(using: .png, properties: [:]))
+                    try data.write(to: URL(fileURLWithPath: directory).appendingPathComponent("sonos-\(mode.rawValue)-\(count).png"))
+                }
+            }
+        }
+    }
+}

--- a/Tests/NullPlayerAppTests/SonosRoomMixerTests.swift
+++ b/Tests/NullPlayerAppTests/SonosRoomMixerTests.swift
@@ -7,7 +7,7 @@ final class SonosRoomMixerTests: XCTestCase {
     func testSonosMenuAlwaysIncludesRoomWindowAndRefresh() throws {
         let output = ContextMenuBuilder.buildMenuBarOutputMenu()
         let sonos = try XCTUnwrap(output.items.first { $0.title == "Sonos" }?.submenu)
-        XCTAssertEqual(sonos.items.first?.title, "Rooms & Volume…")
+        XCTAssertEqual(sonos.items.first?.title, "Sonos Rooms…")
         let refresh = try XCTUnwrap(sonos.items.first { $0.title == "Refresh" })
         XCTAssertTrue(refresh.isEnabled)
         XCTAssertEqual(refresh.action, #selector(MenuActions.refreshSonosRooms))

--- a/skills/sonos-casting/SKILL.md
+++ b/skills/sonos-casting/SKILL.md
@@ -81,6 +81,47 @@ Response contains all groups and their member zones.
 
 ## User Interface
 
+### Sonos Rooms window
+
+Open **Windows → Sonos Rooms** or **Output → Sonos → Rooms & Volume…**. The context-menu
+**Output Devices → Sonos** submenu exposes the same entry. The existing Sonos submenu remains
+available even before discovery finds a room, including its **Refresh** command.
+
+The window is a resizable center-stack room mixer. Its scrollable list has no fixed room limit;
+**Refresh** and **Start/Stop Casting** stay in a fixed footer. Each room has a selection checkbox,
+an independent 0–100 volume slider, a numeric level, and selection/error status. Volume is available
+before casting as well as during a cast. An unreadable volume is shown as unavailable, not as zero.
+The empty state retains Refresh. Native controls use a light/dark appearance matched to the skin;
+sliders use the skin's text color.
+
+- `Casting/SonosRoomMixer.swift` owns shared room selection/start actions and per-room volume state.
+  Both the existing menu and the window call these actions, including coordinator transfer when
+  removing the current coordinator. Starting a cast resolves an actual selected room and makes it
+  standalone before starting, so an unselected existing group is not used as a fallback target.
+- Room volume uses **RenderingControl**, `Channel=Master`, on the room representative's own
+  renderer. `UPnPManager.getSonosRoomVolume` / `setSonosRoomVolume` do not require an active session
+  and never send `SetGroupVolume`. The player's existing group-volume path is unchanged.
+- Writes are single-flight and latest-value-wins **per room**, with SOAP retries disabled for
+  superseded writes. Polling uses at most four concurrent reads; per-room revision checks prevent
+  a read begun before a slider edit from replacing the new value. One failed room does not disable
+  other rooms. Refresh retries discovery as well as topology and levels.
+- `Windows/Sonos/` owns the controller and shared controls; `Windows/ModernSonos/` supplies Original
+  and Metal chrome. `.wal` uses the `.sonos` hosted-window registry entry and a chromeless
+  `WinampModernHostedSurface`, with the standard hosted drag helper and palette.
+- WindowManager registers `.sonos` as a center-stack sizing policy with a double-height baseline.
+  User-expanded height is preserved on restore; the window participates in snapping, scaling,
+  stack collapse, Compact Mode, and live UI rebuilding. AppState stores visibility and frame with
+  backward-compatible decoding. Speaker volume is always read from the speaker, never restored
+  from saved window state.
+- Polling belongs to the visible view and is suspended on hide, minimize, occlusion, and teardown.
+  Volume writes belong to the mixer so an accepted slider edit can finish across a UI rebuild.
+
+`SonosRoomMixerTests` covers independent room writes, stale-read protection, bounded polling with
+32 rooms, scrolling to the last room, footer visibility with no rooms, restored sizing, and the
+Sonos menu. Set `SONOS_RENDER_DUMP` to an existing directory when running the tests to render
+empty and 32-room fixtures for Classic, Original, and Metal. These are rendering fixtures, not
+proof of playback or hardware volume control.
+
 ### Menu Structure
 
 ```
@@ -199,7 +240,9 @@ Sonos uses **GroupRenderingControl** (not `RenderingControl`) so that volume/mut
 | Set mute | `SetGroupMute` (no Channel arg) | `SetMute` (Channel=Master) |
 | Service type | `urn:schemas-upnp-org:service:GroupRenderingControl:1` | `urn:schemas-upnp-org:service:RenderingControl:1` |
 
-This is handled in `UPnPManager.setVolume(_:)`, `getVolume()`, and `setMute(_:)` by branching on `session.device.type == .sonos`.
+This group-level behavior is handled in `UPnPManager.setVolume(_:)`, `getVolume()`, and `setMute(_:)`
+by branching on `session.device.type == .sonos`. The room mixer's independent RenderingControl
+path is described above; do not route a room slider through these group methods.
 
 ### Playback State Monitoring
 
@@ -427,6 +470,16 @@ For non-Plex backends, preserve both `Track.contentType` and sample rate from se
 > Scan functions only reject _definitively_ incompatible formats (ALAC, AIFF, WavPack, Monkey's Audio, known >48 kHz SR). They pass nil-SR lossless tracks through so the cast function can fetch and decide. Never use strict mode in a skip/scan loop — it causes Plex FLAC tracks with nil SR to be skipped silently without a fetch attempt.
 
 ## Troubleshooting
+
+### Debugging a live defect
+
+For a screen-only defect, follow the live-defect process in
+[`winamp-modern-skin-guide/reference/harness.md`](../winamp-modern-skin-guide/reference/harness.md).
+Identify the running executable by PID and checkout before comparing it to a worktree build.
+Measure actual window/control frames, capture the window, and verify Refresh in both an empty
+list and a populated one. Check light/dark native control appearance as well as skin colors;
+a control with a valid frame can still be unreadable. For volume, read back the edited room and
+an untouched room to distinguish individual RenderingControl from group-volume changes.
 
 ### Confirming a cast is live from outside the app — use `nettop`, not `lsof`
 

--- a/skills/sonos-casting/SKILL.md
+++ b/skills/sonos-casting/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: sonos-casting
-description: Sonos UPnP discovery, multi-room casting, coordinator transfer, custom checkbox UI, and protocol quirks. Use when working on Sonos casting, UPnP control, multi-room audio, or group management.
+description: Sonos UPnP discovery, multi-room casting, coordinator transfer, dockable room mixer, individual room volume, custom checkbox UI, and protocol quirks. Use when working on Sonos casting, room controls, UPnP control, multi-room audio, or group management.
 ---
 
 # Sonos Integration
@@ -15,6 +15,10 @@ This guide covers Sonos speaker discovery, casting, and multi-room grouping in N
 2. Check the rooms you want to cast to (checkboxes stay open for multi-select)
 3. Click **🟢 Start Casting** to begin playback
 4. Click **🔴 Stop Casting** from the Sonos menu to fully end the cast session
+
+For a persistent room list and individual volume controls, open **Windows → Sonos Rooms** or
+**Output → Sonos → Rooms & Volume…**. Resize the window or scroll to reach additional rooms;
+**Refresh** remains in the footer even when no rooms are discovered.
 
 ## Discovery Methods
 
@@ -568,6 +572,10 @@ SSDP requires multicast. Some routers/switches block this:
 |------|---------|
 | `Casting/CastManager.swift` | Central coordinator, `selectedSonosRooms` state, polling timer, sleep/wake handling |
 | `Casting/UPnPManager.swift` | SSDP/mDNS discovery, SOAP control, group topology, `pollSonosPlaybackState()` |
+| `Casting/SonosRoomMixer.swift` | Shared room actions, independent volume writes, bounded polling and stale-read protection |
+| `Windows/Sonos/` | Room mixer controls, window lifecycle, Classic and fallback chrome |
+| `Windows/ModernSonos/ModernSonosChrome.swift` | Original and Metal auxiliary chrome |
+| `WinampModern/WinampModernHostedWindows.swift` | `.sonos` skin-hosted window registration |
 | `App/ContextMenuBuilder.swift` | Menu UI, `SonosRoomCheckboxView`, casting actions |
 | `Casting/LocalMediaServer.swift` | Embedded HTTP server, HEAD handlers, health checks, network monitoring |
 

--- a/skills/sonos-casting/SKILL.md
+++ b/skills/sonos-casting/SKILL.md
@@ -17,7 +17,7 @@ This guide covers Sonos speaker discovery, casting, and multi-room grouping in N
 4. Click **🔴 Stop Casting** from the Sonos menu to fully end the cast session
 
 For a persistent room list and individual volume controls, open **Windows → Sonos Rooms** or
-**Output → Sonos → Rooms & Volume…**. Resize the window or scroll to reach additional rooms;
+**Output → Sonos → Sonos Rooms…**. Resize the window or scroll to reach additional rooms;
 **Refresh** remains in the footer even when no rooms are discovered.
 
 ## Discovery Methods
@@ -87,7 +87,7 @@ Response contains all groups and their member zones.
 
 ### Sonos Rooms window
 
-Open **Windows → Sonos Rooms** or **Output → Sonos → Rooms & Volume…**. The context-menu
+Open **Windows → Sonos Rooms** or **Output → Sonos → Sonos Rooms…**. The context-menu
 **Output Devices → Sonos** submenu exposes the same entry. The existing Sonos submenu remains
 available even before discovery finds a room, including its **Refresh** command.
 

--- a/skills/sonos-casting/SKILL.md
+++ b/skills/sonos-casting/SKILL.md
@@ -104,7 +104,9 @@ sliders use the skin's text color.
   standalone before starting, so an unselected existing group is not used as a fallback target.
 - Room volume uses **RenderingControl**, `Channel=Master`, on the room representative's own
   renderer. `UPnPManager.getSonosRoomVolume` / `setSonosRoomVolume` do not require an active session
-  and never send `SetGroupVolume`. The player's existing group-volume path is unchanged.
+  or an AVTransport URL: they resolve the discovered zone's address and port directly and never send
+  `SetGroupVolume`. AVTransport remains required for casting and group operations. The player's
+  existing group-volume path is unchanged.
 - Writes are single-flight and latest-value-wins **per room**, with SOAP retries disabled for
   superseded writes. Polling uses at most four concurrent reads; per-room revision checks prevent
   a read begun before a slider edit from replacing the new value. One failed room does not disable

--- a/skills/sonos-casting/SKILL.md
+++ b/skills/sonos-casting/SKILL.md
@@ -104,9 +104,7 @@ sliders use the skin's text color.
   standalone before starting, so an unselected existing group is not used as a fallback target.
 - Room volume uses **RenderingControl**, `Channel=Master`, on the room representative's own
   renderer. `UPnPManager.getSonosRoomVolume` / `setSonosRoomVolume` do not require an active session
-  or an AVTransport URL: they resolve the discovered zone's address and port directly and never send
-  `SetGroupVolume`. AVTransport remains required for casting and group operations. The player's
-  existing group-volume path is unchanged.
+  and never send `SetGroupVolume`. The player's existing group-volume path is unchanged.
 - Writes are single-flight and latest-value-wins **per room**, with SOAP retries disabled for
   superseded writes. Polling uses at most four concurrent reads; per-room revision checks prevent
   a read begun before a slider edit from replacing the new value. One failed room does not disable

--- a/skills/ui-guide/SKILL.md
+++ b/skills/ui-guide/SKILL.md
@@ -232,10 +232,10 @@ When adding or refactoring top menu bar content:
 
 ## Dockable Center-Stack Windows
 
-Main, EQ, Playlist, Spectrum, Waveform, Audio Analysis, PeppyMeter, and Flow all participate in the center stack managed by `WindowManager`.
+Main, EQ, Playlist, Spectrum, Waveform, Audio Analysis, PeppyMeter, Flow, and Sonos Rooms all participate in the center stack managed by `WindowManager`.
 
 - Width is normalized to the main stack
-- Height is window-specific: Flow is single-height; PeppyMeter uses a 1.75x landscape height
+- Height is window-specific: Flow is single-height; PeppyMeter uses a 1.75x landscape height; Sonos Rooms uses a double-height baseline and preserves a taller restored list
 - Saved frames are restored through `WindowManager` rather than ad hoc per-window logic
 - Opening a center-stack window must calculate gaps from windows actually docked below main, not
   every visible stack-capable window. Use `dockedCenterStackWindowsBelowMain(mainFrame:)` (vertical
@@ -252,6 +252,13 @@ For new center-stack windows, follow the waveform/spectrum pattern:
 2. Classic chrome in `Windows/...`
 3. Modern chrome in `Windows/Modern...`
 4. Registration and docking behavior in `WindowManager`
+
+Sonos Rooms uses a shared controller/content view with separate Original/Metal chrome and a
+`.wal` hosted-surface adapter. Its scrollable list must leave Refresh and casting controls in a
+fixed footer. Explicitly lay out controls on first show and resize, including when the room list
+is empty, and match native AppKit control appearance to the skin's background. The implementation,
+volume semantics, lifecycle, and rendering fixtures are owned by the
+[Sonos casting skill](../sonos-casting/SKILL.md#sonos-rooms-window).
 
 ### Window Dragging (MUST)
 


### PR DESCRIPTION
Adds a dockable Sonos Rooms window for selecting casting rooms and adjusting each room's volume independently. The room list scrolls without a fixed room limit, while Refresh and Start/Stop Casting remain in a fixed footer. The existing Output → Sonos submenu stays available, including when discovery has found no rooms, and includes a Sonos Rooms entry.

Room sliders use the room representative's RenderingControl endpoint; the player's existing group-volume control remains unchanged. The menu and window share room selection and casting actions. Volume writes are serialized per room with latest-value coalescing, and polling uses at most four concurrent reads with stale-response protection.

The window participates in center-stack sizing, docking, saved state, Compact Mode, and UI mode changes. Classic, Original, and Metal use their auxiliary chrome, while .wal skins use the hosted-window registry. The Sonos and UI skills document the new behavior and debugging paths.

Validation:

- Swift build succeeds.
- Full test suite: 1,917 tests executed, 12 skipped, zero failures.
- Regression coverage includes 32 rooms, scrolling to the last room, fixed footer and empty-state Refresh, independent writes, stale reads, bounded polling, window sizing, hosted dragging, and the Sonos menu.
- Inspected empty and 32-room rendering fixtures for Classic, Original, and Metal; corrected native control contrast on dark skins.

Live speaker volume and playback verification remains outstanding. Rendering fixtures and unit tests do not establish hardware behavior.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Added a Sonos Rooms window for viewing rooms, selecting casting targets, refreshing status, and adjusting per-room volume.
  - Added access through the Windows menu and output-device menus.
  - Added support for Sonos window positioning, docking, resizing, and restoration across interface modes.
  - Added persistent room mixer behavior with casting controls and improved volume update reliability.

- **Documentation**
  - Updated Sonos casting and interface guidance with window behavior, volume controls, and troubleshooting details.

- **Tests**
  - Added coverage for room mixing, volume handling, window layout, restoration, and visual rendering.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->
