### PR TITLE
Add complete Play History download

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,9 @@
 ## Unreleased
 
 - Sonos room volume control
+- **Download your complete Play History as a CSV** — the Library Data and Play History views now
+  include a download button that exports every recorded event, including older and skipped plays,
+  rather than only the 200 recent entries visible in the table.
 
 ## 0.30.0
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,7 +5,7 @@
 - Sonos room volume control
 - **Download your complete Play History as a CSV** — the Library Data and Play History views now
   include a download button that exports every recorded event, including older and skipped plays,
-  rather than only the 200 recent entries visible in the table.
+  rather than only the 200 recent entries visible in the table. Available in every UI mode.
 
 ## 0.30.0
 

--- a/Sources/NullPlayer/App/ContextMenuBuilder.swift
+++ b/Sources/NullPlayer/App/ContextMenuBuilder.swift
@@ -172,10 +172,8 @@ class ContextMenuBuilder {
         menu.addItem(buildWindowItem("Sonos Rooms", visible: wm.isSonosVisible, action: #selector(MenuActions.toggleSonos)))
         menu.addItem(buildWindowItem("Waveform", visible: wm.isWaveformVisible, action: #selector(MenuActions.toggleWaveform)))
         menu.addItem(buildWindowItem("Library Browser", visible: wm.isPlexBrowserVisible, action: #selector(MenuActions.togglePlexBrowser)))
-        if wm.isRunningModernUI {
-            menu.addItem(buildWindowItem("Play History", visible: wm.isLibraryHistoryVisible,
-                                         action: #selector(MenuActions.toggleLibraryHistory)))
-        }
+        menu.addItem(buildWindowItem("Play History", visible: wm.isLibraryHistoryVisible,
+                                     action: #selector(MenuActions.toggleLibraryHistory)))
         menu.addItem(buildWindowItem("Visualizations", visible: wm.isProjectMVisible, action: #selector(MenuActions.toggleProjectM)))
         menu.addItem(buildWindowItem("Video Player", visible: wm.isVideoPlayerVisible,
                                      action: #selector(MenuActions.toggleVideoPlayer),
@@ -3659,7 +3657,6 @@ class MenuActions: NSObject {
     #endif
 
     @objc func toggleLibraryHistory() {
-        guard WindowManager.shared.isModernUIEnabled else { return }
         WindowManager.shared.toggleLibraryHistory()
     }
 

--- a/Sources/NullPlayer/App/WindowManager.swift
+++ b/Sources/NullPlayer/App/WindowManager.swift
@@ -1925,7 +1925,7 @@ class WindowManager {
     }
 
     var isLibraryHistoryVisible: Bool {
-        guard isRunningModernUI, isPlexBrowserVisible else { return false }
+        guard isPlexBrowserVisible else { return false }
         return plexBrowserBrowseMode == ModernBrowseMode.history.rawValue
     }
     
@@ -2640,7 +2640,6 @@ class WindowManager {
     // MARK: - Library History
 
     func showLibraryHistory() {
-        guard isRunningModernUI else { return }
         showPlexBrowser()
         plexBrowserBrowseMode = ModernBrowseMode.history.rawValue
         plexBrowserWindowController?.window?.makeKeyAndOrderFront(nil)
@@ -2650,11 +2649,8 @@ class WindowManager {
     }
 
     func toggleLibraryHistory() {
-        guard isRunningModernUI else { return }
         if isLibraryHistoryVisible {
-            plexBrowserWindowController?.window?.orderOut(nil)
-            postLayoutChangeNotification()
-            updateDockedChildWindows()
+            togglePlexBrowser()
             return
         }
 

--- a/Sources/NullPlayer/Windows/ModernStats/PlayHistoryAgent.swift
+++ b/Sources/NullPlayer/Windows/ModernStats/PlayHistoryAgent.swift
@@ -1,5 +1,6 @@
 import Foundation
 import Combine
+import AppKit
 
 enum StatsDimension: Sendable { case artist, album, genre, source, outputDevice }
 enum StatsGranularity: Sendable { case day, week, month }
@@ -75,6 +76,7 @@ final class PlayHistoryAgent: ObservableObject {
     @Published var genreArtists:   [TopDimensionRow] = []
     @Published var dailyActivity:  [DailyActivityRow] = []
     @Published var isLoading: Bool = false
+    @Published var isExporting: Bool = false
     @Published var error: String? = nil
     @Published var isBackfilling = false
     @Published var backfillCurrent = 0
@@ -284,5 +286,51 @@ final class PlayHistoryAgent: ObservableObject {
         backfillTask?.cancel()
         backfillTask = nil
         isBackfilling = false
+    }
+
+    func exportCompleteHistory() {
+        let panel = NSSavePanel()
+        panel.allowedContentTypes = [.init(filenameExtension: "csv")!]
+        panel.nameFieldStringValue = "NullPlayer Play History.csv"
+        panel.title = "Download Play History"
+        panel.message = "Exports every recorded play event, including skipped entries."
+
+        guard panel.runModal() == .OK, let destination = panel.url else { return }
+        isExporting = true
+        error = nil
+
+        Task {
+            do {
+                try await Task.detached(priority: .userInitiated) { [store] in
+                    let rows = try store.fetchAllEventsForExport()
+                    let csv = Self.makeCSV(rows: rows)
+                    try csv.write(to: destination, atomically: true, encoding: .utf8)
+                }.value
+            } catch {
+                self.error = "Could not export play history: \(error.localizedDescription)"
+            }
+            self.isExporting = false
+        }
+    }
+
+    nonisolated static func makeCSV(rows: [PlayHistoryExportRow]) -> String {
+        let formatter = ISO8601DateFormatter()
+        let header = [
+            "Event ID", "Track ID", "Track URL", "Title", "Artist", "Album", "Genre",
+            "Played At", "Duration Seconds", "Source", "Skipped", "Content Type", "Output Device"
+        ]
+        let lines = rows.map { row in
+            csvLine([
+                String(row.id), row.trackID, row.trackURL, row.title, row.artist, row.album, row.genre,
+                formatter.string(from: row.playedAt), String(row.durationListened), row.source,
+                row.skipped ? "true" : "false", row.contentType, row.outputDevice
+            ])
+        }
+        return ([csvLine(header)] + lines).joined(separator: "\n") + "\n"
+    }
+
+    nonisolated private static func csvLine(_ values: [String]) -> String {
+        values.map { "\"\($0.replacingOccurrences(of: "\"", with: "\"\""))\"" }
+            .joined(separator: ",")
     }
 }

--- a/Sources/NullPlayer/Windows/ModernStats/PlayHistoryStore.swift
+++ b/Sources/NullPlayer/Windows/ModernStats/PlayHistoryStore.swift
@@ -63,6 +63,25 @@ struct RecentEventRow: Identifiable, Sendable {
     }
 }
 
+/// A lossless representation of an event for a full-history export. Unlike the
+/// table rows, these values are read directly from `play_events` so the CSV
+/// remains useful even if the related library track has since been removed.
+struct PlayHistoryExportRow: Sendable {
+    let id: Int64
+    let trackID: String
+    let trackURL: String
+    let title: String
+    let artist: String
+    let album: String
+    let genre: String
+    let playedAt: Date
+    let durationListened: Double
+    let source: String
+    let skipped: Bool
+    let contentType: String
+    let outputDevice: String
+}
+
 struct ArtistTrackRow: Identifiable, Sendable {
     let id: String
     let title: String
@@ -469,6 +488,40 @@ final class PlayHistoryStore: Sendable {
                                   genre: genre, source: source,
                                   playedAt: Date(timeIntervalSince1970: ts),
                                   durationListened: dur, skipped: skip)
+        }
+    }
+
+    /// Fetch every persisted event for CSV export. This deliberately does not
+    /// use the display filter, 30-day default, or the History table's 200-row
+    /// limit: an export is a record of the complete local play history.
+    func fetchAllEventsForExport() throws -> [PlayHistoryExportRow] {
+        let sql = """
+            SELECT id, track_id, track_url, event_title, event_artist, event_album,
+                   event_genre, played_at, duration_listened, source, skipped,
+                   content_type, output_device
+            FROM play_events
+            ORDER BY played_at DESC, id DESC
+            """
+        guard let db = MediaLibraryStore.shared.analyticsConnection else { return [] }
+        let stmt = try db.prepare(sql)
+        return stmt.compactMap { row in
+            guard let id = row[0] as? Int64 else { return nil }
+            let timestamp = row[7] as? Double ?? 0
+            return PlayHistoryExportRow(
+                id: id,
+                trackID: row[1] as? String ?? "",
+                trackURL: row[2] as? String ?? "",
+                title: row[3] as? String ?? "",
+                artist: row[4] as? String ?? "",
+                album: row[5] as? String ?? "",
+                genre: row[6] as? String ?? "",
+                playedAt: Date(timeIntervalSince1970: timestamp),
+                durationListened: row[8] as? Double ?? 0,
+                source: row[9] as? String ?? "",
+                skipped: (row[10] as? Int64 ?? 0) != 0,
+                contentType: row[11] as? String ?? "",
+                outputDevice: row[12] as? String ?? ""
+            )
         }
     }
 

--- a/Sources/NullPlayer/Windows/ModernStats/StatsContentView.swift
+++ b/Sources/NullPlayer/Windows/ModernStats/StatsContentView.swift
@@ -12,11 +12,30 @@ struct StatsContentView: View {
     var body: some View {
         VStack(spacing: 0) {
             StatsHeaderView(agent: agent, title: headerTitle)
-            Picker("", selection: $selectedTab) {
-                Text("Overview").tag(0)
-                Text("History").tag(1)
+            HStack(spacing: 8) {
+                Picker("", selection: $selectedTab) {
+                    Text("Overview").tag(0)
+                    Text("History").tag(1)
+                }
+                .pickerStyle(.segmented)
+                .frame(maxWidth: .infinity)
+
+                Button(action: agent.exportCompleteHistory) {
+                    Group {
+                        if agent.isExporting {
+                            ProgressView().controlSize(.small)
+                        } else {
+                            Label("Download", systemImage: "arrow.down.to.line")
+                        }
+                    }
+                    .frame(minWidth: 88)
+                }
+                .buttonStyle(.bordered)
+                .controlSize(.small)
+                .disabled(agent.isExporting)
+                .help("Download Play History")
+                .accessibilityLabel("Download Play History")
             }
-            .pickerStyle(.segmented)
             .padding(.horizontal, 12)
             .padding(.vertical, 6)
             if selectedTab == 0 {

--- a/Tests/NullPlayerAppTests/PlayHistoryExportTests.swift
+++ b/Tests/NullPlayerAppTests/PlayHistoryExportTests.swift
@@ -1,0 +1,30 @@
+import XCTest
+@testable import NullPlayer
+
+final class PlayHistoryExportTests: XCTestCase {
+    func testCSVIncludesEveryFieldAndEscapesQuotesAndNewlines() {
+        let row = PlayHistoryExportRow(
+            id: 42,
+            trackID: "track-id",
+            trackURL: "/Music/one,two.mp3",
+            title: "A \"quoted\" title",
+            artist: "Artist\nName",
+            album: "Album",
+            genre: "Rock",
+            playedAt: Date(timeIntervalSince1970: 0),
+            durationListened: 12.5,
+            source: "local",
+            skipped: true,
+            contentType: "music",
+            outputDevice: "Built-in Output"
+        )
+
+        let csv = PlayHistoryAgent.makeCSV(rows: [row])
+
+        XCTAssertTrue(csv.hasPrefix("\"Event ID\",\"Track ID\",\"Track URL\""))
+        XCTAssertTrue(csv.contains("\"/Music/one,two.mp3\""))
+        XCTAssertTrue(csv.contains("\"A \"\"quoted\"\" title\""))
+        XCTAssertTrue(csv.contains("\"Artist\nName\""))
+        XCTAssertTrue(csv.contains("\"true\",\"music\",\"Built-in Output\""))
+    }
+}

--- a/skills/local-library/SKILL.md
+++ b/skills/local-library/SKILL.md
@@ -14,6 +14,12 @@ Reference for local media library: scanning, persistence, NAS responsiveness, an
 | Waveform (cue-sheet) | `Waveform/BaseWaveformView.swift` |
 | Play history (Data tab) | `Windows/ModernStats/PlayHistoryStore.swift`, `Windows/ModernStats/PlayHistoryAgent.swift`, `Windows/ModernStats/StatsContentView.swift` |
 
+The History tab is intentionally a recent, display-filtered view: its query has a `LIMIT 200`, while
+the default filter is the last 30 days and excludes skipped events. The **Download Play History**
+button exports every row in `play_events` (including skipped entries) without those display limits.
+Keep export queries separate from display queries so an export never silently inherits a UI cap or
+active filter.
+
 ## Database Schema
 
 **Library**: `MediaLibraryStore` (SQLite via the `SQLite.swift` package). Replaced legacy `library.json`.

--- a/skills/sonos-casting/SKILL.md
+++ b/skills/sonos-casting/SKILL.md
@@ -439,7 +439,7 @@ See [artwork-debugging-history.md](artwork-debugging-history.md) for historical 
 - **Permissive** (`allowUnknownSampleRate: true`): nil sample rate → pass through. Used in _scan/positioning_ functions that advance the playlist index before casting begins.
 
 Always-incompatible formats (regardless of sample rate): `alac`, `aiff`, `aif`, `wv` (WavPack), `ape` (Monkey's Audio).
-Lossless formats requiring the sample-rate check: `flac`, `wav` — rejected above 48 kHz.
+Every track with a known or resolved sample rate is rejected above 48 kHz, regardless of its URL extension or MIME type. Resolve the rate before the final cast verdict for every Plex or local track whose metadata lacks one; do not restore an extension/MIME gate around that resolution. FLAC and WAV additionally require a known rate in strict mode.
 
 Format classification uses the URL extension first, then normalized `Track.contentType` when the URL is extensionless. MIME types are normalized case-insensitively and parameters are ignored, so `Audio/X-FLAC; charset=binary` is treated as FLAC. This matters for Plex, Subsonic/Navidrome, Jellyfin, and Emby stream URLs that may not end in `.flac` or `.wav`.
 

--- a/skills/user-guide/SKILL.md
+++ b/skills/user-guide/SKILL.md
@@ -28,7 +28,7 @@ A faithful recreation of Winamp 2.x for macOS with Plex/Jellyfin/Subsonic integr
 | **Library Browser** | Browse Plex/Jellyfin/Subsonic/Emby and local media | Logo button or context menu |
 | **Visualizations** | Visualization engine host for ProjectM, Geiss and Tripex (consistently labeled "Visualizations" in menus and window chrome) | VZ button, Windows menu, or context menu |
 
-In Original and Original-Metal UI, **Windows > Play History** opens the **Data** tab inside the Library Browser instead of a separate window. The Data tab is also available in the Classic library browser. The Data tab shows:
+In every UI mode — Classic, Original, Original-Metal, and Winamp Modern — **Windows > Play History** opens the **Data** tab inside the Library Browser instead of a separate window. The Data tab shows:
 - **Play Time** summary (day/week/month/year/all-time)
 - **Top Artists** (music only)
 - **Top Movies** and **Top TV Shows** (separate sections; TV groups by show name)


### PR DESCRIPTION
## Summary
- add a complete Play History CSV export that bypasses the History table's 200-row and active-filter limits
- place a labeled download-to-tray control next to the Overview and History tabs
- document the export and add CSV escaping coverage
- include the Sonos sample-rate guidance in this branch

## Validation
- swift build

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Added a Download button for Play History and Library Data views.
  - Export complete play history to CSV, including older and skipped events beyond the 200-entry display limit.
  - Play History is now available through the Windows menu in every UI mode.
  - Sonos room volume controls now support selecting rooms and adjusting each room independently.

- **Documentation**
  - Updated Play History guidance to reflect availability across all UI modes.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->