### PR TITLE
fix(sonos): reject high sample-rate streams

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,10 @@
 ## Unreleased
 
 - Sonos room volume control
+- **Sonos no longer receives audio above its 48 kHz limit** — the compatibility gate now rejects
+  any track with a known or resolved sample rate above 48 kHz, even when its URL extension or MIME
+  type is unrecognized. Local files with unusual extensions are probed before casting, and Plex
+  tracks with missing rate metadata are resolved from the server (GH #422).
 
 ## 0.30.0
 

--- a/Sources/NullPlayer/Casting/CastManager.swift
+++ b/Sources/NullPlayer/Casting/CastManager.swift
@@ -2663,7 +2663,7 @@ class CastManager {
     /// Sonos S1 fails above 48 kHz PCM; use as conservative safe limit.
     static let sonosMaxSampleRate: Int = 48000
 
-    /// Lossless extensions that require the sample-rate check.
+    /// Lossless extensions whose unknown sample rate is unsafe for remote streams.
     private static let sonosLosslessExtensions: Set<String> = ["flac", "wav"]
 
     /// Map common audio MIME types to their extension equivalent for format checking.
@@ -2688,16 +2688,12 @@ class CastManager {
         return track.contentType.map(contentTypeToExtension) ?? ""
     }
 
-    private static func sonosLosslessExtension(for track: Track) -> String? {
-        let ext = sonosFormatExtension(for: track)
-        return sonosLosslessExtensions.contains(ext) ? ext : nil
-    }
-
-    /// Best-effort Sonos sample rate for a lossless track whose metadata has no rate.
+    /// Best-effort Sonos sample rate when track metadata has no rate.
     /// Plex can resolve it from server metadata; local files are probed directly.
+    /// Do not gate this on the URL extension or MIME type: a known high sample rate
+    /// must never bypass Sonos's 48 kHz ceiling merely because its container is unknown.
     static func resolveSonosSampleRate(for track: Track) async -> Int? {
         if let sampleRate = track.sampleRate { return sampleRate }
-        guard sonosLosslessExtension(for: track) != nil else { return nil }
 
         if let ratingKey = track.plexRatingKey {
             let sampleRate = await PlexManager.shared.fetchSampleRate(for: ratingKey)
@@ -2740,7 +2736,7 @@ class CastManager {
         return Int(sampleRate.rounded())
     }
 
-    /// Returns false if the track format is known to be unsupported by Sonos.
+    /// Returns false if the track format or known sample rate is unsupported by Sonos.
     /// Falls back to `track.contentType` when the URL has no file extension
     /// (e.g. server-streamed tracks from Subsonic/Jellyfin/Emby/Plex).
     static func isSonosCompatible(_ track: Track, sampleRateOverride: Int? = nil,
@@ -2749,11 +2745,16 @@ class CastManager {
 
         if sonosUnsupportedExtensions.contains(ext) { return false }
 
+        // The hardware limit applies regardless of which container or MIME type
+        // identified the audio. Restricting this check to FLAC/WAV let high-rate
+        // tracks with an unfamiliar extension or content type reach the speaker.
+        let effectiveSampleRate = sampleRateOverride ?? track.sampleRate
+        if let sampleRate = effectiveSampleRate, sampleRate > sonosMaxSampleRate {
+            return false
+        }
+
         if sonosLosslessExtensions.contains(ext) {
-            let effectiveSampleRate = sampleRateOverride ?? track.sampleRate
-            if let sr = effectiveSampleRate {
-                if sr > sonosMaxSampleRate { return false }
-            } else if !allowUnknownSampleRate {
+            if effectiveSampleRate == nil && !allowUnknownSampleRate {
                 return false  // nil SR in strict mode → block
             }
             // nil SR + allowUnknownSampleRate → pass through (let caller fetch and verify)

--- a/Tests/NullPlayerAppTests/CastingTests.swift
+++ b/Tests/NullPlayerAppTests/CastingTests.swift
@@ -559,6 +559,17 @@ final class CastingTests: XCTestCase {
         XCTAssertFalse(CastManager.isSonosCompatible(track))
     }
 
+    func testHighResolutionTrackWithUnrecognizedContainerIsNotSonosCompatible() {
+        let track = Track(
+            url: URL(string: "https://server.example.test/audio/stream")!,
+            title: "16/192 Stream",
+            sampleRate: 192_000,
+            contentType: "application/octet-stream"
+        )
+
+        XCTAssertFalse(CastManager.isSonosCompatible(track))
+    }
+
     func testSonosCompatibilityNormalizesContentTypeParameters() {
         let track = Track(
             url: URL(string: "http://server.local/stream/123")!,
@@ -582,6 +593,25 @@ final class CastingTests: XCTestCase {
         let resolvedSampleRate = await CastManager.resolveSonosSampleRate(for: track)
 
         XCTAssertEqual(resolvedSampleRate, 96_000)
+        XCTAssertFalse(CastManager.isSonosCompatible(
+            track,
+            sampleRateOverride: resolvedSampleRate,
+            allowUnknownSampleRate: true
+        ))
+    }
+
+    func testResolveSonosSampleRateProbesLocalFileWithUnrecognizedExtension() async throws {
+        let url = FileManager.default.temporaryDirectory
+            .appendingPathComponent("nullplayer-sonos-\(UUID().uuidString)")
+            .appendingPathExtension("stream")
+        defer { try? FileManager.default.removeItem(at: url) }
+
+        try makePCM16WAV(sampleRate: 192_000, channels: 2, frames: 256).write(to: url)
+
+        let track = Track(url: url, title: "16/192 Unrecognized Container")
+        let resolvedSampleRate = await CastManager.resolveSonosSampleRate(for: track)
+
+        XCTAssertEqual(resolvedSampleRate, 192_000)
         XCTAssertFalse(CastManager.isSonosCompatible(
             track,
             sampleRateOverride: resolvedSampleRate,

--- a/skills/sonos-casting/SKILL.md
+++ b/skills/sonos-casting/SKILL.md
@@ -439,7 +439,7 @@ See [artwork-debugging-history.md](artwork-debugging-history.md) for historical 
 - **Permissive** (`allowUnknownSampleRate: true`): nil sample rate → pass through. Used in _scan/positioning_ functions that advance the playlist index before casting begins.
 
 Always-incompatible formats (regardless of sample rate): `alac`, `aiff`, `aif`, `wv` (WavPack), `ape` (Monkey's Audio).
-Every track with a known or resolved sample rate is rejected above 48 kHz, regardless of its URL extension or MIME type. FLAC and WAV additionally require a known rate in strict mode.
+Every track with a known or resolved sample rate is rejected above 48 kHz, regardless of its URL extension or MIME type. Resolve the rate before the final cast verdict for every Plex or local track whose metadata lacks one; do not restore an extension/MIME gate around that resolution. FLAC and WAV additionally require a known rate in strict mode.
 
 Format classification uses the URL extension first, then normalized `Track.contentType` when the URL is extensionless. MIME types are normalized case-insensitively and parameters are ignored, so `Audio/X-FLAC; charset=binary` is treated as FLAC. This matters for Plex, Subsonic/Navidrome, Jellyfin, and Emby stream URLs that may not end in `.flac` or `.wav`.
 

--- a/skills/sonos-casting/SKILL.md
+++ b/skills/sonos-casting/SKILL.md
@@ -439,7 +439,7 @@ See [artwork-debugging-history.md](artwork-debugging-history.md) for historical 
 - **Permissive** (`allowUnknownSampleRate: true`): nil sample rate → pass through. Used in _scan/positioning_ functions that advance the playlist index before casting begins.
 
 Always-incompatible formats (regardless of sample rate): `alac`, `aiff`, `aif`, `wv` (WavPack), `ape` (Monkey's Audio).
-Lossless formats requiring the sample-rate check: `flac`, `wav` — rejected above 48 kHz.
+Every track with a known or resolved sample rate is rejected above 48 kHz, regardless of its URL extension or MIME type. FLAC and WAV additionally require a known rate in strict mode.
 
 Format classification uses the URL extension first, then normalized `Track.contentType` when the URL is extensionless. MIME types are normalized case-insensitively and parameters are ignored, so `Audio/X-FLAC; charset=binary` is treated as FLAC. This matters for Plex, Subsonic/Navidrome, Jellyfin, and Emby stream URLs that may not end in `.flac` or `.wav`.
 
@@ -455,11 +455,11 @@ Functions that advance the playlist index use `allowUnknownSampleRate: true` bec
 ### Cast Functions Are the Final Authority
 
 `castCurrentTrack` and `castNewTrack` in `CastManager.swift` call `resolveSonosSampleRate(for:)`
-for lossless tracks with nil SR. Plex tracks fetch the actual rate from the server; local files
-are probed directly with `AVAudioFile` and asynchronously-loaded `AVAsset` format descriptions.
-The resolution decision must use the same URL-extension-or-content-type classification as
-`isSonosCompatible`; Plex stream URLs are often extensionless, so `Track.contentType` must
-identify FLAC/WAV for the fetch to happen. If a track fails there,
+when metadata has nil SR. Plex tracks fetch the actual rate from the server; local files
+are probed directly with `AVAudioFile` and asynchronously-loaded `AVAsset` format descriptions,
+even when their extension or MIME type is unfamiliar. Plex rate resolution does not depend on
+format classification; classification remains relevant for unsupported codecs and strict unknown
+FLAC/WAV handling. If a track fails there,
 `advanceToFirstSonosCompatibleTrack()` is called again to find the next candidate.
 
 The final compatibility call remains strict for server tracks. A local file whose sample rate is


### PR DESCRIPTION
## Summary
- reject all Sonos tracks with a known sample rate above 48 kHz, independent of container or MIME type
- resolve missing rates for Plex and local tracks even when their type is unrecognized
- add regressions for 192 kHz unknown-container streams and local files

Closes #422.

## Testing
- swift test --filter CastingTests
- swift test

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Improved Sonos casting compatibility checks to reject tracks above 48 kHz regardless of file extension or MIME type.
  - Local files with unfamiliar extensions are now inspected before casting.
  - Missing sample-rate information for Plex tracks is resolved more reliably.

- **Documentation**
  - Updated Sonos casting guidance to reflect the broader sample-rate checks and file inspection behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->